### PR TITLE
You have already run this program for this folder remove the _setting…

### DIFF
--- a/history.md
+++ b/history.md
@@ -39,7 +39,8 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Fixed) _Front-end_ DetailView - When pressing delete the entire clientSide cache is cleared (to avoid next/prev issues)
 - [x]   (Fixed) _Front-end_ Archive - When selecting a new colorClass this is added to the filter
 - [x]   (Fixed) _Front-end_ DetailView - Safari 12 and lower does autorotate the image correct
-
+- [x]   (Added) _CLI_ Stop with warning when running WebHtmlPublish over the same folder (checks for `_settings.json`)
+ 
 # version 0.3.1 - 2020-09-08
 - [x]   (Added) _Front-end_ UI improvement on Archive add t/i keyboard shortcut to select tags
 - [x]   (Added) _Front-end_ Client Side caching for 3 minutes to avoid requests and speed on slow devices

--- a/starsky/starsky.feature.webhtmlpublish/Helpers/PublishCli.cs
+++ b/starsky/starsky.feature.webhtmlpublish/Helpers/PublishCli.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using starsky.feature.webhtmlpublish.Interfaces;
@@ -62,6 +63,14 @@ namespace starsky.feature.webhtmlpublish.Helpers
 			{
 				_console.WriteLine("Please add a valid folder: " + inputFullPath + ". " +
 				                   "This folder is not found");
+				return;
+			}
+			
+			var settingsFullFilePath = Path.Combine(inputFullPath, "_settings.json");
+			if ( _hostFileSystemStorage.ExistFile(settingsFullFilePath) )
+			{
+				_console.WriteLine($"You have already run this program for this folder remove the " +
+				                   $"_settings.json first and try it again"  );
 				return;
 			}
 

--- a/starsky/starskytest/starsky.feature.webhtmlpublish/Helpers/PublishCliTest.cs
+++ b/starsky/starskytest/starsky.feature.webhtmlpublish/Helpers/PublishCliTest.cs
@@ -53,6 +53,20 @@ namespace starskytest.starsky.feature.webhtmlpublish.Helpers
 
 			Assert.IsTrue(console.WrittenLines.LastOrDefault().Contains("done"));
 		}
+		
+		[TestMethod]
+		public void Publisher_WarnWhenAlreadyRun()
+		{			
+			var console = new FakeConsoleWrapper();
+			var fakeSelectorStorage = new FakeSelectorStorage(new FakeIStorage(new List<string>{"/test"}, 
+				new List<string>{"/test/_settings.json"}));
+
+			new PublishCli(fakeSelectorStorage, new FakeIPublishPreflight(), new FakeIWebHtmlPublishService(), 
+				new AppSettings(), console).Publisher(new []{"-p", "/test"});
+
+			Assert.IsTrue(console.WrittenLines.LastOrDefault().Contains("_settings.json"));
+		}
+
 
 	}
 }


### PR DESCRIPTION
…s.json first and try it again
- [x]   (Added) _CLI_ Stop with warning when running WebHtmlPublish over the same folder (checks for `_settings.json`)

# PR Details 

<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (framework not included) 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
