### PR TITLE
Cypress end2end fixes for setting env variables

### DIFF
--- a/.github/workflows/end2end-on-heroku-demo.yml
+++ b/.github/workflows/end2end-on-heroku-demo.yml
@@ -12,11 +12,15 @@ jobs:
     - uses: actions/checkout@v2
       
     - name: Run Cypress in Electron 
-      uses: cypress-io/github-action@v1
+      uses: cypress-io/github-action@v2
+      env:
+        CYPRESS_BASE_URL: https://starskydemo.herokuapp.com  
+        cypress_name: heroku-demo
+        cypress_AUTH_USER: demo@qdraw.nl
+        cypress_AUTH_PASS:  demo@qdraw.nl
       with:
-        command: npm run e2e:heroku-demo
+        command: npm run e2e:env
         working-directory: starsky-tools/end2end  
-
 
     - name: Upload screenshots (always)
       uses: actions/upload-artifact@v2

--- a/starsky-tools/end2end/.gitignore
+++ b/starsky-tools/end2end/.gitignore
@@ -1,1 +1,2 @@
 results
+cypress/screenshots/**/*.png

--- a/starsky-tools/end2end/cypress/plugins/index.ts
+++ b/starsky-tools/end2end/cypress/plugins/index.ts
@@ -10,9 +10,14 @@ function getConfigurationByFile (file: string, folder: string) {
 }
 
 module.exports = (_, config) => {
+  if (process.env.CYPRESS_BASE_URL && process.env.cypress_name && process.env.cypress_AUTH_USER && process.env.cypress_AUTH_PASS) {
+    console.log('ignored due existing env names =>', process.env.CYPRESS_BASE_URL, process.env.cypress_name, process.env.cypress_AUTH_USER, 'cypress_AUTH_PASS')
+    return
+  }
+
   // accept a configEnv value or use development by default
   const file = config.env.configEnv || 'local'
-  const folder = config.env.configFolder || 'starsy'
+  const folder = config.env.configFolder || 'starsky'
 
   // Add Cypress linting to build process
   // on('file:preprocessor', cypressEslint());

--- a/starsky-tools/end2end/cypress/screenshots/.gitignore
+++ b/starsky-tools/end2end/cypress/screenshots/.gitignore
@@ -1,0 +1,1 @@
+!.gitkeep

--- a/starsky-tools/end2end/cypress/support/commands.ts
+++ b/starsky-tools/end2end/cypress/support/commands.ts
@@ -1,6 +1,6 @@
 
 // Get current environment folder
-export const envFolder = Cypress.env().configFolder
+export const envFolder = Cypress.env().configFolder ? Cypress.env().configFolder : 'starsky'
 
 // Get current environment name
 export const envName = Cypress.env().name

--- a/starsky-tools/end2end/package.json
+++ b/starsky-tools/end2end/package.json
@@ -3,8 +3,10 @@
   "version": "0.4.0",
   "scripts": {
     "start": "cypress open --env configFolder=starsky,configEnv=local,CYPRESS_RETRIES=2",
+    "start:env": "cypress open",
     "open:heroku-demo": "cypress open --env configFolder=starsky,configEnv=heroku-demo,CYPRESS_RETRIES=2",
-    "e2e:heroku-demo": "cypress run --env configFolder=starsky,configEnv=heroku-demo,CYPRESS_RETRIES=2"
+    "e2e:heroku-demo": "cypress run --env configFolder=starsky,configEnv=heroku-demo,CYPRESS_RETRIES=2",
+    "e2e:env": "cypress run"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

- make end2end tests work again
- there are not setting env variables anymore

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [x] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
