### PR TITLE
Feature/202010 shift selection helper

### DIFF
--- a/history.md
+++ b/history.md
@@ -46,6 +46,8 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Fixed) _Front-end_ Add loading delete and undo delete for trash page 
 - [x]   (Changed) _Front-end_ Upload multiple files after each other instead of in once
 - [x]   (Fixed) _Front-end_ Show error status when upload fails instead of loading
+- [x]   (Added) _Front-end_ Archive/Search/Trash - When in select mode you can add multiple files 
+                            to the selection by pressing the shift key and click
 
 # version 0.3.2 - 2020-09-19
 - [x]   (Fixed) _Front-end_ DetailView - DateTime push in Detailview has no influence on colorclass anymore
@@ -63,7 +65,8 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Fixed) _Front-end_ Form Control allow command a or ctrl a when a field is full to select the entire text
 - [x]   (Security) _Back-end_  Upgrade .NET Core (TargetFramework) to 3.1.8 (using SDK 3.1.402)
 - [x]   (Added) _CLI_ Add account creation by StarskyAdminCli
-- [x]   (Added) _AppSettings.UseHttpsRedirection_ - Redirect users to https page. You should enable before going to production. Always disabled in debug/develop mode
+- [x]   (Added) _AppSettings.UseHttpsRedirection_ - Redirect users to https page. 
+                                            You should enable before going to production. Always disabled in debug/develop mode
 - [x]   (Added) _CLI_ Show DateTime when the Assemblies are build with the flags: `-h -v`
 
 # version 0.3.1 - 2020-09-08
@@ -97,7 +100,8 @@ _Note: When you upgrade from 0.2.7 please make sure you have applied the configu
 - [x]   (Added) _Front-end_  Gpx view, go to current location (no marker, only change view)
 - [x]   (Security) _Frond-end_  Upgrade ClientApp CRA _(Create React App 3.4.3 2020-08-12)_
 - [x]   (Fixed) _Front-end_ Add Preloader icon when pressing ColorClassSelect
-- [x]   (Fixed) _Front-end_ For Archive and Search: When in select mode and navigate next to the select mode is still on but there are no items selected
+- [x]   (Fixed) _Front-end_ For Archive and Search: When in select mode and navigate next to 
+                            the select mode is still on but there are no items selected
 
 # version 0.3.0-beta.1 - 2020-08-16
 - [x]   __(Breaking change)__ _Back-end_ Manifest (_settings.json) for exporting
@@ -189,7 +193,8 @@ _Note: When you upgrade from 0.2.7 please make sure you have applied the configu
 - [x]   (Fixed)  _Front-end_ use appendChild instead of append in portal for older browsers
 - [x]   (Fixed)  _Front-end_ order when files are added does now match the backend (archive-context)
 - [x]   (Removed) _Back-end_ Import to filter on files older than 2 years
-- [x]   (Fixed)  _Back-end_  Import UnitTests __Can't build after 2020-04-22, Import UnitTests have a date bug. For all versions older than 0.2.2__
+- [x]   (Fixed)  _Back-end_  Import UnitTests __Can't build after 2020-04-22, Import UnitTests have a date bug.__ 
+                             __For all versions older than 0.2.2__
 - [x]   (feature) _Back-end_ Import to async function refactor
 - [x]   (Fixed)  _Back-end_ Fixes for bugs introduced after refactoring
 - [x]   (Fixed)  _Back-end_ Bugfixes for starskyImporter
@@ -240,7 +245,8 @@ _Should build before 2020-04-22, Import UnitTests have a date bug. For all versi
 - [x]	(feature) _Back-end_ Injection framework implemented
 - [x] 	(rename) _Back-end_ Feature renaming and docs updates
 - [x] 	(feature) _Back-end support for RAW that is not Sony for example Nikon `.NEF`
