### PR TITLE
Feature/202009 search delete bugfix

### DIFF
--- a/starsky/.config/dotnet-tools.json
+++ b/starsky/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.38.4",
+      "version": "0.38.5",
       "commands": [
         "dotnet-cake"
       ]
     },
     "dotnet-reportgenerator-globaltool": {
-      "version": "4.6.1",
+      "version": "4.6.7",
       "commands": [
         "reportgenerator"
       ]

--- a/starsky/build.cake
+++ b/starsky/build.cake
@@ -564,6 +564,9 @@ Task("SonarBegin")
         if (branchName == "(no branch)" || branchName == "") {
           branchName = "master";
         }
+
+        var tsconfig = System.IO.Path.Combine(clientAppProject,"tsconfig.json");
+        
         Information($">> Selecting Branch: {branchName}");
 
         IEnumerable<string> redirectedStandardOutput;
@@ -581,6 +584,7 @@ Task("SonarBegin")
                       .Append($"/d:sonar.login=\"{login}\"")
                       .Append($"/d:sonar.branch.name=\"{branchName}\"")
                       .Append($"/o:" + organisation)
+                      .Append($"/d:sonar.typescript.tsconfigPath={tsconfig}")
                       .Append($"/d:sonar.cs.opencover.reportsPaths=\"{netCoreCoverageFile}\"")
                       .Append($"/d:sonar.typescript.lcov.reportPaths=\"{jestCoverageFile}\"")
                       .Append($"/d:sonar.exclusions=\"**/setupTests.js,**/react-app-env.d.ts,**/service-worker.ts,*webhtmlcli/**/*.js,**/wwwroot/js/**/*,**/*/Migrations/*,**/*spec.tsx,,**/*stories.tsx,**/*spec.ts,**/src/index.tsx,**/src/style/css/vendor/*\"")

--- a/starsky/build.cake
+++ b/starsky/build.cake
@@ -564,9 +564,9 @@ Task("SonarBegin")
         if (branchName == "(no branch)" || branchName == "") {
           branchName = "master";
         }
-
+        /* this should fix No inputs were found in config file 'tsconfig.json'.  */
         var tsconfig = System.IO.Path.Combine(clientAppProject,"tsconfig.json");
-        
+
         Information($">> Selecting Branch: {branchName}");
 
         IEnumerable<string> redirectedStandardOutput;

--- a/starsky/starsky.foundation.database/Interfaces/IQuery.cs
+++ b/starsky/starsky.foundation.database/Interfaces/IQuery.cs
@@ -45,12 +45,12 @@ namespace starsky.foundation.database.Interfaces
         Task<FileIndexItem> GetObjectByFilePathAsync(string filePath);
         
         FileIndexItem RemoveItem(FileIndexItem updateStatusContent);
-        
+
         /// <summary>
         /// Clear the directory name from the cache
         /// </summary>
         /// <param name="directoryName">the path of the directory (there is no parent generation)</param>
-        void RemoveCacheParentItem(string directoryName);
+        bool RemoveCacheParentItem(string directoryName);
 
         string GetSubPathByHash(string fileHash);
 	    void ResetItemByHash(string fileHash);

--- a/starsky/starsky.foundation.database/Query/Query.cs
+++ b/starsky/starsky.foundation.database/Query/Query.cs
@@ -223,6 +223,14 @@ namespace starsky.foundation.database.Query
 	            // Set state to edit mode
                 _context.Attach(item).State = EntityState.Modified;
             }
+            
+            void CatchLoop(Exception e)
+            {
+	            foreach ( var item in updateStatusContentList )
+	            {
+		            RetrySaveChanges(item, e);
+	            }
+            }
 
             try
             {
@@ -230,11 +238,11 @@ namespace starsky.foundation.database.Query
             }
             catch (ObjectDisposedException e)
             {
-	            RetrySaveChanges(e);
+	            CatchLoop(e);
             }
             catch (InvalidOperationException e)
             {
-	            RetrySaveChanges(e);
+	            CatchLoop(e);
             }
 
             CacheUpdateItem(updateStatusContentList);
@@ -244,15 +252,18 @@ namespace starsky.foundation.database.Query
         /// <summary>
         /// Retry when an Exception has occured
         /// </summary>
+        /// <param name="updateStatusContent"></param>
         /// <param name="e">Exception</param>
-        private void RetrySaveChanges(Exception e)
+        private void RetrySaveChanges(FileIndexItem updateStatusContent, Exception e)
         {
 	        // InvalidOperationException: A second operation started on this context before a previous operation completed.
 	        // https://go.microsoft.com/fwlink/?linkid=2097913
 	        Thread.Sleep(10);
-	        if ( _appSettings.Verbose ) Console.WriteLine("Retry Exception\n" + e);
-	        _context = new InjectServiceScope(_scopeFactory).Context();
-	        _context.SaveChanges();
+	        if ( _appSettings.Verbose ) Console.WriteLine($"Retry Exception {e}\n");
+	        var context = new InjectServiceScope(_scopeFactory).Context();
+	        context.Attach(updateStatusContent).State = EntityState.Modified;
+	        context.SaveChanges();
+	        context.Attach(updateStatusContent).State = EntityState.Detached; 
         }
         
 
