### PR TITLE
Feature/202009 bugfixes 82

### DIFF
--- a/history.md
+++ b/history.md
@@ -34,7 +34,11 @@ node starsky-tools/build-tools/app-version-update.js
 - [ ]   (x) Move multiple files __not implemented__
 
 # version 0.3.2 _(Unreleased)_  2020-09-??
-- add here features
+- [x]   (Fixed) _Front-end_ DetailView - DateTime push in Detailview has no influence on colorclass anymore
+- [x]   (Fixed) _Front-end_ DetailView - Links to collections are always with `details=true`
+- [x]   (Fixed) _Front-end_ DetailView - When pressing delete the entire clientSide cache is cleared (to avoid next/prev issues)
+- [x]   (Fixed) _Front-end_ Archive - When selecting a new colorClass this is added to the filter
+- [x]   (Fixed) _Front-end_ DetailView - Safari 12 and lower does autorotate the image correct
 
 # version 0.3.1 - 2020-09-08
 - [x]   (Added) _Front-end_ UI improvement on Archive add t/i keyboard shortcut to select tags

--- a/starsky-tools/mock/api/info/test.jpg.json
+++ b/starsky-tools/mock/api/info/test.jpg.json
@@ -1,0 +1,41 @@
+[
+  {
+    "filePath": "/test.jpg",
+    "fileName": "test.jpg",
+    "fileHash": null,
+    "fileCollectionName": "test",
+    "parentDirectory": "/",
+    "isDirectory": false,
+    "tags": "",
+    "status": "Ok",
+    "description": "Test",
+    "title": "",
+    "dateTime": "2020-09-04T09:38:55",
+    "addToDatabase": "0001-01-01T00:00:00",
+    "lastEdited": "2020-09-10T18:00:39.5695169Z",
+    "latitude": 60.85281,
+    "longitude": 8.1353,
+    "locationAltitude": 7,
+    "locationCity": "New York",
+    "locationState": "Gelderland",
+    "locationCountry": "Nederland",
+    "colorClass": 5,
+    "orientation": "Horizontal",
+    "imageWidth": 4032,
+    "imageHeight": 3024,
+    "imageFormat": "jpg",
+    "collectionPaths": [
+      "/test.jpg",
+      "/test.dng"
+    ],
+    "aperture": 2.2,
+    "shutterSpeed": "1/904",
+    "isoSpeed": 25,
+    "software": "13.6.1",
+    "makeModel": "Apple|iPhone SE (1st generation)|",
+    "make": "Apple",
+    "model": "iPhone SE (1st generation)",
+    "focalLength": 4.199999809265137,
+    "size": 0
+  }
+]

--- a/starsky-tools/mock/set-router.js
+++ b/starsky-tools/mock/set-router.js
@@ -9,6 +9,9 @@ var apiIndex__Starsky01dif = require('./api/index/__starsky_01-dif.json')
 var apiIndex__Starsky01difColorclass0 = require('./api/index/__starsky_01-dif_colorclass0.json')
 
 var apiIndex__Starsky01dif20180101170001 = require('./api/index/__starsky_01-dif-2018.01.01.17.00.01.json')
+
+var apiInfo__testJpg = require('./api/info/test.jpg.json');
+
 var apiSearchTrash = require('./api/search/trash/index.json')
 var apiSearch = require('./api/search/index.json')
 var apiSearchTest = require('./api/search/test.json')
@@ -56,6 +59,15 @@ function setRouter(app) {
   app.get(prefix + '/api/health/details', (req, res) => {
     res.status(503);
     res.json(apiHealthDetails)
+  });
+
+  app.get(prefix + '/api/info', (req, res) => {
+
+    if (req.query.f === "/test.jpg") {
+      return res.json(apiInfo__testJpg);
+    }
+    res.statusCode = 404;
+    return res.json("not found");
   });
 
   app.get(prefix + '/api/index', (req, res) => {

--- a/starsky/starsky/clientapp/package.json
+++ b/starsky/starsky/clientapp/package.json
@@ -31,7 +31,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "lint": "node node_modules/eslint/bin/eslint.js \"src/**\" --max-warnings 0",
+    "lint": "node_modules/typescript/bin/tsc && node node_modules/eslint/bin/eslint.js \"src/**\" --max-warnings 0",
     "test:ci": "npm run lint && react-scripts test --watchAll=false --coverage --reporters=default 2>&1",
     "storybook": "start-storybook",
     "upgrade": "echo 'check readme.md 20200831 3.4.3 (2020-08-12)'"

--- a/starsky/starsky/clientapp/package.json
+++ b/starsky/starsky/clientapp/package.json
@@ -31,7 +31,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "lint": "node_modules/typescript/bin/tsc && node node_modules/eslint/bin/eslint.js \"src/**\" --max-warnings 0",
+    "type_temp": "node_modules/typescript/bin/tsc",
+    "lint": "node node_modules/eslint/bin/eslint.js \"src/**\" --max-warnings 0",
     "test:ci": "npm run lint && react-scripts test --watchAll=false --coverage --reporters=default 2>&1",
     "storybook": "start-storybook",
     "upgrade": "echo 'check readme.md 20200831 3.4.3 (2020-08-12)'"

--- a/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-color-class.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-color-class.spec.tsx
@@ -4,10 +4,9 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import * as AppContext from '../../../contexts/archive-context';
 import { newIArchive } from '../../../interfaces/IArchive';
-import { IConnectionDefault, newIConnectionDefault } from '../../../interfaces/IConnectionDefault';
 import { PageType } from '../../../interfaces/IDetailView';
 import { newIFileIndexItemArray } from '../../../interfaces/IFileIndexItem';
-import * as FetchPost from '../../../shared/fetch-post';
+import * as ColorClassSelect from '../color-class-select/color-class-select';
 import ArchiveSidebarColorClass from './archive-sidebar-color-class';
 
 describe("ArchiveSidebarColorClass", () => {
@@ -26,7 +25,7 @@ describe("ArchiveSidebarColorClass", () => {
       expect(wrapper.exists('.disabled')).toBeFalsy()
     });
 
-    it("Fire event when clicked", () => {
+    it("Fire event when clicked", async () => {
 
 
       // Warning: An update to null inside a test was not wrapped in act(...)
@@ -44,39 +43,40 @@ describe("ArchiveSidebarColorClass", () => {
         dispatch,
       } as AppContext.IArchiveContext;
 
-      // use this: ==> import * as AppContext from '../contexts/archive-context';
-      // var useContext = jest
-      //   .spyOn(AppContext, 'useArchiveContext')
-      //   .mockImplementation(() => contextValues);
-
       jest.mock('@reach/router', () => ({
         navigate: jest.fn(),
         globalHistory: jest.fn(),
       }));
 
+      // to use with: => import { act } from 'react-dom/test-utils';
+      globalHistory.navigate("/?select=test.jpg");
 
-      act(() => {
-        // to use with: => import { act } from 'react-dom/test-utils';
-        globalHistory.navigate("/?select=test.jpg");
-      });
-
-      // spy on fetch
-      // use this import => import * as FetchPost from '../shared/fetch-post';
-      const mockIConnectionDefault: Promise<IConnectionDefault> = Promise.resolve(newIConnectionDefault());
-      var fetchPostSpy = jest.spyOn(FetchPost, 'default').mockImplementationOnce(() => mockIConnectionDefault);
+      var isCalled = false;
+      jest.spyOn(ColorClassSelect, 'default').mockImplementationOnce(() => { return <></> })
+        .mockImplementationOnce(() => { return <></> })
+        .mockImplementationOnce((data) => {
+          return <button onClick={() => {
+            data.onToggle(1);
+            isCalled = true;
+          }} className="colorclass--1"></button>
+        })
 
       const element = mount(<ArchiveSidebarColorClass pageType={PageType.Archive} isReadOnly={false} fileIndexItems={newIFileIndexItemArray()} />);
 
       // Make sure that the element exist in the first place
-      expect(element.find('a.colorclass--1')).toBeTruthy();
+      expect(element.find('button.colorclass--1')).toBeTruthy();
 
-      element.find('button.colorclass--1').simulate("click");
+      await act(async () => {
+        await element.find('button.colorclass--1').simulate("click");
+      });
 
-      expect(fetchPostSpy).toHaveBeenCalledTimes(1);
+      expect(isCalled).toBeTruthy();
+      expect(dispatch).toBeCalled();
+      expect(dispatch).toBeCalledWith({ "colorclass": 1, "select": ["test.jpg"], "type": "update" });
 
       useContextSpy.mockClear()
-
     });
+
   });
 });
 

--- a/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-color-class.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-color-class.tsx
@@ -3,6 +3,7 @@ import { ArchiveContext } from '../../../contexts/archive-context';
 import useLocation from '../../../hooks/use-location';
 import { PageType } from '../../../interfaces/IDetailView';
 import { IFileIndexItem } from '../../../interfaces/IFileIndexItem';
+import { FileListCache } from '../../../shared/filelist-cache';
 import { URLPath } from '../../../shared/url-path';
 import ColorClassSelect from '../color-class-select/color-class-select';
 
@@ -38,6 +39,8 @@ const ArchiveSidebarColorClass: React.FunctionComponent<IArchiveSidebarColorClas
     collections={props.pageType !== PageType.Search ? (new URLPath().StringToIUrl(history.location.search).collections !== false) : false}
     onToggle={(colorclass) => {
       dispatch({ type: 'update', colorclass, select });
+      // Entire cache because the relativeObjects in detailview can reference that order
+      new FileListCache().CacheCleanEverything();
     }}
     filePath={selectParams} isEnabled={!props.isReadOnly && select.length !== 0} clearAfter={true} />)
 });

--- a/starsky/starsky/clientapp/src/components/molecules/color-class-filter/color-class-filter.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/color-class-filter/color-class-filter.tsx
@@ -80,7 +80,7 @@ const ColorClassFilter: React.FunctionComponent<IColorClassProp> = memo((props) 
       if (index !== -1) urlObject.colorClass.splice(index, 1);
     }
 
-    new SelectCheckIfActive().IsActive(urlObject.select, urlObject.colorClass, state.fileIndexItems)
+    urlObject.select = new SelectCheckIfActive().IsActive(urlObject.select, urlObject.colorClass, state.fileIndexItems);
 
     return new URLPath().IUrlToString(urlObject);
   }