-- [x]   (feature) tiff, `arw`:sony, `dng`:adobe, `nef`:nikon, `raf`:fuji, `cr2`:canon, `orf`:olympus, `rw2`:panasonic, `pef`:pentax,
+- [x]   (feature) tiff, `arw`:sony, `dng`:adobe, `nef`:nikon, `raf`:fuji, `cr2`:canon, 
+                        `orf`:olympus, `rw2`:panasonic, `pef`:pentax,
 - [x]   (bugfix) _Back-end_ allow underscore import/upload (api name changed in later version)
 - [x]   (bugfix) _Front-end_ Download selection thumbnail right extension suggestion
 - [x]   (version) _Back-end_ __breaking change__ rename of api `/api/import/history`
@@ -272,7 +278,8 @@ _Should build before 2020-04-22, Import UnitTests have a date bug. For all versi
 
 # version 0.1.16 - 2020-02-23
 - [x]  (bugfix) _Back-end_ `/api/import/fromUrl` Path Traversal Injection fix
-- [x]  (feature) _Back-end_ Feature toggle to change from `Newtonsoft.Json` to `System.Text.Json` _using Newtonsoft for this version_
+- [x]  (feature) _Back-end_ Feature toggle to change from `Newtonsoft.Json` to `System.Text.Json` 
+                            _using Newtonsoft for this version_
 - [x]  (bugfix) _Frond-end_ Trash display content after deleted (changes in wrapper)
 - [x]  (rename) _Back-end_ `/api/import/allowed` to `/api/allowed-types/mimetype/sync`
 - [x]  (upgrade) _Frond-end_  Upgrade ClientApp CRA _(Create React App 3.3.1, 2020-01-31)_
@@ -302,7 +309,8 @@ _Should build before 2020-04-22, Import UnitTests have a date bug. For all versi
 # version 0.1.14 - 2020-02-04
 - [x]   (bugfix) _back-end_ Security fixes in controllers
 - [x]   (bugfix) _back-end + front-end_ name: colorClassActiveList replace everywhere
-- [x]   (version) _Back-end_ update to .NET .Core SDK 3.1.101 and version 3.0.2 (TargetFramework). Run `./build.sh` before you start developing
+- [x]   (version) _Back-end_ update to .NET .Core SDK 3.1.101 and version 3.0.2 (TargetFramework). 
+                            Run `./build.sh` before you start developing
 - [x]   (bugfix) _Front-end_ preloader when uploading
 - [x]   (bugfix) _Front-end_ translations in item-list-view, item-text-list-view,
 - [x]   (bugfix)  _Front-end_ translations in containers/search, containers/trash, search, trash and trash-page
@@ -330,7 +338,8 @@ _Should build before 2020-04-22, Import UnitTests have a date bug. For all versi
 - [x]   (bugfix) _API_ fix various issues in `/api/rename`
 - [x]   (remove) _General_ starskyApp content
 - [x]   (docs) _General_ add html generation to build process
-- [x]   (remove) _API_ only the retryThumbnail is removed `api/thumbnail?retryThumbnail=true`  (remove thumbnail if corrupt) due public facing
+- [x]   (remove) _API_ only the retryThumbnail is removed `api/thumbnail?retryThumbnail=true`  
+                        (remove thumbnail if corrupt) due public facing
 - [x]   (remove) _Front-end_ search replace is no longer a beta feature, so no feature toggle
 - [x]   (bugfix) _Front-end_ archive updating multiple values didn't provide the right results
 - [x]   (bugfix) _Front-end_ when pressing multiple colorclass items with the value 0 (colorless/no-color) these are updated
@@ -379,7 +388,8 @@ _Upgrade to .NET Core 3.0 (TargetFramework) & EF Core 3.1-preview3_
 - [x] Indexes are working now for MySQL at the first time run
 - [x] Upgrade to .NET Core & EF Core 3.1-preview3 (EF Core 3.0 is missing PredicateBuilder support)
 - [x] (bugfix) 23:00 o'clock/first of month date.spec unittest
-- []  (Add warning) (bug) for iOS Safari only when using .local domains login fails (work around use ip-addresses) __bug is not fixed__
+- []  (Add warning) (bug) for iOS Safari only when using .local domains login fails 
+                       (work around use ip-addresses) (update to iOS13)
 - [x] Update build pipeline to support multiple runtimes in 1 run
 - [x] Upgrade from Swagger 4.0.1 to Swagger 5 (has breaking changes)
 