@@ -270,16 +281,15 @@ namespace starsky.foundation.database.Query
 	        {
 				_context.Attach(updateStatusContent).State = EntityState.Modified;
 	            _context.SaveChanges();
-            }
+	            _context.Attach(updateStatusContent).State = EntityState.Detached;
+	        }
             catch ( ObjectDisposedException e)
             {
-	            RetrySaveChanges(e);
+	            RetrySaveChanges(updateStatusContent, e);
             }
             
             CacheUpdateItem(new List<FileIndexItem>{updateStatusContent});
-			
-	        _context.Attach(updateStatusContent).State = EntityState.Detached;
-	        
+
             return updateStatusContent;
         }
 
@@ -369,16 +379,17 @@ namespace starsky.foundation.database.Query
         /// Clear the directory name from the cache
         /// </summary>
         /// <param name="directoryName">the path of the directory (there is no parent generation)</param>
-        public void RemoveCacheParentItem(string directoryName)
+        public bool RemoveCacheParentItem(string directoryName)
         {
             // Add protection for disabled caching
-            if( _cache == null || _appSettings?.AddMemoryCache == false) return;
+            if( _cache == null || _appSettings?.AddMemoryCache == false) return false;
             
             var queryCacheName = CachingDbName(typeof(List<FileIndexItem>).Name, 
                 PathHelper.RemoveLatestSlash(directoryName));
-            if (!_cache.TryGetValue(queryCacheName, out var objectFileFolders)) return;
+            if (!_cache.TryGetValue(queryCacheName, out var objectFileFolders)) return false;
             
             _cache.Remove(queryCacheName);
+            return true;
         }
 
 	    /// <summary>

--- a/starsky/starsky/Controllers/ApiController.cs
+++ b/starsky/starsky/Controllers/ApiController.cs
@@ -50,13 +50,11 @@ namespace starsky.Controllers
             }
 
             var singleItem = _query.SingleItem(f);
-            if (singleItem != null && singleItem.IsDirectory)
-            {
-                _query.RemoveCacheParentItem(f);
-                return Json("cache successful cleared");
-            }
-
-            return BadRequest("ignored, please check if the 'f' path exist or use a folder string to clear the cache");
+            if ( singleItem == null || !singleItem.IsDirectory )
+	            return BadRequest(
+		            "ignored, please check if the 'f' path exist or use a folder string to clear the cache");
+            
+            return Json(_query.RemoveCacheParentItem(f) ? "cache successful cleared" : "cache did not exist");
         }
 
     }

--- a/starsky/starsky/Controllers/MetaUpdateController.cs
+++ b/starsky/starsky/Controllers/MetaUpdateController.cs
@@ -70,7 +70,7 @@ namespace starsky.Controllers
 			});
 			
             // When all items are not found
-            if (fileIndexResultsList.All(p => p.Status != FileIndexItem.ExifStatus.Ok))
+            if (fileIndexResultsList.All(p => p.Status != FileIndexItem.ExifStatus.Ok && p.Status != FileIndexItem.ExifStatus.Deleted))
                 return NotFound(fileIndexResultsList);
 
             // Clone an new item in the list to display

--- a/starsky/starsky/Health/DiskStorageHealthCheck.cs
+++ b/starsky/starsky/Health/DiskStorageHealthCheck.cs
@@ -26,14 +26,16 @@ namespace starsky.Health
 			{
 				foreach ((string, long) valueTuple in _options.ConfiguredDrives.Values)
 				{
-					string driveName = valueTuple.Item1;
-					long num = valueTuple.Item2;
-					(bool exists4, long actualFreeMegabytes4) = GetSystemDriveInfo(driveName);
+					var driveName = valueTuple.Item1;
+					var num = valueTuple.Item2;
+					var (exists4, actualFreeMegabytes4) = GetSystemDriveInfo(driveName);
 					if (!exists4)
-						return Task.FromResult(new HealthCheckResult(context.Registration.FailureStatus, "Configured drive " + driveName + " is not present on system"));
+						return Task.FromResult(new HealthCheckResult(context.Registration.FailureStatus, 
+							"Configured drive " + driveName + " is not present on system"));
 					if (actualFreeMegabytes4 < num)
 						return Task.FromResult(new HealthCheckResult(context.Registration.FailureStatus,
-							$"Minimum configured megabytes for disk {driveName} is {num} but actual free space are {actualFreeMegabytes4} megabytes"));
+							$"Minimum configured megabytes for disk {driveName} is {num} " +
+							$"but actual free space are {actualFreeMegabytes4} megabytes"));
 				}
 				return Task.FromResult(HealthCheckResult.Healthy());
 			}

--- a/starsky/starsky/clientapp/src/components/atoms/more-menu/more-menu.tsx
+++ b/starsky/starsky/clientapp/src/components/atoms/more-menu/more-menu.tsx
@@ -4,17 +4,17 @@ import { Language } from '../../../shared/language';
 
 type MoreMenuPropTypes = {
   children?: React.ReactNode;
+  defaultEnableMenu?: boolean
 }
 
 export const MoreMenuEventCloseConst = "CLOSE_MORE_MENU";
 