--- a/starsky/starsky/clientapp/src/components/molecules/color-class-filter/color-class-filter.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/color-class-filter/color-class-filter.tsx
@@ -1,8 +1,11 @@
 import { Link } from '@reach/router';
 import React, { memo, useEffect, useState } from 'react';
+import { ArchiveContext } from '../../../contexts/archive-context';
 import useGlobalSettings from '../../../hooks/use-global-settings';
 import useLocation from '../../../hooks/use-location';
+import { newIArchive } from '../../../interfaces/IArchive';
 import { Language } from '../../../shared/language';
+import { SelectCheckIfActive } from '../../../shared/select-check-if-active';
 import { URLPath } from '../../../shared/url-path';
 import Preloader from '../../atoms/preloader/preloader';
 
@@ -37,16 +40,17 @@ const ColorClassFilter: React.FunctionComponent<IColorClassProp> = memo((props) 
   // used for reading current location
   var history = useLocation();
 
-  const [colorClassUsage] = useState(props.colorClassUsage);
+  let { state } = React.useContext(ArchiveContext);
+  // props is used as default, state only for update
+  if (!state) state = { ...newIArchive(), colorClassUsage: props.colorClassUsage }
+  const [colorClassUsage, setIsColorClassUsage] = useState(props.colorClassUsage);
 
-  // const [colorClassUsage, setIsColorClassUsage] = useState(props.colorClassUsage);
-  // if (!state) state = { ...newIArchive(), colorClassUsage: [] }
-
-  // useEffect(() => {
-  //   setIsColorClassUsage(state.colorClassUsage);
-  //   // it should not update when the prop are changing
-  //   // eslint-disable-next-line
-  // }, [state.colorClassUsage])
+  useEffect(() => {
+    if (!state.colorClassUsage) return;
+    setIsColorClassUsage(state.colorClassUsage);
+    // it should not update when the prop are changing
+    // eslint-disable-next-line
+  }, [state.colorClassUsage])
 
   const [isLoading, setIsLoading] = useState(false);
   // When change-ing page the loader should be gone
@@ -61,14 +65,12 @@ const ColorClassFilter: React.FunctionComponent<IColorClassProp> = memo((props) 
     return new URLPath().IUrlToString(urlObject);
   }
 
-  function updateColorClass(item: number): string {
+  function getFilterUrlColorClass(item: number): string {
     var urlObject = new URLPath().StringToIUrl(history.location.search);
 
     if (!urlObject.colorClass) {
       urlObject.colorClass = [];
     }
-
-    //  checkIfSelectIsActive(urlObject.select, urlObject.colorClass, state.fileIndexItems)
 
     if (!urlObject.colorClass || urlObject.colorClass.indexOf(item) === -1) {
       urlObject.colorClass.push(item)
@@ -77,26 +79,12 @@ const ColorClassFilter: React.FunctionComponent<IColorClassProp> = memo((props) 
       var index = urlObject.colorClass.indexOf(item);
       if (index !== -1) urlObject.colorClass.splice(index, 1);
     }
+
+    new SelectCheckIfActive().IsActive(urlObject.select, urlObject.colorClass, state.fileIndexItems)
+
     return new URLPath().IUrlToString(urlObject);
   }
 
-  // function checkIfSelectIsActive(select: string[] | undefined, colorClassList: number[], fileIndexItems: IFileIndexItem[]) {
-  //   if (!select || !colorClassList) return;
-
-  //   // todo merge
-  //   // check if file exist in state or remove the selected item from the selection
-  //  // CHECK if tests are not timeout due memory issues
-  //   colorClassList.forEach(usage => {
-  //     const even = (element: IFileIndexItem) => element.colorClass === usage;
-  //     if (!state.fileIndexItems.some(even).valueOf()) {
-  //       var indexer = colorClassList.indexOf(usage);
-  //       state.colorClassUsage.splice(indexer, 1);
-
-  //     }
-
-  //     // console.log(element);
-  //   });
-  // }
 
   let resetButton = <Link to={cleanColorClass()} className="btn colorclass colorclass--reset">{colorContent[9]}</Link>;
   let resetButtonDisabled = <div className="btn colorclass colorclass--reset disabled">{colorContent[9]}</div>;
@@ -114,14 +102,16 @@ const ColorClassFilter: React.FunctionComponent<IColorClassProp> = memo((props) 
     }
     {
       colorClassUsage.map((item) => (
-        item >= 0 && item <= 8 ? <Link onClick={() => setIsLoading(true)} key={item} to={updateColorClass(item)}
+        item >= 0 && item <= 8 ? <Link onClick={() =>
+          setIsLoading(true)
+        } key={item} to={getFilterUrlColorClass(item)}
           className={props.colorClassActiveList.indexOf(item) >= 0 ?
             "btn btn--default colorclass colorclass--" + item + " active" : "btn colorclass colorclass--" + item}>
           <label /><span>{colorContent[item]}</span> </Link>
           : <span key={item} />
       ))
     }
-  </div>);
+  </div >);
 });
 
 export default ColorClassFilter