@@ -411,7 +421,8 @@ _Works with  .NET Core SDK 3.0.100_
 - starsky-tools/thumbnail, added auto cleanup, allow ranges e.g. 1-20 ago
 - (V2 UI Archive/Trash) add Select all/Undo selection to menu
 - (bugfix) search queries shorter than 2 digits are working
-- __(behind feature flag)__ Front-end for Replace API `archive-sidebar-label-edit` in folder view (add localStorage item with name `beta_replace`)
+- __(behind feature flag)__ Front-end for Replace API `archive-sidebar-label-edit` in folder view 
+                            (add localStorage item with name `beta_replace`)
 - (front-end) `archive-sidebar-label-edit` split in separate components
 - (front-end) show collections in DetailView
 - (front-end) reject delete button when a file is read-only mode

--- a/starsky/starsky/clientapp/src/components/molecules/item-list-view/item-list-view.stories.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/item-list-view/item-list-view.stories.tsx
@@ -1,22 +1,30 @@
+import { globalHistory } from '@reach/router';
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import { IFileIndexItem, newIFileIndexItemArray } from '../../../interfaces/IFileIndexItem';
 import ItemListView from './item-list-view';
 
+var exampleData8Selected = [
+  { fileName: 'test.jpg', filePath: '/test.jpg', lastEdited: '1' },
+  { fileName: 'test2.jpg', filePath: '/test2.jpg', lastEdited: '1' },
+  { fileName: 'test3.jpg', filePath: '/test3.jpg', lastEdited: '1' },
+  { fileName: 'test4.jpg', filePath: '/test4.jpg', lastEdited: '1' },
+  { fileName: 'test5.jpg', filePath: '/test5.jpg', lastEdited: '1' },
+  { fileName: 'test6.jpg', filePath: '/test6.jpg', lastEdited: '1' },
+  { fileName: 'test7.jpg', filePath: '/test7.jpg', lastEdited: '1' },
+  { fileName: 'test8.jpg', filePath: '/test8.jpg', lastEdited: '1' }
+] as IFileIndexItem[]
+
 storiesOf("components/molecules/item-list-view", module)
   .add("default", () => {
+    globalHistory.navigate("/");
     return <ItemListView fileIndexItems={newIFileIndexItemArray()} colorClassUsage={[]} />
   })
