### PR TITLE
Cache Bugfixes and general improvements

### DIFF
--- a/history.md
+++ b/history.md
@@ -39,6 +39,10 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Added) _Front-end_ Warning when video is not found
 - [x]   (Added) _Front-end_ Warning when playback is not supported or not working
 - [x]   (Added) _Back-end_ Download API has now default client side caching
+- [x]   (Added) _Front-end_ Add Preloader for ColorClass filter, only used when using this app on a slow server
+- [x]   (Added) _Front-end_ Add updating parent items in the front-end cache
+- [x]   (Added) _Back-end_ Publish - Files that are not found while publishing are ignored
+- [x]   (Added) _Back-end_ Publish - Show status when there a no items found before publishing
 
 
 # version 0.3.0 - 2020-09-02

--- a/starsky/starsky.feature.webhtmlpublish/Services/WebHtmlPublishService.cs
+++ b/starsky/starsky.feature.webhtmlpublish/Services/WebHtmlPublishService.cs
@@ -126,7 +126,9 @@ namespace starsky.feature.webhtmlpublish.Services
 		    if(base64ImageArray == null) base64ImageArray = new string[fileIndexItemsList.Count];
             
 		    // Order alphabetically
-		    fileIndexItemsList = fileIndexItemsList.OrderBy(p => p.FileName).ToList();
+		    // Ignore Items with Errors
+		    fileIndexItemsList = fileIndexItemsList.OrderBy(p => p.FileName)
+			    .Where(p=> p.Status == FileIndexItem.ExifStatus.Ok).ToList();
 
 		    var copyResult = new Dictionary<string,bool>();
             

--- a/starsky/starsky/Controllers/PublishController.cs
+++ b/starsky/starsky/Controllers/PublishController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using starsky.feature.metaupdate.Interfaces;
 using starsky.feature.webhtmlpublish.Interfaces;
+using starsky.foundation.database.Models;
 using starsky.foundation.platform.Helpers;
 using starsky.foundation.platform.Models;
 using starsky.foundation.storage.Interfaces;
