### PR TITLE
Azure devops sonarqube uses the correct branch name instead of master

### DIFF
--- a/azure-pipelines-starsky.yml
+++ b/azure-pipelines-starsky.yml
@@ -68,7 +68,7 @@ steps:
   displayName: 'Cake SonarBuildTest'
   inputs:
     filePath: 'starsky\build.ps1'
-    arguments: '-runtime="linux-arm,linux-arm64" -target="SonarBuildTest" -branch="$(Build.SourceBranchName)"'
+    arguments: '-runtime="linux-arm,linux-arm64" -target="SonarBuildTest" -branch="$(Build.SourceBranch)"'
     pwsh: true
     workingDirectory: '$(Build.SourcesDirectory)\starsky\'
 

--- a/azure-pipelines-starsky.yml
+++ b/azure-pipelines-starsky.yml
@@ -68,7 +68,7 @@ steps:
   displayName: 'Cake SonarBuildTest'
   inputs:
     filePath: 'starsky\build.ps1'
-    arguments: '-runtime="linux-arm,linux-arm64" -target="SonarBuildTest"'
+    arguments: '-runtime="linux-arm,linux-arm64" -target="SonarBuildTest" -branch="$(Build.SourceBranchName)"'
     pwsh: true
     workingDirectory: '$(Build.SourcesDirectory)\starsky\'
 

--- a/starsky/build.cake
+++ b/starsky/build.cake
@@ -28,6 +28,10 @@ var configuration = Argument("Configuration", "Release");
 var genericName = "generic-netcore";
 var runtimeInput = Argument("runtime", genericName);
 var branchName = Argument("branch", "");
+/* when running from Azure Devops $(Build.SourceBranch) */
+if(branchName.StartsWith("refs/heads/")) {
+  branchName  = branchName.Replace("refs/heads/","");
+}
 var noSonar = HasArgument("no-sonar") || HasArgument("nosonar");
 
 /* to get a list with the generic item */


### PR DESCRIPTION
# PR Details 

Azure devops sonarqube uses the correct branch name instead of master

## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (framework not included) 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