-const MoreMenu: React.FunctionComponent<MoreMenuPropTypes> = ({ children }) => {
+const MoreMenu: React.FunctionComponent<MoreMenuPropTypes> = ({ children, defaultEnableMenu }) => {
 
   const settings = useGlobalSettings();
   const language = new Language(settings.language);
   const MessageMore = language.text("Meer", "More");
-
-  const [enabledMenu, setEnabledMenu] = React.useState(false);
+  const [enabledMenu, setEnabledMenu] = React.useState(defaultEnableMenu);
 
   function toggleMoreMenu() {
     if (!children) return;

--- a/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-label-edit-add-overwrite.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-label-edit-add-overwrite.spec.tsx
@@ -148,7 +148,7 @@ describe("ArchiveSidebarLabelEditAddOverwrite", () => {
       });
 
       expect(spy).toBeCalled();
-      expect(spy).toBeCalledWith(new UrlQuery().prefix + "/api/update", "append=true&collections=true&tags=a&f=%2F%2Ftest.jpg");
+      expect(spy).toBeCalledWith(new UrlQuery().prefix + "/api/update", "append=true&collections=true&tags=a&f=%2Ftest.jpg");
 
       expect(dispatchedValues).toStrictEqual([{
         type: 'update',
@@ -249,7 +249,7 @@ describe("ArchiveSidebarLabelEditAddOverwrite", () => {
       });
 
       expect(spy).toBeCalled();
-      expect(spy).toBeCalledWith(new UrlQuery().prefix + "/api/update", "append=true&collections=true&tags=a&f=%2F%2Ftest.jpg%3B%2F%2Ftest1.jpg");
+      expect(spy).toBeCalledWith(new UrlQuery().prefix + "/api/update", "append=true&collections=true&tags=a&f=%2Ftest.jpg%3B%2Ftest1.jpg");
 
       expect(dispatchedValues).toStrictEqual([{
         type: 'update',

--- a/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-label-edit-add-overwrite.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-label-edit-add-overwrite.tsx
@@ -28,6 +28,11 @@ const ArchiveSidebarLabelEditAddOverwrite: React.FunctionComponent = () => {
     "Alleen de bestanden met schrijfrechten zijn geupdate.",
     "One or more files are read only. " +
     "Only the files with write permissions have been updated.");
+  const MessageErrorNotFoundSourceMissing = new Language(settings.language).text(
+    "Eén of meerdere bestanden zijn al verdwenen. " +
+    "Alleen de bestanden die wel aanwezig zijn geupdate. Draai een handmatige sync",
+    "One or more files are already gone. " +
+    "Only the files that are present are updated. Run a manual sync");
 
   var history = useLocation();
   let { state, dispatch } = React.useContext(ArchiveContext);
@@ -90,8 +95,10 @@ const ArchiveSidebarLabelEditAddOverwrite: React.FunctionComponent = () => {
       var result = new CastToInterface().InfoFileIndexArray(anyData.data);
       result.forEach(element => {
         if (element.status === IExifStatus.ReadOnly) setIsError(MessageErrorReadOnly);
-        if (element.status !== IExifStatus.Ok) return;
-        dispatch({ type: 'update', ...element, select: [element.fileName] });
+        if (element.status === IExifStatus.NotFoundSourceMissing) setIsError(MessageErrorNotFoundSourceMissing);
+        if (element.status === IExifStatus.Ok || element.status === IExifStatus.Deleted) {
+          dispatch({ type: 'update', ...element, select: [element.fileName] });
+        }
       });
 
       // loading + update button

--- a/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-label-edit-add-overwrite.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-label-edit-add-overwrite.tsx
@@ -10,6 +10,7 @@ import { CastToInterface } from '../../../shared/cast-to-interface';
 import FetchPost from '../../../shared/fetch-post';
 import { Keyboard } from '../../../shared/keyboard';
 import { Language } from '../../../shared/language';
+import { ClearSearchCache } from '../../../shared/search/clear-search-cache';
 import { SidebarUpdate } from '../../../shared/sidebar-update';
 import { URLPath } from '../../../shared/url-path';
 import { UrlQuery } from '../../../shared/url-query';
@@ -104,11 +105,7 @@ const ArchiveSidebarLabelEditAddOverwrite: React.FunctionComponent = () => {
       // loading + update button
       setIsLoading(false);
       setInputEnabled(true);
-
-      // clear search cache * when you refresh the search page this is needed to display the correct labels
-      var searchTag = new URLPath().StringToIUrl(history.location.search).t;
-      if (!searchTag) return;
-      FetchPost(new UrlQuery().UrlSearchRemoveCacheApi(), `t=${searchTag}`);
+      ClearSearchCache(history.location.search);
 
     }).catch(() => {
       // loading + update button

--- a/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-label-edit-search-replace.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-label-edit-search-replace.spec.tsx
@@ -112,7 +112,7 @@ describe("ArchiveSidebarLabelEditSearchReplace", () => {
 
 
       expect(spy).toBeCalled();
-      expect(spy).toBeCalledWith(new UrlQuery().prefix + "/api/replace", "f=%2F%2Ftest.jpg&collections=true&fieldName=tags&search=a&replace=");
+      expect(spy).toBeCalledWith(new UrlQuery().prefix + "/api/replace", "f=%2Ftest.jpg&collections=true&fieldName=tags&search=a&replace=");
     });
 
     it('click update | read only', async () => {

--- a/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-label-edit-search-replace.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-label-edit-search-replace.tsx
@@ -26,6 +26,11 @@ const ArchiveSidebarLabelEditSearchReplace: React.FunctionComponent = () => {
     "Alleen de bestanden met schrijfrechten zijn geupdate.",
     "One or more files are read only. " +
     "Only the files with write permissions have been updated.");
+  const MessageErrorNotFoundSourceMissing = new Language(settings.language).text(
+    "Eén of meerdere bestanden zijn al verdwenen. " +
+    "Alleen de bestanden die wel aanwezig zijn geupdate. Draai een handmatige sync",
+    "One or more files are already gone. " +
+    "Only the files that are present are updated. Run a manual sync");
 
   var history = useLocation();
   let { state, dispatch } = React.useContext(ArchiveContext);
@@ -101,9 +106,12 @@ const ArchiveSidebarLabelEditSearchReplace: React.FunctionComponent = () => {
           var result = new CastToInterface().InfoFileIndexArray(anyData.data);
           result.forEach(element => {
             if (element.status === IExifStatus.ReadOnly) setIsError(MessageErrorReadOnly);
-            if (element.status !== IExifStatus.Ok) return;
-            dispatch({ type: 'update', ...element, select: [element.fileName] });
+            if (element.status === IExifStatus.NotFoundSourceMissing) setIsError(MessageErrorNotFoundSourceMissing);
+            if (element.status === IExifStatus.Ok || element.status === IExifStatus.Deleted) {
+              dispatch({ type: 'update', ...element, select: [element.fileName] });
+            }
           });
+
 
           // loading + update button
           setIsLoading(false);

--- a/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-label-edit-search-replace.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/archive-sidebar/archive-sidebar-label-edit-search-replace.tsx
@@ -8,6 +8,7 @@ import { ISidebarUpdate } from '../../../interfaces/ISidebarUpdate';
 import { CastToInterface } from '../../../shared/cast-to-interface';
 import FetchPost from '../../../shared/fetch-post';
 import { Language } from '../../../shared/language';
+import { ClearSearchCache } from '../../../shared/search/clear-search-cache';
 import { SidebarUpdate } from '../../../shared/sidebar-update';
 import { URLPath } from '../../../shared/url-path';
 import { UrlQuery } from '../../../shared/url-query';
@@ -117,11 +118,7 @@ const ArchiveSidebarLabelEditSearchReplace: React.FunctionComponent = () => {
           setIsLoading(false);
           setInputEnabled(true);
 
-          // clear search cache * when you refresh the search page this is needed to display the correct labels
-          var searchTag = new URLPath().StringToIUrl(history.location.search).t;
-          if (!searchTag) return;
-          FetchPost(new UrlQuery().UrlSearchRemoveCacheApi(), `t=${searchTag}`);
-
+          ClearSearchCache(history.location.search);
         }).catch(() => {
           // loading + update button
           setIsLoading(false);

--- a/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.spec.tsx
@@ -1,0 +1,14 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { newIArchive } from '../../../interfaces/IArchive';
+import { IArchiveProps } from '../../../interfaces/IArchiveProps';
+import { newIFileIndexItemArray } from '../../../interfaces/IFileIndexItem';
+import MenuOptionMoveToTrash from './menu-option-move-to-trash';
+
+describe("MenuOptionMoveToTrash", () => {
+  it("renders", () => {
+    var test = { ...newIArchive(), fileIndexItems: newIFileIndexItemArray() } as IArchiveProps
+    shallow(<MenuOptionMoveToTrash setSelect={jest.fn()} select={["test.jpg"]} isReadOnly={true} state={test} dispatch={jest.fn()} />)
+  });
+
+});

--- a/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.stories.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.stories.tsx
@@ -1,0 +1,22 @@
+import { storiesOf } from "@storybook/react";
+import React from "react";
+import { newIArchive } from '../../../interfaces/IArchive';
+import { IArchiveProps } from '../../../interfaces/IArchiveProps';
+import { IFileIndexItem } from '../../../interfaces/IFileIndexItem';
+import MoreMenu from '../../atoms/more-menu/more-menu';
+import MenuOptionMoveToTrash from './menu-option-move-to-trash';
+
+storiesOf("components/molecules/menu-option-move-to-trash", module)
+  .add("default", () => {
+    var test = {
+      ...newIArchive(), fileIndexItems: [{
+        parentDirectory: '/',
+        fileName: 'test.jpg'
+      } as IFileIndexItem]
+    } as IArchiveProps;
+    return <>
+      <MoreMenu defaultEnableMenu={true}>
+        <MenuOptionMoveToTrash setSelect={() => { }} select={["test.jpg"]} isReadOnly={false} state={test} dispatch={() => { }} />
+      </MoreMenu>
+    </>
+  })

--- a/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.tsx
@@ -1,0 +1,64 @@
+import React, { memo } from 'react';
+import { ArchiveAction } from '../../../contexts/archive-context';
+import useGlobalSettings from '../../../hooks/use-global-settings';
+import useLocation from '../../../hooks/use-location';
+import { IArchiveProps } from '../../../interfaces/IArchiveProps';
+import FetchPost from '../../../shared/fetch-post';
+import { Language } from '../../../shared/language';
+import { ClearSearchCache } from '../../../shared/search/clear-search-cache';
+import { Select } from '../../../shared/select';
+import { URLPath } from '../../../shared/url-path';
+import { UrlQuery } from '../../../shared/url-query';
+
+interface IMenuOptionMoveToTrashProps {
+  select: string[],
+  setSelect: React.Dispatch<React.SetStateAction<string[] | undefined>>
+  isReadOnly: boolean,
+  state: IArchiveProps
+  dispatch: React.Dispatch<ArchiveAction>
+}
+
+const MenuOptionMoveToTrash: React.FunctionComponent<IMenuOptionMoveToTrashProps> = memo(({ state, dispatch, select, setSelect, isReadOnly }) => {
+  const settings = useGlobalSettings();
+  const language = new Language(settings.language);
+
+  var undoSelection = () => new Select(select, setSelect, state, history).undoSelection();
+
+  const MessageMoveToTrash = language.text("Verplaats naar prullenmand", "Move to Trash");
+
+  var history = useLocation();
+
+  async function moveToTrashSelection() {
+    if (!select || isReadOnly) return;
+
+    var toUndoTrashList = new URLPath().MergeSelectFileIndexItem(select, state.fileIndexItems);
+    if (!toUndoTrashList) return;
+    var selectParams = new URLPath().ArrayToCommaSeperatedStringOneParent(toUndoTrashList, "");
+    if (selectParams.length === 0) return;
+
+    var bodyParams = new URLSearchParams();
+
+    bodyParams.append("f", selectParams);
+    bodyParams.set("Tags", "!delete!");
+    bodyParams.set("append", "true");
+    bodyParams.set("Colorclass", "8");
+    bodyParams.set("collections", (new URLPath().StringToIUrl(history.location.search).collections !== false).toString());
+
+    var resultDo = await FetchPost(new UrlQuery().UrlUpdateApi(), bodyParams.toString());
+    if (resultDo.statusCode !== 404 && resultDo.statusCode !== 200) {
+      return;
+    }
+    undoSelection();
+    // dispatch({ 'type': 'remove', toRemoveFileList: toUndoTrashList });
+    ClearSearchCache(history.location.search);
+  }
+
+  return (<>
+    {select.length >= 1 ? <li data-test="trash" className={!isReadOnly ? "menu-option" : "menu-option disabled"}
+      onClick={() => moveToTrashSelection()}>{MessageMoveToTrash}</li> : null}
+  </>
+  );
+
+});
+
+export default MenuOptionMoveToTrash;

--- a/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.tsx
@@ -38,7 +38,7 @@ const DetailViewSidebar: React.FunctionComponent<IDetailViewSidebarProps> = memo
   const MessageDateLessThan1Minute = language.text("minder dan één minuut", "less than one minute");
   const MessageDateMinutes = language.text("minuten", "minutes");
   const MessageDateHour = language.text("uur", "hour");
-  const MessageNounUnknown = language.text("Onbekende", "Unknown");
+  const MessageNounNameless = language.text("Naamloze", "Unnamed");
   const MessageLocation = language.text("locatie", "location");
   const MessageReadOnlyFile = language.text("Alleen lezen bestand", "Read only file");
   const MessageNotFoundSourceMissing = language.text("Mist in de index", "Misses in the index");
@@ -324,7 +324,7 @@ const DetailViewSidebar: React.FunctionComponent<IDetailViewSidebarProps> = memo
               <b>{fileIndexItem.locationCity}</b>
               <p>{fileIndexItem.locationCountry}</p>
             </> : <>
-              <b>{MessageNounUnknown}</b>
+              <b>{MessageNounNameless}</b>
               <p>{MessageLocation}</p>
             </>}
         </a> : ""}

--- a/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/detail-view-sidebar/detail-view-sidebar.tsx
@@ -14,6 +14,7 @@ import { isValidDate, parseDate, parseRelativeDate, parseTime } from '../../../s
 import FetchPost from '../../../shared/fetch-post';
 import { Keyboard } from '../../../shared/keyboard';
 import { Language } from '../../../shared/language';
+import { ClearSearchCache } from '../../../shared/search/clear-search-cache';
 import { URLPath } from '../../../shared/url-path';
 import { UrlQuery } from '../../../shared/url-query';
 import FormControl from '../../atoms/form-control/form-control';
@@ -143,11 +144,7 @@ const DetailViewSidebar: React.FunctionComponent<IDetailViewSidebarProps> = memo
 
       setFileIndexItem(currentItem);
       dispatch({ 'type': 'update', ...currentItem });
-
-      // clear search cache
-      var searchTag = new URLPath().StringToIUrl(history.location.search).t;
-      if (!searchTag) return;
-      FetchPost(new UrlQuery().UrlSearchRemoveCacheApi(), `t=${searchTag}`);
+      ClearSearchCache(history.location.search);
     });
   }
 
@@ -248,7 +245,8 @@ const DetailViewSidebar: React.FunctionComponent<IDetailViewSidebarProps> = memo
         collections={new URLPath().StringToIUrl(history.location.search).collections !== false}
         onToggle={(result) => {
           setFileIndexItem({ ...fileIndexItem, lastEdited: new Date().toString(), colorClass: result });
-          dispatch({ 'type': 'update', lastEdited: new Date().toString(), colorclass: result })
+          dispatch({ 'type': 'update', lastEdited: new Date().toString(), colorclass: result });
+          ClearSearchCache(history.location.search);
         }}
         filePath={fileIndexItem.filePath}
         currentColorClass={fileIndexItem.colorClass}

--- a/starsky/starsky/clientapp/src/components/organisms/menu-detail-view/menu-detail-view.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/menu-detail-view/menu-detail-view.tsx
@@ -16,6 +16,7 @@ import FetchPost from '../../../shared/fetch-post';
 import { FileListCache } from '../../../shared/filelist-cache';
 import { Keyboard } from '../../../shared/keyboard';
 import { Language } from '../../../shared/language';
+import { ClearSearchCache } from '../../../shared/search/clear-search-cache';
 import { URLPath } from '../../../shared/url-path';
 import { UrlQuery } from '../../../shared/url-query';
 import MoreMenu from '../../atoms/more-menu/more-menu';
@@ -151,18 +152,11 @@ const MenuDetailView: React.FunctionComponent = () => {
       setIsLoading(false);
     }
 
-    clearSearchCache();
+    ClearSearchCache(history.location.search);
 
     // Client side Caching: the order of files in a normal folder has changed
     // Entire cache becouse the relativeObjects objects can reference to this page
     new FileListCache().CacheCleanEverything();
-  }
-
-  function clearSearchCache() {
-    // clear search cache * when you refresh the search page this is needed to display the correct labels
-    var searchTag = new URLPath().StringToIUrl(history.location.search).t;
-    if (!searchTag) return;
-    FetchPost(new UrlQuery().UrlSearchRemoveCacheApi(), `t=${searchTag}`);
   }
 
   /**

--- a/starsky/starsky/clientapp/src/components/organisms/menu-search/menu-search.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/menu-search/menu-search.tsx
@@ -9,12 +9,13 @@ import { URLPath } from '../../../shared/url-path';
 import HamburgerMenuToggle from '../../atoms/hamburger-menu-toggle/hamburger-menu-toggle';
 import MoreMenu from '../../atoms/more-menu/more-menu';
 import MenuSearchBar from '../../molecules/menu-inline-search/menu-inline-search';
+import MenuOptionMoveToTrash from '../../molecules/menu-option-move-to-trash/menu-option-move-to-trash';
 import ModalDownload from '../modal-download/modal-download';
 import NavContainer from '../nav-container/nav-container';
 
 export const MenuSearch: React.FunctionComponent<any> = (_) => {
 
-  let { state } = React.useContext(ArchiveContext);
+  let { state, dispatch } = React.useContext(ArchiveContext);
   state = defaultStateFallback(state);
 
   const [hamburgerMenu, setHamburgerMenu] = React.useState(false);
@@ -94,6 +95,7 @@ export const MenuSearch: React.FunctionComponent<any> = (_) => {
                 {MessageUndoSelection}</li> : null}
               {select.length !== state.fileIndexItems.length ? <li className="menu-option" onClick={() => allSelection()}>
                 {MessageSelectAll}</li> : null}
+              <MenuOptionMoveToTrash state={state} dispatch={dispatch} select={select} setSelect={setSelect} isReadOnly={false} />
               <li data-test="export" className="menu-option" onClick={() => setModalExportOpen(!isModalExportOpen)}>Download</li>
             </MoreMenu> : null}
 

--- a/starsky/starsky/clientapp/src/components/organisms/menu-trash/menu-trash.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/menu-trash/menu-trash.tsx
@@ -4,12 +4,14 @@ import useGlobalSettings from '../../../hooks/use-global-settings';
 import useLocation from '../../../hooks/use-location';
 import FetchPost from '../../../shared/fetch-post';
 import { Language } from '../../../shared/language';
+import { ClearSearchCache } from '../../../shared/search/clear-search-cache';
 import { Select } from '../../../shared/select';
 import { URLPath } from '../../../shared/url-path';
 import { UrlQuery } from '../../../shared/url-query';
 import HamburgerMenuToggle from '../../atoms/hamburger-menu-toggle/hamburger-menu-toggle';
 import Modal from '../../atoms/modal/modal';
 import MoreMenu from '../../atoms/more-menu/more-menu';
+import Preloader from '../../atoms/preloader/preloader';
 import MenuSearchBar from '../../molecules/menu-inline-search/menu-inline-search';
 import NavContainer from '../nav-container/nav-container';
 
@@ -31,6 +33,7 @@ const MenuTrash: React.FunctionComponent<any> = memo((_) => {
   const MessageCancel = language.text("Annuleren", "Cancel");
 
   const [hamburgerMenu, setHamburgerMenu] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
 
   var history = useLocation();
 
@@ -49,6 +52,7 @@ const MenuTrash: React.FunctionComponent<any> = memo((_) => {
 
   function forceDelete() {
     if (!select) return;
+    setIsLoading(true);
 
     var toUndoTrashList = new URLPath().MergeSelectFileIndexItem(select, state.fileIndexItems);
     if (!toUndoTrashList) return;
@@ -62,11 +66,14 @@ const MenuTrash: React.FunctionComponent<any> = memo((_) => {
 
     FetchPost(new UrlQuery().UrlDeleteApi(), bodyParams.toString(), 'delete').then(() => {
       dispatch({ type: 'remove', toRemoveFileList: toUndoTrashList });
+      ClearSearchCache(history.location.search);
+      setIsLoading(false);
     });
   }
 
   function undoTrash() {
     if (!select) return;
+    setIsLoading(true);
 
     var toUndoTrashList = new URLPath().MergeSelectFileIndexItem(select, state.fileIndexItems);
     if (!toUndoTrashList) return;
@@ -83,6 +90,8 @@ const MenuTrash: React.FunctionComponent<any> = memo((_) => {
     // to replace
     FetchPost(new UrlQuery().UrlReplaceApi(), bodyParams.toString()).then(() => {
       dispatch({ type: 'remove', toRemoveFileList: toUndoTrashList });
+      ClearSearchCache(history.location.search);
+      setIsLoading(false);
     });
   }
 
@@ -90,6 +99,7 @@ const MenuTrash: React.FunctionComponent<any> = memo((_) => {
 
   return (
     <>
+      {isLoading ? <Preloader isOverlay={true} /> : null}
       {isModalDeleteOpen ? <Modal
         id="delete-modal"
         isOpen={isModalDeleteOpen}

--- a/starsky/starsky/clientapp/src/containers/search.tsx
+++ b/starsky/starsky/clientapp/src/containers/search.tsx
@@ -63,7 +63,8 @@ function Search(archive: IArchiveProps) {
             {MessageTryOtherQuery}
           </div>
         </div> : null}
-        <SearchPagination {...archive} />
+        {archive.lastPageNumber !== 0 ? <SearchPagination {...archive} /> : null}
+
       </div>
     </div>
   </>

--- a/starsky/starsky/clientapp/src/containers/search.tsx
+++ b/starsky/starsky/clientapp/src/containers/search.tsx
@@ -56,14 +56,14 @@ function Search(archive: IArchiveProps) {
           </> : null}
         </div>
         <SearchPagination {...archive} />
-        {archive.collectionsCount >= 1 ? <ItemListView {...archive} colorClassUsage={archive.colorClassUsage}>
-        </ItemListView> : null}
+        {archive.collectionsCount >= 1 ? <ItemListView
+          {...archive} colorClassUsage={archive.colorClassUsage}> </ItemListView> : null}
         {archive.collectionsCount === 0 ? <div className="folder">
           <div className="warning-box">
             {MessageTryOtherQuery}
           </div>
         </div> : null}
-        {archive.fileIndexItems.length >= 20 ? <SearchPagination {...archive} /> : null}
+        <SearchPagination {...archive} />
       </div>
     </div>
   </>

--- a/starsky/starsky/clientapp/src/contexts/archive-context.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.tsx
@@ -13,11 +13,11 @@ const ArchiveContext = React.createContext<IArchiveContext>({} as IArchiveContex
 
 export type IArchiveContext = {
   state: State,
-  dispatch: React.Dispatch<Action>,
+  dispatch: React.Dispatch<ArchiveAction>,
 }
 
 type ReactNodeProps = { children: React.ReactNode }
-type Action = {
+export type ArchiveAction = {
   type: 'remove',
   toRemoveFileList: string[]
 } |
@@ -59,7 +59,7 @@ const initialState: State = {
   dateCache: Date.now()
 };
 
-export function archiveReducer(state: State, action: Action): State {
+export function archiveReducer(state: State, action: ArchiveAction): State {
   switch (action.type) {
     case "remove":
       // files == subpath style not only the name (/dir/file.jpg)

--- a/starsky/starsky/clientapp/src/hooks/use-searchlist.ts
+++ b/starsky/starsky/clientapp/src/hooks/use-searchlist.ts
@@ -54,7 +54,7 @@ const useSearchList = (query: string | undefined, pageNumber = 0, resetPageTypeB
       var archiveMedia = new CastToInterface().MediaArchive(responseObject);
       setPageType(archiveMedia.data.pageType);
 
-      if (archiveMedia.data.pageType !== PageType.Search) return;
+      if (archiveMedia.data.pageType !== PageType.Search && archiveMedia.data.pageType !== PageType.Trash) return;
 
       // We don't know those values in the search context
       archiveMedia.data.colorClassUsage = [];

--- a/starsky/starsky/clientapp/src/pages/search-page.tsx
+++ b/starsky/starsky/clientapp/src/pages/search-page.tsx
@@ -15,8 +15,8 @@ const SearchPage: FunctionComponent<RouteComponentProps<ISearchPageProps>> = (pr
   var urlObject = new URLPath().StringToIUrl(history.location.search);
   var searchList = useSearchList(urlObject.t, urlObject.p, true);
 
-  if (!searchList) return (<>Something went wrong</>)
-  if (!searchList.archive) return (<>Something went wrong</>)
+  if (!searchList) return (<>Something went wrong</>);
+  if (!searchList.archive) return (<>Something went wrong</>);
 
   return (<>
     {searchList.pageType === PageType.Loading ? <Preloader isOverlay={true} isDetailMenu={false}></Preloader> : null}

--- a/starsky/starsky/clientapp/src/shared/search/clear-search-cache.ts
+++ b/starsky/starsky/clientapp/src/shared/search/clear-search-cache.ts
@@ -1,0 +1,14 @@
+import FetchPost from '../fetch-post';
+import { URLPath } from '../url-path';
+import { UrlQuery } from '../url-query';
+
+/**
+ * clear search cache * when you refresh the search page this is needed to display the correct labels
+ * @param historyLocationSearch 
+ */
+export function ClearSearchCache(historyLocationSearch: string) {
+  // clear search cache * when you refresh the search page this is needed to display the correct labels
+  var searchTag = new URLPath().StringToIUrl(historyLocationSearch).t;
+  if (!searchTag) return;
+  FetchPost(new UrlQuery().UrlSearchRemoveCacheApi(), `t=${searchTag}`);
+}

--- a/starsky/starsky/clientapp/src/shared/url-path.ts
+++ b/starsky/starsky/clientapp/src/shared/url-path.ts
@@ -317,11 +317,16 @@ export class URLPath {
     var selectParams = "";
     for (let index = 0; index < select.length; index++) {
       const element = select[index];
-      selectParams += parent + "/" + element;
+
+      // no double slash in front of path
+      var slash = !parent && element.startsWith("/") ? "" : "/";
+      selectParams += parent + slash + element;
+
       if (index !== select.length - 1) {
         selectParams += ";";
       }
     }
+    console.log(selectParams);
     return selectParams;
   }
 

--- a/starsky/starsky/clientapp/src/shared/url-query.ts
+++ b/starsky/starsky/clientapp/src/shared/url-query.ts
@@ -46,7 +46,7 @@ export class UrlQuery {
   }
 
   public UrlTrashPage(): string {
-    return document.location.pathname.indexOf(this.prefix) === -1 ? `/trash` : `${this.prefix}/trash`;
+    return document.location.pathname.indexOf(this.prefix) === -1 ? `/trash?t=!delete!` : `${this.prefix}/trash?t=!delete!`;
   }
 
   public UrlImportPage(): string {

--- a/starsky/starsky/starsky.csproj
+++ b/starsky/starsky/starsky.csproj
@@ -10,6 +10,7 @@
     <ProjectGuid>{894dce96-b51a-4ea2-80bf-e330bf1e8198}</ProjectGuid>
     <DefineConstants>SYSTEM_TEXT_ENABLED</DefineConstants>
     <DebugType>Full</DebugType>
+    <!-- <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked> -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <WarningLevel>0</WarningLevel>

--- a/starsky/starskycore/Services/SearchService.cs
+++ b/starsky/starskycore/Services/SearchService.cs
@@ -47,6 +47,8 @@ namespace starskycore.Services
 		    {
 			    throw new ArgumentException("Search Input Query is longer then 500 chars");
 		    }
+		    
+		    if ( query == "!delete!" ) enableCache = false;
 
             if(!enableCache || 
                _cache == null || _appSettings?.AddMemoryCache == false) 
@@ -396,11 +398,12 @@ namespace starskycore.Services
 	    /// <summary>
 	    /// Allow -inurl shortcut
 	    /// </summary>
-	    /// <param name="query"></param>
-	    /// <returns></returns>
+	    /// <param name="query">search Query</param>
+	    /// <returns>replaced Url</returns>
         public string QueryShortcuts(string query)
         {
-            query = query.Replace("-inurl", "-FilePath");
+	        // should be ignoring case
+            query = Regex.Replace(query, "-inurl", "-FilePath", RegexOptions.IgnoreCase);
             return query;
         }
 

--- a/starsky/starskytest/FakeMocks/FakeIQuery.cs
+++ b/starsky/starskytest/FakeMocks/FakeIQuery.cs
@@ -78,7 +78,7 @@ namespace starskytest.FakeMocks
 			return updateStatusContent;
 		}
 
-		public void RemoveCacheParentItem(string directoryName)
+		public bool RemoveCacheParentItem(string directoryName)
 		{
 			throw new System.NotImplementedException();
 		}


### PR DESCRIPTION
# PR Details 

RetrySaveChanges was failing ++ add default option for more menu ++ add ClearCache to more places ++ move MenuOptionMoveToTrash to seperate component ++ add loading for trash page ++ add click back to trash ++ fix issue where searching for !delete! didn't work ++ show search delete cache result ++ fix issue where -inURL is case sensitive 

## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (framework not included) 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