@@ -70,6 +71,9 @@ namespace starsky.Controllers
 		{
 			var inputFilePaths = PathHelper.SplitInputFilePaths(f).ToList();
 			var info = _metaInfo.GetInfo(inputFilePaths, false);
+			if (info.All(p => p.Status != FileIndexItem.ExifStatus.Ok))
+				return NotFound(info);
+
 			var slugItemName = _appSettings.GenerateSlug(itemName);
 			var location = Path.Combine(_appSettings.TempFolder,slugItemName );
 			

--- a/starsky/starsky/clientapp/src/components/molecules/color-class-filter/color-class-filter.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/color-class-filter/color-class-filter.spec.tsx
@@ -1,5 +1,8 @@
-import { shallow } from 'enzyme';
+import { globalHistory } from '@reach/router';
+import { act } from '@testing-library/react';
+import { mount, shallow } from 'enzyme';
 import React from 'react';
+import { URLPath } from '../../../shared/url-path';
 import ColorClassFilter from './color-class-filter';
 
 describe("ColorClassFilter", () => {
@@ -18,4 +21,41 @@ describe("ColorClassFilter", () => {
     var component = shallow(<ColorClassFilter itemsCount={1} subPath={"/test"} colorClassActiveList={[1]} colorClassUsage={[3]}></ColorClassFilter>);
     expect(component.exists('.colorclass--reset')).toBeTruthy();
   });
+
+  it("onClick value and preloader exist", () => {
+    var component = mount(<ColorClassFilter itemsCount={1} subPath={"/test"} colorClassActiveList={[1]} colorClassUsage={[1, 2]}></ColorClassFilter>)
+
+    expect(component.exists('.colorclass--2')).toBeTruthy();
+
+    component.find('.colorclass--2').last().simulate('click');
+    expect(component.exists('.preloader')).toBeTruthy();
+
+    component.unmount();
+  });
+
+  it("undo selection when clicking on already selected colorclass", () => {
+
+    globalHistory.navigate("/?colorclass=1");
+
+    var component = mount(<ColorClassFilter itemsCount={1} subPath={"/test"} colorClassActiveList={[1]} colorClassUsage={[1, 2]}></ColorClassFilter>)
+
+    expect(component.find('.colorclass--1').last().hasClass('active')).toBeTruthy();
+
+    var urlToStringSpy = jest.spyOn(URLPath.prototype, 'IUrlToString').mockImplementationOnce(() => {
+      return "";
+    })
+
+    act(() => {
+      component.find('.colorclass--1').last().simulate('click');
+    });
+
+    expect(urlToStringSpy).toBeCalled();
+    expect(urlToStringSpy).toBeCalledWith({ "colorClass": [] });
+
+    component.unmount();
+    globalHistory.navigate("/")
+
+
+  });
+
 });

--- a/starsky/starsky/clientapp/src/components/molecules/color-class-filter/color-class-filter.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/color-class-filter/color-class-filter.tsx
@@ -1,9 +1,10 @@
 import { Link } from '@reach/router';
-import React, { memo } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 import useGlobalSettings from '../../../hooks/use-global-settings';
 import useLocation from '../../../hooks/use-location';
 import { Language } from '../../../shared/language';
 import { URLPath } from '../../../shared/url-path';
+import Preloader from '../../atoms/preloader/preloader';
 
 //  <ColorClassFilter itemsCount={this.props.collectionsCount} subPath={this.props.subPath} 
 // colorClassActiveList={this.props.colorClassActiveList} colorClassUsage={this.props.colorClassUsage}></ColorClassFilter>
@@ -36,6 +37,12 @@ const ColorClassFilter: React.FunctionComponent<IColorClassProp> = memo((props) 
   // used for reading current location
   var history = useLocation();
 
+  const [isLoading, setIsLoading] = useState(false);
+  // When change-ing page the loader should be gone
+  useEffect(() => {
+    setIsLoading(false);
+  }, [props.colorClassActiveList])
+
   function cleanColorClass(): string {
     if (!props.subPath) return "/";
     var urlObject = new URLPath().StringToIUrl(history.location.search);
@@ -45,6 +52,7 @@ const ColorClassFilter: React.FunctionComponent<IColorClassProp> = memo((props) 
 
   function updateColorClass(item: number): string {
     var urlObject = new URLPath().StringToIUrl(history.location.search);
+
     if (!urlObject.colorClass) {
       urlObject.colorClass = [];
     }
@@ -69,12 +77,13 @@ const ColorClassFilter: React.FunctionComponent<IColorClassProp> = memo((props) 
 
   if (props.itemsCount === 0 || props.colorClassUsage.length === 1) return (<></>);
   return (<div className="colorclass colorclass--filter">
+    {isLoading ? <Preloader isDetailMenu={false} isOverlay={true} /> : null}
     {
       props.colorClassActiveList.length !== 0 ? resetButton : resetButtonDisabled
     }
     {
       props.colorClassUsage.map((item, index) => (
-        item >= 0 && item <= 8 ? <Link key={item} to={updateColorClass(item)}
+        item >= 0 && item <= 8 ? <Link onClick={() => setIsLoading(true)} key={item} to={updateColorClass(item)}
           className={props.colorClassActiveList.indexOf(item) >= 0 ?
             "btn btn--default colorclass colorclass--" + item + " active" : "btn colorclass colorclass--" + item}>
           <label /><span>{colorContent[item]}</span> </Link>

--- a/starsky/starsky/clientapp/src/contexts/detailview-context.tsx
+++ b/starsky/starsky/clientapp/src/contexts/detailview-context.tsx
@@ -66,7 +66,6 @@ export function detailviewReducer(state: State, action: Action): State {
     case "update":
       /* eslint-disable-next-line no-redeclare */
       var { tags, description, title, status, colorclass, fileHash, orientation, lastEdited, dateTime } = action;
-
       if (tags !== undefined) state.fileIndexItem.tags = tags;
       if (description !== undefined) state.fileIndexItem.description = description;
       if (title !== undefined) state.fileIndexItem.title = title;
@@ -80,7 +79,8 @@ export function detailviewReducer(state: State, action: Action): State {
       // Need to update otherwise other events are not triggerd
       return updateCache({ ...state, lastUpdated: new Date() });
     case "reset":
-      return updateCache(action.payload);
+      // this is triggert a lot when loading a page
+      return action.payload;
   }
 }
 
@@ -88,6 +88,9 @@ export function detailviewReducer(state: State, action: Action): State {
  * Update the cache based on the keys
  */
 function updateCache(stateLocal: IDetailView): IDetailView {
+  if (!stateLocal.fileIndexItem) {
+    return stateLocal;
+  }
   var urlObject = { f: stateLocal.subPath, colorClass: stateLocal.colorClassActiveList, collections: stateLocal.collections } as IUrl;
   new FileListCache().CacheSetObject(urlObject, { ...stateLocal });
   return stateLocal;

--- a/starsky/starsky/clientapp/src/interfaces/IDetailView.ts
+++ b/starsky/starsky/clientapp/src/interfaces/IDetailView.ts
@@ -44,6 +44,5 @@ export interface IDetailView {
 }
 
 export function newDetailView(): IDetailView {
-    return {
-    } as IDetailView;
+    return { pageType: PageType.DetailView } as IDetailView;
 }

--- a/starsky/starsky/clientapp/src/interfaces/IFileIndexItem.ts
+++ b/starsky/starsky/clientapp/src/interfaces/IFileIndexItem.ts
@@ -17,6 +17,7 @@ export interface IFileIndexItem {
     lastEdited?: string;
     filePath: string;
     fileName: string;
+    fileCollectionName: string;
     fileHash: string;
     parentDirectory: string;
     status: IExifStatus;

--- a/starsky/starsky/clientapp/src/shared/filelist-cache.spec.ts
+++ b/starsky/starsky/clientapp/src/shared/filelist-cache.spec.ts
@@ -99,7 +99,8 @@ describe("FileListCache", () => {
       // this should be an Archive not Detailview
       fileListCache.CacheSet("?f=/test_non_valid", detailView);
 
-      fileListCache.CacheSet("?f=/test_non_valid/image.jpg&collections=false", {} as any);
+      // the detailview value needs to have a fileIndexItem value
+      fileListCache.CacheSet("?f=/test_non_valid/image.jpg&collections=false", newDetailView());
 
       // expect nothing happend
     });

--- a/starsky/starsky/clientapp/src/style/css/24-detailview.css
+++ b/starsky/starsky/clientapp/src/style/css/24-detailview.css
@@ -236,7 +236,7 @@
 .gpx-controls .icon.icon--zoom_in,
 .gpx-controls .icon.icon--zoom_out {
   text-indent: -999px;
-  padding-left: 40px;
+  padding-left: 37px; /* needed for safari instead of 40 */
   background-position: 12px;
   max-width: 40px;
 }

--- a/starsky/starskytest/FakeMocks/FakeIMetaInfo.cs
+++ b/starsky/starskytest/FakeMocks/FakeIMetaInfo.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using starsky.feature.metaupdate.Interfaces;
 using starsky.foundation.database.Models;
 
@@ -6,9 +7,26 @@ namespace starskytest.FakeMocks
 {
 	public class FakeIMetaInfo : IMetaInfo
 	{
+		private List<FileIndexItem> Exist { get; set; }
+		public FakeIMetaInfo(List<FileIndexItem> existItems)
+		{
+			Exist = existItems;
+			if ( Exist == null )
+			{
+				Exist = new List<FileIndexItem>();
+			}
+		}
+		
 		public List<FileIndexItem> GetInfo(List<string> inputFilePaths, bool collections)
 		{
-			return new List<FileIndexItem>();
+			var result = new List<FileIndexItem>();
+			foreach ( var path in inputFilePaths )
+			{
+				var data = Exist.FirstOrDefault(p => p.FilePath == path);
+				if ( data == null ) continue;
+				result.Add(data);
+			}
+			return result;
 		}
 	}
 }


### PR DESCRIPTION
# PR Details 

- Add Preloader for ColorClass filter, only used when using this app on a slow server
- Add updating parent items in the front-end cache
- Files that are not found while publishing are ignored
- Show status when there a no items found before publishing

## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] C# Unit tests 
- [x] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (framework not included) 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