--- a/starsky/starsky/clientapp/src/components/molecules/color-class-filter/color-class-filter.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/color-class-filter/color-class-filter.tsx
@@ -3,6 +3,7 @@ import React, { memo, useEffect, useState } from 'react';
 import { ArchiveContext } from '../../../contexts/archive-context';
 import useGlobalSettings from '../../../hooks/use-global-settings';
 import useLocation from '../../../hooks/use-location';
+import { newIArchive } from '../../../interfaces/IArchive';
 import { IFileIndexItem } from '../../../interfaces/IFileIndexItem';
 import { Language } from '../../../shared/language';
 import { URLPath } from '../../../shared/url-path';
@@ -40,6 +41,7 @@ const ColorClassFilter: React.FunctionComponent<IColorClassProp> = memo((props) 
   var history = useLocation();
 
   let { state } = React.useContext(ArchiveContext);
+  if (!state) state = { ...newIArchive(), colorClassUsage: [] }
   const [colorClassUsage, setIsColorClassUsage] = useState(props.colorClassUsage);
 
   useEffect(() => {

--- a/starsky/starsky/clientapp/src/components/molecules/color-class-filter/color-class-filter.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/color-class-filter/color-class-filter.tsx
@@ -1,10 +1,7 @@
 import { Link } from '@reach/router';
 import React, { memo, useEffect, useState } from 'react';
-import { ArchiveContext } from '../../../contexts/archive-context';
 import useGlobalSettings from '../../../hooks/use-global-settings';
 import useLocation from '../../../hooks/use-location';
-import { newIArchive } from '../../../interfaces/IArchive';
-import { IFileIndexItem } from '../../../interfaces/IFileIndexItem';
 import { Language } from '../../../shared/language';
 import { URLPath } from '../../../shared/url-path';
 import Preloader from '../../atoms/preloader/preloader';
@@ -40,15 +37,16 @@ const ColorClassFilter: React.FunctionComponent<IColorClassProp> = memo((props) 
   // used for reading current location
   var history = useLocation();
 
-  let { state } = React.useContext(ArchiveContext);
-  if (!state) state = { ...newIArchive(), colorClassUsage: [] }
-  const [colorClassUsage, setIsColorClassUsage] = useState(props.colorClassUsage);
+  const [colorClassUsage] = useState(props.colorClassUsage);
 
-  useEffect(() => {
-    setIsColorClassUsage(state.colorClassUsage);
-    // it should not update when the prop are changing
-    // eslint-disable-next-line
-  }, [state.colorClassUsage])
+  // const [colorClassUsage, setIsColorClassUsage] = useState(props.colorClassUsage);
+  // if (!state) state = { ...newIArchive(), colorClassUsage: [] }
+
+  // useEffect(() => {
+  //   setIsColorClassUsage(state.colorClassUsage);
+  //   // it should not update when the prop are changing
+  //   // eslint-disable-next-line
+  // }, [state.colorClassUsage])
 
   const [isLoading, setIsLoading] = useState(false);
   // When change-ing page the loader should be gone
@@ -70,7 +68,7 @@ const ColorClassFilter: React.FunctionComponent<IColorClassProp> = memo((props) 
       urlObject.colorClass = [];
     }
 
-    checkIfSelectIsActive(urlObject.select, urlObject.colorClass, state.fileIndexItems)
+    //  checkIfSelectIsActive(urlObject.select, urlObject.colorClass, state.fileIndexItems)
 
     if (!urlObject.colorClass || urlObject.colorClass.indexOf(item) === -1) {
       urlObject.colorClass.push(item)
@@ -82,22 +80,23 @@ const ColorClassFilter: React.FunctionComponent<IColorClassProp> = memo((props) 
     return new URLPath().IUrlToString(urlObject);
   }
 
-  function checkIfSelectIsActive(select: string[] | undefined, colorClassList: number[], fileIndexItems: IFileIndexItem[]) {
-    if (!select || !colorClassList) return;
+  // function checkIfSelectIsActive(select: string[] | undefined, colorClassList: number[], fileIndexItems: IFileIndexItem[]) {
+  //   if (!select || !colorClassList) return;
 
-    // todo merge
-    // check if file exist in state or remove the selected item from the selection
-    colorClassList.forEach(usage => {
-      const even = (element: IFileIndexItem) => element.colorClass === usage;
-      if (!state.fileIndexItems.some(even).valueOf()) {
-        var indexer = colorClassList.indexOf(usage);
-        state.colorClassUsage.splice(indexer, 1);
+  //   // todo merge
+  //   // check if file exist in state or remove the selected item from the selection
+  //  // CHECK if tests are not timeout due memory issues
+  //   colorClassList.forEach(usage => {
+  //     const even = (element: IFileIndexItem) => element.colorClass === usage;
+  //     if (!state.fileIndexItems.some(even).valueOf()) {
+  //       var indexer = colorClassList.indexOf(usage);
+  //       state.colorClassUsage.splice(indexer, 1);
 
-      }
+  //     }
 
-      // console.log(element);
-    });
-  }
+  //     // console.log(element);
+  //   });
+  // }
 
   let resetButton = <Link to={cleanColorClass()} className="btn colorclass colorclass--reset">{colorContent[9]}</Link>;
   let resetButtonDisabled = <div className="btn colorclass colorclass--reset disabled">{colorContent[9]}</div>;

--- a/starsky/starsky/clientapp/src/components/molecules/color-class-select/color-class-select.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/color-class-select/color-class-select.tsx
@@ -1,5 +1,5 @@
 import 'core-js/modules/es.array.find';
-import React, { memo, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import useGlobalSettings from '../../../hooks/use-global-settings';
 import useKeyboardEvent from '../../../hooks/use-keyboard-event';
 import { IExifStatus } from '../../../interfaces/IExifStatus';
@@ -24,7 +24,7 @@ export interface IColorClassSelectProps {
 /**
  * Used to update colorclasses
  */
-const ColorClassSelect: React.FunctionComponent<IColorClassSelectProps> = memo((props) => {
+const ColorClassSelect: React.FunctionComponent<IColorClassSelectProps> = (props) => {
 
   // content
   const settings = useGlobalSettings();
@@ -63,7 +63,7 @@ const ColorClassSelect: React.FunctionComponent<IColorClassSelectProps> = memo((
    * Used for Updating Colorclasses
    * @param colorClass value to update
    */
-  var handleChange = (colorClass: number) => {
+  var handleColorClassUpdate = (colorClass: number) => {
 
     if (!props.isEnabled) return;
 
@@ -95,7 +95,7 @@ const ColorClassSelect: React.FunctionComponent<IColorClassSelectProps> = memo((
 
   useKeyboardEvent(/[0-8]/, (event: KeyboardEvent) => {
     if (new Keyboard().isInForm(event)) return;
-    handleChange(Number(event.key));
+    handleColorClassUpdate(Number(event.key));
   });
 
   return (<>
@@ -104,7 +104,7 @@ const ColorClassSelect: React.FunctionComponent<IColorClassSelectProps> = memo((
     <div className={props.isEnabled ? "colorclass colorclass--select" : "colorclass colorclass--select colorclass--disabled"}>
       {
         colorContent.map((item, index) => (
-          <button key={index} onClick={() => { handleChange(index); }}
+          <button key={index} onClick={() => { handleColorClassUpdate(index); }}
             className={currentColorClass === index ? "btn btn--default colorclass colorclass--" + index + " active" :
               "btn colorclass colorclass--" + index}>
             <label /><span>{item}</span>
@@ -112,6 +112,6 @@ const ColorClassSelect: React.FunctionComponent<IColorClassSelectProps> = memo((
         ))
       }
     </div></>)
-});
+};
 
 export default ColorClassSelect

--- a/starsky/starsky/clientapp/src/components/molecules/color-class-select/color-class-select.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/color-class-select/color-class-select.tsx
@@ -105,7 +105,8 @@ const ColorClassSelect: React.FunctionComponent<IColorClassSelectProps> = memo((
       {
         colorContent.map((item, index) => (
           <button key={index} onClick={() => { handleChange(index); }}
-            className={currentColorClass === index ? "btn btn--default colorclass colorclass--" + index + " active" : "btn colorclass colorclass--" + index}>
+            className={currentColorClass === index ? "btn btn--default colorclass colorclass--" + index + " active" :
+              "btn colorclass colorclass--" + index}>
             <label /><span>{item}</span>
           </button>
         ))

--- a/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.spec.tsx
@@ -2,9 +2,11 @@ import { globalHistory } from '@reach/router';
 import { mount, ReactWrapper, shallow } from 'enzyme';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+import * as useDetailViewContext from '../../../contexts/detailview-context';
 import { DetailViewContext } from '../../../contexts/detailview-context';
+import * as useFetch from '../../../hooks/use-fetch';
 import { IConnectionDefault, newIConnectionDefault } from '../../../interfaces/IConnectionDefault';
-import { IRelativeObjects, PageType } from '../../../interfaces/IDetailView';
+import { IRelativeObjects, newDetailView, PageType } from '../../../interfaces/IDetailView';
 import { IExifStatus } from '../../../interfaces/IExifStatus';
 import { IFileIndexItem, newIFileIndexItem } from '../../../interfaces/IFileIndexItem';
 import { ClipboardHelper } from '../../../shared/clipboard-helper';
@@ -39,6 +41,8 @@ describe("DetailViewSidebar", () => {
         state: {
           breadcrumb: [],
           fileIndexItem: {
+            filePath: '/test.jpg',
+            status: IExifStatus.Ok,
             tags: 'tags!',
             description: 'description!',
             title: 'title!',
@@ -194,6 +198,7 @@ describe("DetailViewSidebar", () => {
       expect(fetchPostSpy).toBeCalled();
 
       var expectedBodyParams = new URLSearchParams();
+      expectedBodyParams.append("f", "/test.jpg");
       expectedBodyParams.append("tags", "a");
 
       expect(fetchPostSpy).toBeCalledWith(new UrlQuery().UrlUpdateApi(), expectedBodyParams.toString());
@@ -219,7 +224,9 @@ describe("DetailViewSidebar", () => {
       expect(fetchPostSpy).toBeCalled();
 
       var expectedBodyParams = new URLSearchParams();
+      expectedBodyParams.append("f", "/test.jpg");
       expectedBodyParams.append("tags", "\0");
+
       var expectedBodyString = expectedBodyParams.toString().replace(/%00/ig, nullChar);
 
       expect(fetchPostSpy).toBeCalledWith(new UrlQuery().UrlUpdateApi(), expectedBodyString);
@@ -264,6 +271,41 @@ describe("DetailViewSidebar", () => {
       expect(component.find('[data-name="tags"]').hasClass('disabled')).toBeTruthy();
       expect(component.find('[data-name="description"]').hasClass('disabled')).toBeTruthy();
       expect(component.find('[data-name="title"]').hasClass('disabled')).toBeTruthy();
+
+    });
+
+    xit("SKIPPED test /info content ---- d", () => {
+
+      // usage ==> import * as useFetch from '../../../hooks/use-fetch';
+      var fetchContent = {
+        ...newIConnectionDefault(), statusCode: 200, data: [{
+          filePath: 'a',
+          lastEdited: '',
+          status: IExifStatus.Ok,
+        } as IFileIndexItem] as IFileIndexItem[]
+      };
+      jest.spyOn(useFetch, 'default')
+        .mockImplementationOnce(() => fetchContent)
+        .mockImplementationOnce(() => fetchContent)
+        .mockImplementationOnce(() => fetchContent)
+
+
+      var contextObject = {
+        dispatch: jest.fn(),
+        state: { ...newDetailView(), lastEdited: '' }
+      } as useDetailViewContext.IDetailViewContext;
+
+      jest.spyOn(useDetailViewContext, 'useDetailViewContext')
+        .mockImplementationOnce(() => contextObject)
+        .mockImplementationOnce(() => contextObject)
+
+
+      var component = mount(<DetailViewSidebar status={IExifStatus.Ok} filePath={"/t"}></DetailViewSidebar>);
+
+      // FAIL!!!
+
+      console.log(component.html());
+
 
     });
 

--- a/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.spec.tsx
@@ -306,7 +306,7 @@ describe("DetailViewSidebar", () => {
         key: "c",
       });
 
-      var copySpy = jest.spyOn(ClipboardHelper.prototype, 'Copy').mockImplementationOnce(() => { })
+      var copySpy = jest.spyOn(ClipboardHelper.prototype, 'Copy').mockImplementationOnce(() => { return true })
 
       act(() => {
         window.dispatchEvent(event);
@@ -322,7 +322,7 @@ describe("DetailViewSidebar", () => {
         key: "v",
       });
 
-      var pasteSpy = jest.spyOn(ClipboardHelper.prototype, 'Paste').mockImplementationOnce(() => { })
+      var pasteSpy = jest.spyOn(ClipboardHelper.prototype, 'Paste').mockImplementationOnce(() => { return true })
 
       act(() => {
         window.dispatchEvent(event);

--- a/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.stories.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.stories.tsx
@@ -13,6 +13,7 @@ storiesOf("components/organisms/detail-view-sidebar", module)
       state: {
         breadcrumb: [],
         fileIndexItem: {
+          filePath: '/test.jpg',
           tags: 'tags!',
           description: 'description!',
           title: 'title!',
@@ -25,15 +26,16 @@ storiesOf("components/organisms/detail-view-sidebar", module)
           focalLength: 10,
           longitude: 1,
           latitude: 1,
+          isoSpeed: 100,
         } as IFileIndexItem,
         relativeObjects: {} as IRelativeObjects,
-        subPath: "/",
+        subPath: "/test.jpg",
         status: IExifStatus.Default,
         pageType: PageType.DetailView,
         colorClassActiveList: [],
       } as any
     };
     return <DetailViewContext.Provider value={contextProvider}>
-      <DetailViewSidebar status={IExifStatus.Default} filePath={"/t"}>></DetailViewSidebar>
+      <DetailViewSidebar status={IExifStatus.Default} filePath={"/test.jpg"}></DetailViewSidebar>
     </DetailViewContext.Provider>
   })

--- a/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.tsx
@@ -249,7 +249,7 @@ const DetailViewSidebar: React.FunctionComponent<IDetailViewSidebarProps> = memo
         Details
       </div> : null}
 
-    {/* when the image is created */}
+    {/* dateTime when the image is created */}
     {isModalDatetimeOpen ? <ModalDatetime
       subPath={fileIndexItem.filePath}
       dateTime={fileIndexItem.dateTime}
@@ -257,7 +257,7 @@ const DetailViewSidebar: React.FunctionComponent<IDetailViewSidebarProps> = memo
         setModalDatetimeOpen(false);
         if (!result || !result[0]) return;
         setFileIndexItem(result[0]);
-        dispatch({ 'type': 'update', ...result[0], lastEdited: '' })
+        dispatch({ 'type': 'update', dateTime: result[0].dateTime, lastEdited: '' })
       }} isOpen={true} /> : null}
 
     <div className="content--text">

--- a/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.tsx
@@ -67,6 +67,7 @@ const DetailViewSidebar: React.FunctionComponent<IDetailViewSidebarProps> = memo
   useEffect(() => {
     if (!infoResponseObject.data) return;
     var infoFileIndexItem = new CastToInterface().InfoFileIndexArray(infoResponseObject.data);
+    if (!infoFileIndexItem) return;
     updateCollections(infoFileIndexItem);
     dispatch({ 'type': 'update', ...infoFileIndexItem[0], lastEdited: '' })
   }, [dispatch, infoResponseObject]);

--- a/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.tsx
@@ -63,13 +63,13 @@ const DetailViewSidebar: React.FunctionComponent<IDetailViewSidebarProps> = memo
 
   // To Get information from Info Api
   var location = new UrlQuery().UrlQueryInfoApi(props.filePath);
-  const responseObject = useFetch(location, 'get');
+  const infoResponseObject = useFetch(location, 'get');
   useEffect(() => {
-    if (!responseObject.data) return;
-    var infoFileIndexItem = new CastToInterface().InfoFileIndexArray(responseObject.data);
+    if (!infoResponseObject.data) return;
+    var infoFileIndexItem = new CastToInterface().InfoFileIndexArray(infoResponseObject.data);
     updateCollections(infoFileIndexItem);
     dispatch({ 'type': 'update', ...infoFileIndexItem[0], lastEdited: '' })
-  }, [dispatch, responseObject]);
+  }, [dispatch, infoResponseObject]);
 
   // use time from state and not the update api
   useEffect(() => {
@@ -317,7 +317,7 @@ const DetailViewSidebar: React.FunctionComponent<IDetailViewSidebarProps> = memo
         </a> : ""}
 
       {collections.map((item, index) => (
-        <Link to={new UrlQuery().updateFilePathHash(history.location.search, item)}
+        <Link to={new UrlQuery().updateFilePathHash(history.location.search + "&details=true", item)}
           key={index} className={index !== 1 ? "box" : "box box--child"} data-test="collections">
           {index !== 1 ? <div className="icon icon--photo" /> : null}
           <b>{new URLPath().getChild(item)}</b>

--- a/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.tsx
@@ -256,7 +256,8 @@ const DetailViewSidebar: React.FunctionComponent<IDetailViewSidebarProps> = memo
       handleExit={(result) => {
         setModalDatetimeOpen(false);
         if (!result || !result[0]) return;
-        setFileIndexItem(result[0]);
+        // only update the content that can be changed
+        setFileIndexItem({ ...fileIndexItem, dateTime: result[0].dateTime });
         dispatch({ 'type': 'update', dateTime: result[0].dateTime, lastEdited: '' })
       }} isOpen={true} /> : null}
 
@@ -317,6 +318,7 @@ const DetailViewSidebar: React.FunctionComponent<IDetailViewSidebarProps> = memo
         </a> : ""}
 
       {collections.map((item, index) => (
+        // some senarios details is set off, this is linked from details
         <Link to={new UrlQuery().updateFilePathHash(history.location.search + "&details=true", item)}
           key={index} className={index !== 1 ? "box" : "box box--child"} data-test="collections">
           {index !== 1 ? <div className="icon icon--photo" /> : null}

--- a/starsky/starsky/clientapp/src/components/organisms/menu-detail-view/menu-detail-view.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/menu-detail-view/menu-detail-view.spec.tsx
@@ -431,7 +431,11 @@ describe("MenuDetailView", () => {
 
       var state = {
         subPath: "/trashed/test1.jpg",
-        fileIndexItem: { status: IExifStatus.Deleted, filePath: "/trashed/test1.jpg", fileName: "test1.jpg" }
+        fileIndexItem: { status: IExifStatus.Deleted, filePath: "/trashed/test1.jpg", fileName: "test1.jpg" },
+        relativeObjects: {
+          nextFilePath: '/',
+          prevFilePath: '/'
+        }
       } as IDetailView;
       var contextValues = { state, dispatch: jest.fn() }
 

--- a/starsky/starsky/clientapp/src/components/organisms/menu-detail-view/menu-detail-view.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/menu-detail-view/menu-detail-view.tsx
@@ -13,6 +13,7 @@ import { CastToInterface } from '../../../shared/cast-to-interface';
 import { IsEditedNow } from '../../../shared/date';
 import FetchGet from '../../../shared/fetch-get';
 import FetchPost from '../../../shared/fetch-post';
+import { FileListCache } from '../../../shared/filelist-cache';
 import { Keyboard } from '../../../shared/keyboard';
 import { Language } from '../../../shared/language';
 import { URLPath } from '../../../shared/url-path';
@@ -149,7 +150,15 @@ const MenuDetailView: React.FunctionComponent = () => {
       dispatch({ 'type': 'update', status: IExifStatus.Ok, lastEdited: new Date().toISOString() });
       setIsLoading(false);
     }
+
     clearSearchCache();
+
+    // Client side Caching: the order of files in a normal folder has changed
+    if (!state.relativeObjects) {
+      return;
+    }
+    if (state.relativeObjects.nextFilePath) new FileListCache().CacheRemoveObject({ f: state.relativeObjects.nextFilePath });
+    if (state.relativeObjects.prevFilePath) new FileListCache().CacheRemoveObject({ f: state.relativeObjects.prevFilePath });
   }
 
   function clearSearchCache() {

--- a/starsky/starsky/clientapp/src/components/organisms/menu-detail-view/menu-detail-view.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/menu-detail-view/menu-detail-view.tsx
@@ -157,8 +157,8 @@ const MenuDetailView: React.FunctionComponent = () => {
     if (!state.relativeObjects) {
       return;
     }
-    if (state.relativeObjects.nextFilePath) new FileListCache().CacheRemoveObject({ f: state.relativeObjects.nextFilePath });
-    if (state.relativeObjects.prevFilePath) new FileListCache().CacheRemoveObject({ f: state.relativeObjects.prevFilePath });
+    if (state.relativeObjects.nextFilePath) new FileListCache().CacheSingleRemoveObject({ f: state.relativeObjects.nextFilePath });
+    if (state.relativeObjects.prevFilePath) new FileListCache().CacheSingleRemoveObject({ f: state.relativeObjects.prevFilePath });
   }
 
   function clearSearchCache() {

--- a/starsky/starsky/clientapp/src/components/organisms/menu-detail-view/menu-detail-view.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/menu-detail-view/menu-detail-view.tsx
@@ -154,11 +154,8 @@ const MenuDetailView: React.FunctionComponent = () => {
     clearSearchCache();
 
     // Client side Caching: the order of files in a normal folder has changed
-    if (!state.relativeObjects) {
-      return;
-    }
-    if (state.relativeObjects.nextFilePath) new FileListCache().CacheSingleRemoveObject({ f: state.relativeObjects.nextFilePath });
-    if (state.relativeObjects.prevFilePath) new FileListCache().CacheSingleRemoveObject({ f: state.relativeObjects.prevFilePath });
+    // Entire cache becouse the relativeObjects objects can reference to this page
+    new FileListCache().CacheCleanEverything();
   }
 
   function clearSearchCache() {

--- a/starsky/starsky/clientapp/src/contexts/archive-context.spec.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.spec.tsx
@@ -1,3 +1,4 @@
+import { IArchive, newIArchive } from '../interfaces/IArchive';
 import { IArchiveProps } from '../interfaces/IArchiveProps';
 import { IExifStatus } from '../interfaces/IExifStatus';
 import { archiveReducer } from './archive-context';
@@ -26,14 +27,16 @@ describe("ArchiveContext", () => {
 
   it("update - check if item is update (append false)", () => {
     var state = {
+      ...newIArchive(),
       fileIndexItems: [{
         fileName: 'test.jpg'
       },
       {
         fileName: 'test1.jpg'
       },
-      ]
-    } as IArchiveProps;
+      ],
+      colorClassUsage: [] as number[],
+    } as IArchive;
     var action = { type: 'update', tags: 'tags', colorclass: 1, description: 'description', title: 'title', append: false, select: ['test.jpg'] } as any
 
     var result = archiveReducer(state, action);

--- a/starsky/starsky/clientapp/src/contexts/archive-context.spec.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.spec.tsx
@@ -1,5 +1,6 @@
 import { IArchive, newIArchive } from '../interfaces/IArchive';
 import { IArchiveProps } from '../interfaces/IArchiveProps';
+import { PageType } from '../interfaces/IDetailView';
 import { IExifStatus } from '../interfaces/IExifStatus';
 import { archiveReducer } from './archive-context';
 
@@ -66,6 +67,64 @@ describe("ArchiveContext", () => {
     expect(result.fileIndexItems[0].tags).toBe('tags1, tags');
     expect(result.fileIndexItems[0].description).toBe('description1description');
     expect(result.fileIndexItems[0].title).toBe('title1title');
+  });
+
+  it("update - colorclass", () => {
+    var state = {
+      ...newIArchive(),
+      fileIndexItems: [{
+        fileName: 'test.jpg',
+        tags: 'tags1',
+        description: 'description1',
+        title: 'title1',
+        colorClass: 1
+      } as any],
+      colorClassUsage: [1, 2],
+      colorClassActiveList: [],
+      breadcrumb: [],
+      collectionsCount: 0,
+      pageType: PageType.ApplicationException,
+      dateCache: 0,
+      isReadOnly: false,
+    } as IArchive;
+
+    var action = { type: 'update', colorClass: 2, select: ['test.jpg'] } as any
+
+    console.log(state.colorClassUsage);
+
+    var result = archiveReducer(state, action);
+
+    expect(result.colorClassUsage.length).toBe(2);
+    expect(result.colorClassUsage[0]).toBe(1);
+    expect(result.colorClassUsage[1]).toBe(2);
+
+  });
+
+  it("update - colorclass 2", () => {
+    var state = {
+      ...newIArchive(),
+      fileIndexItems: [{
+        fileName: 'test.jpg',
+        tags: 'tags1',
+        description: 'description1',
+        title: 'title1',
+        colorClass: 1
+      } as any],
+      colorClassUsage: [2],
+      colorClassActiveList: [],
+      breadcrumb: [],
+      collectionsCount: 0,
+      pageType: PageType.ApplicationException,
+      dateCache: 0,
+      isReadOnly: false,
+    } as IArchive;
+
+    var action = { type: 'update', colorClass: 3, select: ['test.jpg'] } as any
+
+    var result = archiveReducer(state, action);
+
+    expect(result.colorClassUsage.length).toBe(1);
+    expect(result.colorClassUsage[0]).toBe(2);
   });
 
   it("add -- and check if is orderd", () => {

--- a/starsky/starsky/clientapp/src/contexts/archive-context.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.tsx
@@ -101,7 +101,7 @@ export function archiveReducer(state: State, action: Action): State {
 
             // checks the list of colorclasses that can be selected and removes the ones without 
             // only usefull when there are no colorclasses selected
-            if (!state.colorClassActiveList) {
+            if (state.colorClassActiveList && state.colorClassActiveList.length === 0) {
               state.colorClassUsage.forEach(usage => {
                 const even = (element: IFileIndexItem) => element.colorClass === usage;
                 if (!state.fileIndexItems.some(even).valueOf()) {

--- a/starsky/starsky/clientapp/src/contexts/archive-context.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.tsx
@@ -94,7 +94,23 @@ export function archiveReducer(state: State, action: Action): State {
             if (title) state.fileIndexItems[index].title = title;
           }
           // colorclass = 0 ==> colorless/no-color
-          if (colorclass !== undefined && colorclass !== -1) state.fileIndexItems[index].colorClass = colorclass;
+          if (colorclass !== undefined && colorclass !== -1) {
+            state.fileIndexItems[index].colorClass = colorclass;
+            // add to list of colorclasses that can be selected
+            if (state.colorClassUsage && state.colorClassUsage.indexOf(colorclass) === -1) state.colorClassUsage.push(colorclass);
+
+            // checks the list of colorclasses that can be selected and removes the ones without 
+            // only usefull when there are no colorclasses selected
+            if (!state.colorClassActiveList) {
+              state.colorClassUsage.forEach(usage => {
+                const even = (element: IFileIndexItem) => element.colorClass === usage;
+                if (!state.fileIndexItems.some(even).valueOf()) {
+                  var indexer = state.colorClassUsage.indexOf(usage);
+                  state.colorClassUsage.splice(indexer, 1);
+                }
+              });
+            }
+          }
           state.fileIndexItems[index].lastEdited = new Date().toISOString();
         }
       });

--- a/starsky/starsky/clientapp/src/contexts/archive-context.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.tsx
@@ -101,9 +101,12 @@ export function archiveReducer(state: State, action: Action): State {
 
             // checks the list of colorclasses that can be selected and removes the ones without 
             // only usefull when there are no colorclasses selected
-            if (state.colorClassActiveList && state.colorClassActiveList.length === 0) {
+
+            if (state.colorClassActiveList === undefined) state.colorClassActiveList = [];
+            if (state.colorClassActiveList.length === 0) {
               state.colorClassUsage.forEach(usage => {
                 const even = (element: IFileIndexItem) => element.colorClass === usage;
+                // some is not working in context of jest
                 if (!state.fileIndexItems.some(even).valueOf()) {
                   var indexer = state.colorClassUsage.indexOf(usage);
                   state.colorClassUsage.splice(indexer, 1);

--- a/starsky/starsky/clientapp/src/contexts/detailview-context.tsx
+++ b/starsky/starsky/clientapp/src/contexts/detailview-context.tsx
@@ -5,12 +5,11 @@ import { newIFileIndexItem, Orientation } from '../interfaces/IFileIndexItem';
 import { IUrl } from '../interfaces/IUrl';
 import { FileListCache } from '../shared/filelist-cache';
 
-const DetailViewContext = React.createContext<IContext>({} as IContext)
+const DetailViewContext = React.createContext<IDetailViewContext>({} as IDetailViewContext)
 
-type State = IDetailView
 type ReactNodeProps = { children: React.ReactNode }
 
-const initialState: State = {
+const initialState: IDetailView = {
   breadcrumb: [],
   fileIndexItem: newIFileIndexItem(),
   relativeObjects: {} as IRelativeObjects,
@@ -46,11 +45,11 @@ type Action = {
   payload: IDetailView
 };
 
-type IContext = {
-  state: State,
+export type IDetailViewContext = {
+  state: IDetailView,
   dispatch: React.Dispatch<Action>,
 }
-export function detailviewReducer(state: State, action: Action): State {
+export function detailviewReducer(state: IDetailView, action: Action): IDetailView {
   switch (action.type) {
     case "remove":
       var { tags } = action;

--- a/starsky/starsky/clientapp/src/shared/cast-to-interface.spec.ts
+++ b/starsky/starsky/clientapp/src/shared/cast-to-interface.spec.ts
@@ -46,6 +46,11 @@ describe("cast-to-interface", () => {
       ]);
       expect(test[0].tags).toBe("test");
     });
+
+    it("should ignore string", () => {
+      var test = new CastToInterface().InfoFileIndexArray("test");
+      expect(test).toStrictEqual([]);
+    });
   });
 
 });

--- a/starsky/starsky/clientapp/src/shared/cast-to-interface.ts
+++ b/starsky/starsky/clientapp/src/shared/cast-to-interface.ts
@@ -45,6 +45,7 @@ export class CastToInterface {
    * Return casted list
    */
   InfoFileIndexArray = (data: any): Array<IFileIndexItem> => {
+    if (typeof data === 'string') return [];
     return data as Array<IFileIndexItem>;
   }
 

--- a/starsky/starsky/clientapp/src/shared/detect-automatic-rotation.spec.ts
+++ b/starsky/starsky/clientapp/src/shared/detect-automatic-rotation.spec.ts
@@ -1,3 +1,4 @@
+import BrowserDetect from './browser-detect';
 import DetectAutomaticRotation, { testAutoOrientationImageURL } from './detect-automatic-rotation';
 
 describe("select", () => {
@@ -19,5 +20,13 @@ describe("select", () => {
       var result = await DetectAutomaticRotation();
       expect(result).toBeFalsy();
     });
+
+    it("iOS should be true", async () => {
+      jest.spyOn(BrowserDetect.prototype, 'IsIOS').mockImplementationOnce(() => { return true });
+
+      var result = await DetectAutomaticRotation();
+      expect(result).toBeTruthy();
+    });
+
   });
 });

--- a/starsky/starsky/clientapp/src/shared/detect-automatic-rotation.ts
+++ b/starsky/starsky/clientapp/src/shared/detect-automatic-rotation.ts
@@ -1,5 +1,6 @@
-import detectAutomaticRotationJpeg from '../style/images/detect-automatic-rotation.jpg';
 // use the: IMAGE_INLINE_SIZE_LIMIT=1 due the fact that data: are not supported by the CSP
+import { BrowserDetect } from '../shared/browser-detect';
+import detectAutomaticRotationJpeg from '../style/images/detect-automatic-rotation.jpg';
 
 /**
  * Black 2x1 JPEG, with the following meta information set:
@@ -16,9 +17,17 @@ export const testAutoOrientationImageURL = 'data:image/jpeg;base64,/9j/4QAiRXhpZ
 
 /**
  * check if browser supports automatic image orientation
- * Supported: Chrome 81+ and Safari (Desktop) 13.1+ and Safari Mobile (?)
+ * Supported: Chrome 81+ and Safari (Desktop) 13.1+ and Safari Mobile 13+
+ * Hacked/Supported though BrowserDetect hack: Safari on iOS 12 and lower
  */
 const DetectAutomaticRotation = async (): Promise<boolean> => {
+
+  // iOS 12 and lower don't update the img.width but does rotate the image.
+  // this BrowserDetect method detect if the browser is iOS or iPad OS
+  if (new BrowserDetect().IsIOS()) {
+    return true;
+  }
+
   return new Promise((resolve) => {
     const img = new Image();
     img.onload = () => {
@@ -29,5 +38,36 @@ const DetectAutomaticRotation = async (): Promise<boolean> => {
     img.src = detectAutomaticRotationJpeg;
   });
 };
+
+
+/*
+Exif orientation values to correctly display the letter F:
+
+  1             2
+██████        ██████
+██                ██
+████            ████
+██                ██
+██                ██
+
+  3             4
+    ██        ██
+    ██        ██
+  ████        ████
+    ██        ██
+██████        ██████
+
+  5             6
+██████████    ██
+██  ██        ██  ██
+██            ██████████
+
+  7             8
+      ██    ██████████
+  ██  ██        ██  ██
+██████████            ██
+
+*/
+
 
 export default DetectAutomaticRotation;

--- a/starsky/starsky/clientapp/src/shared/filelist-cache.ts
+++ b/starsky/starsky/clientapp/src/shared/filelist-cache.ts
@@ -99,6 +99,17 @@ export class FileListCache {
     return cache;
   }
 
+  public CacheRemove(locationSearch: string) {
+    var urlObject = new URLPath().StringToIUrl(locationSearch);
+    this.CacheRemoveObject(urlObject);
+  }
+
+  public CacheRemoveObject(urlObject: IUrl) {
+    if (localStorage.getItem('clientCache') === 'false') return null;
+    urlObject = this.SetDefaultUrlObjectValues(urlObject);
+    sessionStorage.removeItem(this.CacheKeyGenerator(urlObject))
+  }
+
   /**
    * And clean the old ones
    */

--- a/starsky/starsky/clientapp/src/shared/filelist-cache.ts
+++ b/starsky/starsky/clientapp/src/shared/filelist-cache.ts
@@ -115,20 +115,27 @@ export class FileListCache {
     return cache;
   }
 
-  public CacheSingleRemove(locationSearch: string) {
+  public CacheRemove(locationSearch: string) {
     var urlObject = new URLPath().StringToIUrl(locationSearch);
-    this.CacheSingleRemoveObject(urlObject);
+    this.CacheRemoveObject(urlObject);
   }
 
-  public CacheSingleRemoveObject(urlObject: IUrl) {
+  public CacheRemoveObject(urlObject: IUrl) {
     if (localStorage.getItem('clientCache') === 'false') return null;
     urlObject = this.SetDefaultUrlObjectValues(urlObject);
 
-    var colorClassOptions = [];
+    this.CleanAllLookingNames(urlObject);
+  }
+
+  private CleanAllLookingNames(urlObject: IUrl) {
+    if (!urlObject.f) {
+      return;
+    }
     this.GetAll().forEach(item => {
-      // item.name.endsWith(urlObject.f)
+      if (item.name.endsWith(urlObject.f as string)) {
+        sessionStorage.removeItem(item.name)
+      }
     });
-    sessionStorage.removeItem(this.CacheKeyGenerator(urlObject))
   }
 
   private GetAll(): IGetAllTransferObject[] {

--- a/starsky/starsky/clientapp/src/shared/filelist-cache.ts
+++ b/starsky/starsky/clientapp/src/shared/filelist-cache.ts
@@ -33,8 +33,15 @@ export class FileListCache {
     if (localStorage.getItem('clientCache') === 'false') return;
     urlObject = this.SetDefaultUrlObjectValues(urlObject);
     value.dateCache = Date.now();
-    sessionStorage.setItem(this.CacheKeyGenerator(urlObject), JSON.stringify(value));
-    return value;
+
+    try {
+      // old versions of safari don't allow sessionStorage in private navigation
+      sessionStorage.setItem(this.CacheKeyGenerator(urlObject), JSON.stringify(value));
+      return value;
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
   }
 
   /**

--- a/starsky/starsky/clientapp/src/shared/filelist-cache.ts
+++ b/starsky/starsky/clientapp/src/shared/filelist-cache.ts
@@ -41,7 +41,6 @@ export class FileListCache {
       return value;
     } catch (error) {
       console.error(error);
-      return null;
     }
   }
 

--- a/starsky/starsky/clientapp/src/shared/filelist-cache.ts
+++ b/starsky/starsky/clientapp/src/shared/filelist-cache.ts
@@ -115,29 +115,6 @@ export class FileListCache {
     return cache;
   }
 
-  public CacheRemove(locationSearch: string) {
-    var urlObject = new URLPath().StringToIUrl(locationSearch);
-    this.CacheRemoveObject(urlObject);
-  }
-
-  public CacheRemoveObject(urlObject: IUrl) {
-    if (localStorage.getItem('clientCache') === 'false') return null;
-    urlObject = this.SetDefaultUrlObjectValues(urlObject);
-
-    this.CleanAllLookingNames(urlObject);
-  }
-
-  private CleanAllLookingNames(urlObject: IUrl) {
-    if (!urlObject.f) {
-      return;
-    }
-    this.GetAll().forEach(item => {
-      if (item.name.endsWith(urlObject.f as string)) {
-        sessionStorage.removeItem(item.name)
-      }
-    });
-  }
-
   private GetAll(): IGetAllTransferObject[] {
     var list = [];
     for (let index = 0; index < Object.keys(sessionStorage).length; index++) {
@@ -165,7 +142,7 @@ export class FileListCache {
   }
 
   /**
-   * And clean the old ones
+   * And clean All Items
    */
   public CacheCleanEverything(): void {
     this.GetAll().forEach(item => {

--- a/starsky/starsky/clientapp/src/shared/filelist-cache.ts
+++ b/starsky/starsky/clientapp/src/shared/filelist-cache.ts
@@ -6,11 +6,6 @@ import { URLPath } from './url-path';
 
 export class FileListCache {
 
-  constructor() {
-    if (sessionStorage) return;
-    throw Error("Session Storage is needed")
-  }
-
   private cachePrefix = "starsky;";
 
   private timeoutInMinutes = 3;
@@ -21,6 +16,7 @@ export class FileListCache {
     this.setParentItem(urlObject, value);
     return value;
   }
+
 
   private SetDefaultUrlObjectValues(urlObject: IUrl): IUrl {
     if (!urlObject.f) urlObject.f = "/";
@@ -88,11 +84,19 @@ export class FileListCache {
     return this.CacheSetObject(urlObject, value);
   }
 
+  /**
+  * GETTER of cache
+  * @param locationSearch where to look for
+  */
   public CacheGet(locationSearch: string): IArchive | IDetailView | null {
     var urlObject = new URLPath().StringToIUrl(locationSearch);
     return this.CacheGetObject(urlObject);
   }
 
+  /**
+   * GETTER of cache
+   * @param urlObject where to look for 
+   */
   public CacheGetObject(urlObject: IUrl): IArchive | IDetailView | null {
     if (localStorage.getItem('clientCache') === 'false') return null;
     urlObject = this.SetDefaultUrlObjectValues(urlObject);

--- a/starsky/starsky/clientapp/src/shared/select-check-if-active.spec.ts
+++ b/starsky/starsky/clientapp/src/shared/select-check-if-active.spec.ts
@@ -1,0 +1,31 @@
+
+import { newIFileIndexItem } from '../interfaces/IFileIndexItem';
+import { SelectCheckIfActive } from './select-check-if-active';
+
+describe("SelectCheckIfActive", () => {
+  describe("IsActive", () => {
+
+    it("filter nr 2 out", () => {
+
+      var result = new SelectCheckIfActive().IsActive(["test1.jpg", "test2.jpg"], [1], [
+        { ...newIFileIndexItem(), colorClass: 1, fileName: 'test1.jpg' },
+        { ...newIFileIndexItem(), colorClass: 2, fileName: 'test2.jpg' }
+      ]);
+
+      expect(result.length).toBe(1)
+      expect(result[0]).toBe('test1.jpg')
+    });
+
+    it("ignore files wihout colorclass marking", () => {
+
+      var result = new SelectCheckIfActive().IsActive(["test1.jpg", "test2.jpg"], [1], [
+        { ...newIFileIndexItem(), fileName: 'test1.jpg' },
+        { ...newIFileIndexItem(), colorClass: 1, fileName: 'test2.jpg' }
+      ]);
+
+      expect(result.length).toBe(1)
+      expect(result[0]).toBe('test2.jpg')
+    });
+
+  });
+});

--- a/starsky/starsky/clientapp/src/shared/select-check-if-active.spec.ts
+++ b/starsky/starsky/clientapp/src/shared/select-check-if-active.spec.ts
@@ -5,6 +5,11 @@ import { SelectCheckIfActive } from './select-check-if-active';
 describe("SelectCheckIfActive", () => {
   describe("IsActive", () => {
 
+    it("select is null", () => {
+      var result = new SelectCheckIfActive().IsActive(undefined, [1], []);
+      expect(result.length).toBe(0)
+    });
+
     it("filter nr 2 out", () => {
 
       var result = new SelectCheckIfActive().IsActive(["test1.jpg", "test2.jpg"], [1], [

--- a/starsky/starsky/clientapp/src/shared/select-check-if-active.ts
+++ b/starsky/starsky/clientapp/src/shared/select-check-if-active.ts
@@ -1,0 +1,22 @@
+import { IFileIndexItem } from '../interfaces/IFileIndexItem';
+
+export class SelectCheckIfActive {
+
+  public IsActive(select: string[] | undefined, colorclasses: number[], fileIndexItems: IFileIndexItem[]) {
+    if (!select) return [];
+
+    // it should contain on the colorclasses
+    const fileNameList = fileIndexItems.filter(el => el.colorClass !== undefined
+      && colorclasses.indexOf(el.colorClass) !== -1).map(ele => ele.fileName);
+
+    // you can't select an item thats not shown
+    select.forEach(selectedPath => {
+      if (fileNameList.indexOf(selectedPath) === -1) {
+        var selectIndex = select.indexOf(selectedPath);
+        delete select[selectIndex];
+      }
+    });
+    // remove emthy items from the list
+    return select.filter(res => res);
+  }
+}

--- a/starsky/starsky/clientapp/src/shared/select.ts
+++ b/starsky/starsky/clientapp/src/shared/select.ts
@@ -13,6 +13,7 @@ export class Select {
     setSelect: React.Dispatch<React.SetStateAction<string[] | undefined>>,
     state: IArchiveProps,
     history: IUseLocation) {
+    // props
     this.select = select;
     this.setSelect = setSelect;
     this.state = state;
@@ -63,4 +64,5 @@ export class Select {
     }
     this.history.navigate(new URLPath().IUrlToString(urlObject), { replace: true });
   }
+
 }


### PR DESCRIPTION
# PR Details 

- [x]   (Fixed) _Front-end_ DetailView - DateTime push in Detailview has no influence on colorclass anymore
- [x]   (Fixed) _Front-end_ DetailView - Links to collections are always with `details=true`
- [x]   (Fixed) _Front-end_ DetailView - When pressing delete the entire clientSide cache is cleared (to avoid next/prev issues)
- [x]   (Fixed) _Front-end_ Archive - When selecting a new colorClass this is added to the filter
- [x]   (Fixed) _Front-end_ DetailView - Safari 12 and lower does autorotate the image correct


## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [x] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (framework not included) 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
