### PR TITLE
Upgrade to Java 11 for SonarQube

### DIFF
--- a/.github/workflows/starsky-sonarqube-clientapp-netcore.yml
+++ b/.github/workflows/starsky-sonarqube-clientapp-netcore.yml
@@ -34,6 +34,13 @@ jobs:
         with:
           dotnet-version: 3.1.402
         
+      - name: Use Java 11   
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11.0.9' # The JDK version to make available on the path.
+          java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
+          architecture: x64 # (x64 or x86) - defaults to x64
+        
       - name: Build
         shell: bash
         env:

--- a/azure-pipelines-starsky.yml
+++ b/azure-pipelines-starsky.yml
@@ -49,7 +49,7 @@ steps:
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - task: PowerShell@2
-  displayName: "Use JDK11 by default"
+  displayName: "Use JDK11 by default (needed for sonarqube)"
   inputs:
     targetType: 'inline'
     script: |

--- a/azure-pipelines-starsky.yml
+++ b/azure-pipelines-starsky.yml
@@ -48,6 +48,14 @@ steps:
     version: 3.1.402
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
+- task: PowerShell@2
+  displayName: "Use JDK11 by default"
+  inputs:
+    targetType: 'inline'
+    script: |
+      $jdkPath = $env:JAVA_HOME_11_X64
+      Write-Host "##vso[task.setvariable variable=JAVA_HOME]$jdkPath"
+
 - task: DotNetCoreCLI@2
   displayName: 'dotnet tool restore'
   inputs:


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

-SonarQube Upgrade to Java 11 in pipeline
- Change Azure Devops pipeline to support Java 11

## Why?
The version of Java (1.8.0_272) you have used to run this analysis is deprecated and we will stop accepting it accepting it soon.Please update to at least Java 11. Read more here
https://sonarcloud.io/documentation/appendices/end-of-support/

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [x] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