-  .add("8 items", () => {
-    var exampleData = [
-      { fileName: 'test.jpg', filePath: '/test.jpg' },
-      { fileName: 'test2.jpg', filePath: '/test2.jpg' },
-      { fileName: 'test3.jpg', filePath: '/test3.jpg' },
-      { fileName: 'test4.jpg', filePath: '/test4.jpg' },
-      { fileName: 'test2.jpg', filePath: '/test5.jpg' },
-      { fileName: 'test6.jpg', filePath: '/test6.jpg' },
-      { fileName: 'test7.jpg', filePath: '/test7.jpg' },
-      { fileName: 'test8.jpg', filePath: '/test8.jpg' }
-    ] as IFileIndexItem[]
-    return <ItemListView fileIndexItems={exampleData} colorClassUsage={[]} />
+  .add("8 items (selection disabled)", () => {
+    globalHistory.navigate("/");
+    return <ItemListView fileIndexItems={exampleData8Selected} colorClassUsage={[]} />
+  })
+  .add("8 items (selection enabled)", () => {
+    globalHistory.navigate("/?select=");
+    return <ItemListView fileIndexItems={exampleData8Selected} colorClassUsage={[]} />
   })

--- a/starsky/starsky/clientapp/src/components/molecules/item-list-view/item-list-view.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/item-list-view/item-list-view.tsx
@@ -5,7 +5,9 @@ import { PageType } from '../../../interfaces/IDetailView';
 import { IFileIndexItem } from '../../../interfaces/IFileIndexItem';
 import { INavigateState } from '../../../interfaces/INavigateState';
 import { Language } from '../../../shared/language';
+import { URLPath } from '../../../shared/url-path';
 import ListImageBox from '../list-image-box/list-image-box';
+import { ShiftSelectionHelper } from './shift-selection-helper';
 
 interface ItemListProps {
   fileIndexItems: Array<IFileIndexItem>,
@@ -65,8 +67,13 @@ const ItemListView: React.FunctionComponent<ItemListProps> = memo((props) => {
           </div> : null : null
       }
       {
-        items.map((item, index) => (
-          <ListImageBox item={item} key={item.fileName + item.lastEdited + item.colorClass}></ListImageBox>
+        items.map((item) => (
+          <ListImageBox item={item}
+            key={item.fileName + item.lastEdited + item.colorClass}
+            onSelectionCallback={(f) =>
+              ShiftSelectionHelper(history, new URLPath().getSelect(history.location.search), f, items)
+            }
+          />
         ))
       }
     </div>)

--- a/starsky/starsky/clientapp/src/components/molecules/item-list-view/shift-selection-helper.spec.ts
+++ b/starsky/starsky/clientapp/src/components/molecules/item-list-view/shift-selection-helper.spec.ts
@@ -4,7 +4,8 @@ import { ShiftSelectionHelper } from './shift-selection-helper';
 
 describe("ShiftSelectionHelper", () => {
 
-  it("renders (without state component)", () => {
-    ShiftSelectionHelper(globalHistory, [], "test", newIFileIndexItemArray());
+  it("filePath not found", () => {
+    var result = ShiftSelectionHelper(globalHistory, [], "test", newIFileIndexItemArray());
+    expect(result).toBeFalsy();
   });
 });

--- a/starsky/starsky/clientapp/src/components/molecules/item-list-view/shift-selection-helper.spec.ts
+++ b/starsky/starsky/clientapp/src/components/molecules/item-list-view/shift-selection-helper.spec.ts
@@ -1,11 +1,50 @@
 import { globalHistory } from '@reach/router';
-import { newIFileIndexItemArray } from '../../../interfaces/IFileIndexItem';
+import { newIFileIndexItem, newIFileIndexItemArray } from '../../../interfaces/IFileIndexItem';
 import { ShiftSelectionHelper } from './shift-selection-helper';
 
 describe("ShiftSelectionHelper", () => {
 
+  it("items undefined", () => {
+    var result = ShiftSelectionHelper(globalHistory, [], "test", undefined as any);
+    expect(result).toBeFalsy();
+  });
+
+  it("select undefined", () => {
+    var result = ShiftSelectionHelper(globalHistory, undefined as any, "test", newIFileIndexItemArray());
+    expect(result).toBeFalsy();
+  });
+
   it("filePath not found", () => {
     var result = ShiftSelectionHelper(globalHistory, [], "test", newIFileIndexItemArray());
     expect(result).toBeFalsy();
+  });
+
+  var exampleItems = [
+    { ...newIFileIndexItem(), fileName: 'test0', filePath: '/test0' },
+    { ...newIFileIndexItem(), fileName: 'test1', filePath: '/test1' },
+    { ...newIFileIndexItem(), fileName: 'test2', filePath: '/test2' },
+    { ...newIFileIndexItem(), fileName: 'test3', filePath: '/test3' },
+    { ...newIFileIndexItem(), fileName: 'test4', filePath: '/test4' }
+  ];
+
+  it("add item after and assume first is selected", () => {
+    globalHistory.navigate("/");
+    var result = ShiftSelectionHelper(globalHistory, [], "/test3", exampleItems);
+    expect(globalHistory.location.search).toBe('?select=test0,test3,test1,test2')
+    expect(result).toBeTruthy();
+  });
+
+  it("add item before", () => {
+    globalHistory.navigate("/");
+    var result = ShiftSelectionHelper(globalHistory, ["test4"], "/test2", exampleItems);
+    expect(globalHistory.location.search).toBe('?select=test4,test2,test3')
+    expect(result).toBeTruthy();
+  });
+
+  it("add same item", () => {
+    globalHistory.navigate("/");
+    var result = ShiftSelectionHelper(globalHistory, ["test4"], "/test4", exampleItems);
+    expect(globalHistory.location.search).toBe('?select=test4')
+    expect(result).toBeTruthy();
   });
 });

--- a/starsky/starsky/clientapp/src/components/molecules/item-list-view/shift-selection-helper.spec.ts
+++ b/starsky/starsky/clientapp/src/components/molecules/item-list-view/shift-selection-helper.spec.ts
@@ -1,0 +1,10 @@
+import { globalHistory } from '@reach/router';
+import { newIFileIndexItemArray } from '../../../interfaces/IFileIndexItem';
+import { ShiftSelectionHelper } from './shift-selection-helper';
+
+describe("ShiftSelectionHelper", () => {
+
+  it("renders (without state component)", () => {
+    ShiftSelectionHelper(globalHistory, [], "test", newIFileIndexItemArray());
+  });
+});

--- a/starsky/starsky/clientapp/src/components/molecules/item-list-view/shift-selection-helper.ts
+++ b/starsky/starsky/clientapp/src/components/molecules/item-list-view/shift-selection-helper.ts
@@ -1,0 +1,96 @@
+import { IUseLocation } from '../../../hooks/use-location';
+import { IFileIndexItem } from '../../../interfaces/IFileIndexItem';
+import { URLPath } from '../../../shared/url-path';
+
+/**
+ * Find the value that is the closest
+ * @see: https://stackoverflow.com/a/60029167
+ * @param _array 
+ * @param _number 
+ */
+function closest(_array: number[], _number: number): number {
+  const diffArr = _array.map(x => Math.abs(_number - x));
+  const minNumber = Math.min(...diffArr);
+  return diffArr.findIndex(x => x === minNumber);
+}
+
+/**
+ * Get the index value of items by the newest file that is selected
+ * @param filePath subPath
+ * @param items all items in the folder
+ */
+function getIndexOfCurrentAppendFilePath(filePath: string, items:
+  IFileIndexItem[]): number {
+  var filePathAppendIndex: number = -1;
+  for (let index = 0; index < items.length; index++) {
+    const element = items[index];
+    if (element.filePath === filePath) {
+      filePathAppendIndex = index;
+    }
+  }
+  return filePathAppendIndex;
+}
+
+/**
+ * Find the location where the selection is from (so the other location that user implicit means to select)
+ * @param filePathAppendIndex - Get the index value of items by the newest file that is selected
+ * @param select - current selection
+ * @param items - items all items in the folder
+ */
+function getNearbyStartIndex(filePathAppendIndex: number, select: string[],
+  items: IFileIndexItem[]): number {
+  var alreadySelectIndexes: number[] = [];
+  // the order of select is done by the user
+
+  for (let index = 0; index < items.length; index++) {
+    const element = items[index];
+    if (select.indexOf(element.fileName) !== -1) {
+      alreadySelectIndexes.push(index);
+    }
+  }
+  return alreadySelectIndexes[closest(alreadySelectIndexes, filePathAppendIndex)];
+}
+
+/**
+ * Loop from the lowest value to the highest to support adding bellow and above
+ * @param filePathAppendIndex - Get the index value of items by the newest file that is selected
+ * @param nearbyStartIndex - the location where the selection is from
+ * @param items  - items all items in the folder
+ */
+function toAddedLoopMinToMax(filePathAppendIndex: number,
+  nearbyStartIndex: number, items: IFileIndexItem[]): string[] {
+  var toBeAddedToSelect: string[] = [];
+
+  // loop from the lowest value to the highest
+  for (let index = Math.min(filePathAppendIndex, nearbyStartIndex);
+    index <= Math.max(filePathAppendIndex, nearbyStartIndex); index++) {
+    toBeAddedToSelect.push(items[index].fileName);
+  }
+  return toBeAddedToSelect;
+}
+
+/**
+ * Select multiple files by pressing shift and click the range
+ * @param history - react hook to navigate
+ * @param select - current selection
+ * @param filePath - latest click filePath
+ * @param items - list of items in current view
+ */
+export function ShiftSelectionHelper(history: IUseLocation, select: string[], filePath: string, items:
+  IFileIndexItem[]) {
+  if (!items || select === undefined) return;
+
+  // when nothing is selected assume the first
+  if (select.length === 0) select = [items[0].fileName];
+
+  var filePathAppendIndex = getIndexOfCurrentAppendFilePath(filePath, items)
+  var nearbyStartIndex = getNearbyStartIndex(filePathAppendIndex, select, items);
+  var toBeAddedToSelect = toAddedLoopMinToMax(filePathAppendIndex, nearbyStartIndex, items);
+
+  // remove duplicates
+  var newSelect = [...select, items[filePathAppendIndex].fileName, ...toBeAddedToSelect].filter(function (item, pos) {
+    return [...select, items[filePathAppendIndex].fileName, ...toBeAddedToSelect].indexOf(item) == pos;
+  });
+  var urlObject = new URLPath().updateSelection(history.location.search, newSelect);
+  history.navigate(new URLPath().IUrlToString(urlObject), { replace: true });
+}

--- a/starsky/starsky/clientapp/src/components/molecules/item-list-view/shift-selection-helper.ts
+++ b/starsky/starsky/clientapp/src/components/molecules/item-list-view/shift-selection-helper.ts
@@ -77,13 +77,14 @@ function toAddedLoopMinToMax(filePathAppendIndex: number,
  * @param items - list of items in current view
  */
 export function ShiftSelectionHelper(history: IUseLocation, select: string[], filePath: string, items:
-  IFileIndexItem[]) {
-  if (!items || select === undefined) return;
+  IFileIndexItem[]): boolean {
+  if (!items || select === undefined) return false;
 
   // when nothing is selected assume the first
-  if (select.length === 0) select = [items[0].fileName];
+  if (select.length === 0 && items.length >= 1) select = [items[0].fileName];
 
-  var filePathAppendIndex = getIndexOfCurrentAppendFilePath(filePath, items)
+  var filePathAppendIndex = getIndexOfCurrentAppendFilePath(filePath, items);
+  if (filePathAppendIndex === -1) return false;
   var nearbyStartIndex = getNearbyStartIndex(filePathAppendIndex, select, items);
   var toBeAddedToSelect = toAddedLoopMinToMax(filePathAppendIndex, nearbyStartIndex, items);
 
@@ -93,4 +94,5 @@ export function ShiftSelectionHelper(history: IUseLocation, select: string[], fi
   });
   var urlObject = new URLPath().updateSelection(history.location.search, newSelect);
   history.navigate(new URLPath().IUrlToString(urlObject), { replace: true });
+  return true;
 }

--- a/starsky/starsky/clientapp/src/components/molecules/item-list-view/shift-selection-helper.ts
+++ b/starsky/starsky/clientapp/src/components/molecules/item-list-view/shift-selection-helper.ts
@@ -90,7 +90,7 @@ export function ShiftSelectionHelper(history: IUseLocation, select: string[], fi
 
   // remove duplicates
   var newSelect = [...select, items[filePathAppendIndex].fileName, ...toBeAddedToSelect].filter(function (item, pos) {
-    return [...select, items[filePathAppendIndex].fileName, ...toBeAddedToSelect].indexOf(item) == pos;
+    return [...select, items[filePathAppendIndex].fileName, ...toBeAddedToSelect].indexOf(item) === pos;
   });
   var urlObject = new URLPath().updateSelection(history.location.search, newSelect);
   history.navigate(new URLPath().IUrlToString(urlObject), { replace: true });

--- a/starsky/starsky/clientapp/src/components/molecules/list-image-box/list-image-box.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/list-image-box/list-image-box.spec.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@reach/router';
+import { globalHistory, Link } from '@reach/router';
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 import { IExifStatus } from '../../../interfaces/IExifStatus';
@@ -14,29 +14,85 @@ describe("ListImageTest", () => {
     shallow(<ListImageBox item={fileIndexItem} />)
   });
 
-  it("when click on Link, it should display a preloader", () => {
-    var fileIndexItem = {
-      fileName: 'test',
-      status: IExifStatus.Ok
-    } as IFileIndexItem
-    var component = mount(<ListImageBox item={fileIndexItem} />)
-    component.find(Link).simulate('click', {
-      metaKey: false
+  describe("NonSelectMode", () => {
+
+    beforeAll(() => {
+      globalHistory.navigate("/")
+    })
+
+    it("NonSelectMode - when click on Link, it should display a preloader", () => {
+      var fileIndexItem = {
+        fileName: 'test',
+        status: IExifStatus.Ok
+      } as IFileIndexItem
+      var component = mount(<ListImageBox item={fileIndexItem} />)
+      component.find(Link).simulate('click', {
+        metaKey: false
+      });
+
+      expect(component.exists('.preloader--overlay')).toBeTruthy();
+      component.unmount();
     });
 
-    expect(component.exists('.preloader--overlay')).toBeTruthy();
+    it(" when click on Link, with command key it should ignore preloader", () => {
+
+      var fileIndexItem = {
+        fileName: 'test',
+        status: IExifStatus.Ok
+      } as IFileIndexItem
+      var component = mount(<ListImageBox item={fileIndexItem} />)
+      component.find(Link).simulate('click', {
+        metaKey: true
+      });
+
+      expect(component.exists('.preloader--overlay')).toBeFalsy();
+      component.unmount();
+    });
   });
 
-  it("when click on Link, with command key it should ignore preloader", () => {
-    var fileIndexItem = {
-      fileName: 'test',
-      status: IExifStatus.Ok
-    } as IFileIndexItem
-    var component = mount(<ListImageBox item={fileIndexItem} />)
-    component.find(Link).simulate('click', {
-      metaKey: true
+  describe("SelectMode", () => {
+
+    beforeEach(() => {
+      globalHistory.navigate("/?select=")
     });
 
-    expect(component.exists('.preloader--overlay')).toBeFalsy();
+    it("when click on button it add the selected file to the history", () => {
+      var fileIndexItem = {
+        fileName: 'test',
+        status: IExifStatus.Ok
+      } as IFileIndexItem
+
+      var onSelectionCallback = jest.fn();
+      var component = mount(<ListImageBox item={fileIndexItem}
+        onSelectionCallback={onSelectionCallback} />)
+      component.find('button').simulate('click', {
+        metaKey: false
+      });
+
+      expect(globalHistory.location.search).toBe("?select=test")
+      expect(onSelectionCallback).toBeCalledTimes(0);
+      component.unmount();
+    });
+
+    it("shift click it should submit callback", () => {
+      var fileIndexItem = {
+        fileName: 'test',
+        filePath: '/test.jpg',
+        status: IExifStatus.Ok
+      } as IFileIndexItem
+
+      var onSelectionCallback = jest.fn();
+      var component = mount(<ListImageBox item={fileIndexItem}
+        onSelectionCallback={onSelectionCallback} />)
+      component.find('button').simulate('click', {
+        shiftKey: true
+      });
+
+      expect(onSelectionCallback).toBeCalled();
+      expect(onSelectionCallback).toBeCalledWith("/test.jpg");
+      // the update is done in the callback, not here
+      expect(globalHistory.location.search).toBe("?select=")
+    });
+
   });
 });

--- a/starsky/starsky/clientapp/src/components/molecules/list-image-box/list-image-box.stories.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/list-image-box/list-image-box.stories.tsx
@@ -1,14 +1,21 @@
+import { globalHistory } from '@reach/router';
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import { IFileIndexItem } from '../../../interfaces/IFileIndexItem';
 import ListImageBox from './list-image-box';
 
+var fileIndexItem = {
+  fileName: 'test.jpg',
+  colorClass: 1
+} as IFileIndexItem;
+
 storiesOf("components/molecules/list-image-box", module)
   .add("default", () => {
-    var fileIndexItem = {
-      fileName: 'test.jpg',
-      colorClass: 1
-    } as IFileIndexItem;
+    globalHistory.navigate("/");
     return <><ListImageBox item={fileIndexItem} /></>
     // for multiple items on page see: components/molecules/item-list-view
+  })
+  .add("select", () => {
+    globalHistory.navigate("/?select=test.jpg");
+    return <><ListImageBox item={fileIndexItem} /></>
   })

--- a/starsky/starsky/clientapp/src/components/molecules/list-image-box/list-image-box.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/list-image-box/list-image-box.tsx
@@ -8,19 +8,30 @@ import ListImage from '../../atoms/list-image/list-image';
 import Preloader from '../../atoms/preloader/preloader';
 
 interface IListImageBox {
-  item: IFileIndexItem
+  item: IFileIndexItem,
+  /**
+   * When selecting and pressing shift
+   * @param filePath the entire path (subPath style)
+   */
+  onSelectionCallback?(filePath: string): void;
 }
+
+
 
 const ListImageBox: React.FunctionComponent<IListImageBox> = memo((props) => {
   var item = props.item;
+  if (item.isDirectory === undefined) item.isDirectory = false;
 
   var history = useLocation();
+
+  function updateSelect() {
+    setSelect(new URLPath().StringToIUrl(history.location.search).select);
+  }
 
   // Check if select exist or Length 0 or more
   const [select, setSelect] = React.useState(new URLPath().StringToIUrl(history.location.search).select);
   useEffect(() => {
-    var inSelect = new URLPath().StringToIUrl(history.location.search).select;
-    setSelect(inSelect);
+    updateSelect()
   }, [history.location.search]);
 
   function toggleSelection(fileName: string): void {
@@ -43,7 +54,11 @@ const ListImageBox: React.FunctionComponent<IListImageBox> = memo((props) => {
   if (select) {
     return (
       <div className="list-image-box list-image-box--select">
-        <button onClick={() => toggleSelection(item.fileName)}
+        <button onClick={(event) => {
+          // multiple select using the shift key
+          if (!event.shiftKey) toggleSelection(item.fileName);
+          if (event.shiftKey && props.onSelectionCallback) props.onSelectionCallback(item.filePath);;
+        }}
           className={select.indexOf(item.fileName) === -1 ?
             "box-content colorclass--" + item.colorClass + " isDirectory-" + item.isDirectory :
             "box-content box-content--selected colorclass--" + item.colorClass + " isDirectory-" + item.isDirectory}>

--- a/starsky/starsky/clientapp/src/components/molecules/list-image-box/list-image-box.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/list-image-box/list-image-box.tsx
@@ -47,7 +47,7 @@ const ListImageBox: React.FunctionComponent<IListImageBox> = memo((props) => {
   // selected state
   if (select) {
     return (
-      <div className="list-image-box list-image-box--select">
+      <div className="list-image-box list-image-box--select" data-filepath={item.filePath}>
         <button onClick={(event) => {
           // multiple select using the shift key
           if (!event.shiftKey) toggleSelection(item.fileName);

--- a/starsky/starsky/clientapp/src/components/molecules/list-image-box/list-image-box.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/list-image-box/list-image-box.tsx
@@ -16,22 +16,16 @@ interface IListImageBox {
   onSelectionCallback?(filePath: string): void;
 }
 
-
-
 const ListImageBox: React.FunctionComponent<IListImageBox> = memo((props) => {
   var item = props.item;
   if (item.isDirectory === undefined) item.isDirectory = false;
 
   var history = useLocation();
 
-  function updateSelect() {
-    setSelect(new URLPath().StringToIUrl(history.location.search).select);
-  }
-
   // Check if select exist or Length 0 or more
   const [select, setSelect] = React.useState(new URLPath().StringToIUrl(history.location.search).select);
   useEffect(() => {
-    updateSelect()
+    setSelect(new URLPath().StringToIUrl(history.location.search).select);
   }, [history.location.search]);
 
   function toggleSelection(fileName: string): void {


### PR DESCRIPTION
# PR Details 

- [x]   (Added) _Front-end_ Archive/Search/Trash - When in select mode you can add multiple files 
                            to the selection by pressing the shift key and click

## Related Issue


## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [x] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (framework not included) 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
