### PR TITLE
202009_force_sync_cache_clean_bug

### DIFF
--- a/history.md
+++ b/history.md
@@ -41,6 +41,9 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Fixed) _Front-end_ DetailView - Safari 12 and lower does autorotate the image correct
 - [x]   (Added) _CLI_ Stop with warning when running WebHtmlPublish over the same folder (checks for `_settings.json`)
 - [x]   (Fixed) _Front-end_ Archive - When click on a Link in Archive, with command key it should ignore preloader
+- [x]   (Fixed) _Front-end_ Modal Sync Manually - Folders with plus `+` in the url are synced 
+- [x]   (Fixed) _Front-end_ Modal Sync Manually - When ColorClass is selected, its now updating the state to keep the selection
+- [x]   (Fixed) _Front-end_ Modal Sync Manually - Sync Manual and Clears Cache cleans now also the client cache.
 
 # version 0.3.1 - 2020-09-08
 - [x]   (Added) _Front-end_ UI improvement on Archive add t/i keyboard shortcut to select tags

--- a/starsky-tools/localtunnel/localtunnel.js
+++ b/starsky-tools/localtunnel/localtunnel.js
@@ -100,6 +100,9 @@ function NetCoreAppRouteRoute(req, res, next) {
 
   // Error: socket hang up
   apiProxy.on('error', function (error, req, res) {
+    if (error && error.code && error.code === 'ECONNRESET') {
+      return;
+    }
     var json;
     if (!res.headersSent) {
       res.writeHead(500, { 'content-type': 'application/json' });

--- a/starsky/starsky/clientapp/src/components/organisms/modal-archive-synchronize-manually/modal-archive-synchronize-manually.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/modal-archive-synchronize-manually/modal-archive-synchronize-manually.tsx
@@ -7,6 +7,7 @@ import { IArchiveProps } from '../../../interfaces/IArchiveProps';
 import { CastToInterface } from '../../../shared/cast-to-interface';
 import FetchGet from '../../../shared/fetch-get';
 import FetchPost from '../../../shared/fetch-post';
+import { FileListCache } from '../../../shared/filelist-cache';
 import { Language } from '../../../shared/language';
 import { URLPath } from '../../../shared/url-path';
 import { UrlQuery } from '../../../shared/url-query';
@@ -54,11 +55,12 @@ const ModalArchiveSynchronizeManually: React.FunctionComponent<IModalDisplayOpti
    */
   function removeCache() {
     setIsLoading(true);
-
+    new FileListCache().CacheCleanEverything();
     var parentFolder = props.parentFolder ? props.parentFolder : "/";
     FetchGet(new UrlQuery().UrlRemoveCache(new URLPath().encodeURI(parentFolder))).then((_) => {
       setTimeout(() => {
-        FetchGet(new UrlQuery().UrlIndexServerApiPath(new URLPath().encodeURI(parentFolder))).then((connectionResult) => {
+        var url = new UrlQuery().UrlIndexServerApi(new URLPath().StringToIUrl(history.location.search));
+        FetchGet(url).then((connectionResult) => {
           var removeCacheResult = new CastToInterface().MediaArchive(connectionResult.data);
           var payload = removeCacheResult.data as IArchiveProps;
           if (payload.fileIndexItems) {
@@ -98,14 +100,18 @@ const ModalArchiveSynchronizeManually: React.FunctionComponent<IModalDisplayOpti
     });
   }
 
-  useInterval(() => fetchGeoSyncStatus(), 4333);
+  useInterval(() => fetchGeoSyncStatus(), 10000);
 
   function forceSync() {
     var parentFolder = props.parentFolder ? props.parentFolder : "/";
     setIsLoading(true);
-    FetchGet(new UrlQuery().UrlSync(new URLPath().encodeURI(parentFolder))).then((_) => {
+    new FileListCache().CacheCleanEverything();
+
+    var urlSync = new UrlQuery().UrlSync(parentFolder);
+    FetchGet(urlSync).then((_) => {
       setTimeout(() => {
-        FetchGet(new UrlQuery().UrlIndexServerApiPath(new URLPath().encodeURI(parentFolder))).then((connectionResult) => {
+        var url = new UrlQuery().UrlIndexServerApi(new URLPath().StringToIUrl(history.location.search));
+        FetchGet(url).then((connectionResult) => {
           var forceSyncResult = new CastToInterface().MediaArchive(connectionResult.data);
           var payload = forceSyncResult.data as IArchiveProps;
           if (payload.fileIndexItems) {
@@ -132,7 +138,7 @@ const ModalArchiveSynchronizeManually: React.FunctionComponent<IModalDisplayOpti
   }
 
   return (<Modal
-    id="detailview-export-modal"
+    id="modal-archive-synchronize-manually"
     isOpen={props.isOpen}
     handleExit={() => {
       props.handleExit()

--- a/starsky/starsky/clientapp/src/hooks/use-filelist.ts
+++ b/starsky/starsky/clientapp/src/hooks/use-filelist.ts
@@ -27,7 +27,6 @@ const useFileList = (locationSearch: string, resetPageTypeBeforeLoading: boolean
   const [pageType, setPageType] = useState(PageType.Loading);
   const [parent, setParent] = useState('/');
   var location = new UrlQuery().UrlQueryServerApi(locationSearch);
-  console.log(location);
 
   const fetchContent = async (location: string, abortController: AbortController): Promise<void> => {
     try {

--- a/starsky/starsky/clientapp/src/hooks/use-filelist.ts
+++ b/starsky/starsky/clientapp/src/hooks/use-filelist.ts
@@ -27,6 +27,7 @@ const useFileList = (locationSearch: string, resetPageTypeBeforeLoading: boolean
   const [pageType, setPageType] = useState(PageType.Loading);
   const [parent, setParent] = useState('/');
   var location = new UrlQuery().UrlQueryServerApi(locationSearch);
+  console.log(location);
 
   const fetchContent = async (location: string, abortController: AbortController): Promise<void> => {
     try {

--- a/starsky/starsky/clientapp/src/shared/url-query.ts
+++ b/starsky/starsky/clientapp/src/shared/url-query.ts
@@ -233,6 +233,10 @@ export class UrlQuery {
     return this.prefix + "/export/zip/" + createZipId + ".zip?json=" + json;
   }
 
+  /**
+   * Url of Sync (no need to encode url)
+   * @param parentFolder no need to encode url
+   */
   public UrlSync(parentFolder: string): string {
     return this.prefix + "/sync?f=" + new URLPath().encodeURI(parentFolder);
   }


### PR DESCRIPTION
# PR Details 

- [x]   (Fixed) _Front-end_ Modal Sync Manually - Folders with plus `+` in the url are synced 
- [x]   (Fixed) _Front-end_ Modal Sync Manually - When ColorClass is selected, its now updating the state to keep the selection
- [x]   (Fixed) _Front-end_ Modal Sync Manually - Sync Manual and Clears Cache cleans now also the client cache.

## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [x] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (framework not included) 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
