### PR TITLE
change fallback in storage folder && change update of appsettings

### DIFF
--- a/history.md
+++ b/history.md
@@ -43,6 +43,8 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Changed) _Back-end_ Allow version parameter for "/api/health/version"
 - [x]   (Fixed) _Front-end_  Use real-time update Color class outside selection #252
 - [x]   (Added) _App_ Add Dutch translation to menu's
+- [x]   (Fixed) _Back-end_ When saving StorageFolder from Preferences its now saved in the right format
+- [x]   (Fixed) _Back-end_ Files that are not in the index should not be listed in the cache
 
 # version 0.4.2 - 2020-12-09
 - [x]   (Changed) _Docs_ Update docs and remove old projects from docs 

--- a/starsky/starsky.foundation.database/Interfaces/IQuery.cs
+++ b/starsky/starsky.foundation.database/Interfaces/IQuery.cs
@@ -97,6 +97,12 @@ namespace starsky.foundation.database.Interfaces
         /// </summary>
         /// <param name="updateStatusContent">items to update</param>
         void CacheUpdateItem(List<FileIndexItem> updateStatusContent);
+        
+        /// <summary>
+        /// And remove content from cache
+        /// </summary>
+        /// <param name="updateStatusContent"></param>
+        void RemoveCacheItem(List<FileIndexItem> updateStatusContent);
 
         /// <summary>
         /// Add Sub Path Folder - Parent Folders

--- a/starsky/starsky.foundation.database/Query/Query.cs
+++ b/starsky/starsky.foundation.database/Query/Query.cs
@@ -414,6 +414,22 @@ namespace starsky.foundation.database.Query
 				_cache.Set(queryCacheName, displayFileFolders, new TimeSpan(1,0,0));
 			}
         }
+
+        /// <summary>
+        /// Cache Only! Private api within Query to remove cached items
+        /// This Does remove a SINGLE item from the cache NOT from the database
+        /// </summary>
+        /// <param name="updateStatusContent"></param>
+        public void RemoveCacheItem(List<FileIndexItem> updateStatusContent)
+        {
+	        if( _cache == null || _appSettings?.AddMemoryCache == false) return;
+
+	        foreach ( var item in updateStatusContent.ToList() )
+	        {
+		        RemoveCacheItem(item);
+	        }
+        }
+        
         
         /// <summary>
         /// Cache Only! Private api within Query to remove cached items
@@ -432,10 +448,12 @@ namespace starsky.foundation.database.Query
             
             var displayFileFolders = (List<FileIndexItem>) objectFileFolders;
                         // Order by filename
-            displayFileFolders = displayFileFolders.OrderBy(p => p.FileName).ToList();
+            displayFileFolders = displayFileFolders
+	            .Where(p => p.FilePath != updateStatusContent.FilePath)
+	            .OrderBy(p => p.FileName).ToList();
             
             _cache.Remove(queryCacheName);
-            // generate list agian
+            // generate list again
             _cache.Set(queryCacheName, displayFileFolders, new TimeSpan(1,0,0));
         }
 

--- a/starsky/starsky.foundation.platform/Helpers/SetupAppSettings.cs
+++ b/starsky/starsky.foundation.platform/Helpers/SetupAppSettings.cs
@@ -31,7 +31,7 @@ namespace starsky.foundation.platform.Helpers
 			// to remove spaces and other signs, check help to get your name
 			var appSettingsMachine =
 				$"appsettings.{Environment.MachineName.ToLowerInvariant()}."; // dot here
-			
+
 			builder
 				.SetBasePath(appSettings.BaseDirectoryProject)
 				.AddJsonFile("appsettings.patch.json",true)
@@ -79,13 +79,11 @@ namespace starsky.foundation.platform.Helpers
 			
 			if ( appSettingsPath == null || !File.Exists(appSettingsPath))
 			{
+				// defaults to appsettings.patch.json
 				return builder;
 			}
-			
-			builder
-				.SetBasePath(Directory.GetParent(appSettingsPath).FullName)
-				.AddJsonFile("appsettings.json");
-			
+
+			builder.AddJsonFile(appSettingsPath, false, true);
 			return builder;
 		}
 	}

--- a/starsky/starsky.foundation.platform/Models/AppSettings.cs
+++ b/starsky/starsky.foundation.platform/Models/AppSettings.cs
@@ -25,8 +25,7 @@ namespace starsky.foundation.platform.Models
 
             // Cache for thumbs
             ThumbnailTempFolder = Path.Combine(BaseDirectoryProject, "thumbnailTempFolder");
-			// Main Storage for source files (default)
-            StorageFolder = Path.Combine(BaseDirectoryProject, "storageFolder");
+
             // Temp folder, should be cleaned
             TempFolder = Path.Combine(BaseDirectoryProject, "temp");
 
@@ -139,13 +138,22 @@ namespace starsky.foundation.platform.Models
 		public DateTime AppVersionBuildDateTime => DateAssembly.GetBuildDate(Assembly.GetExecutingAssembly());
 
 		// Can be used in the cli session to select files out of the file database system
-        private string _storageFolder; // in old versions: basePath 
+        private string _storageFolder;
+        
+        /// <summary>
+        /// Main Storage provider on disk
+        /// </summary>
         public string StorageFolder
         {
-            get { return _storageFolder; }
+	        get
+	        {
+		        // ReSharper disable once ArrangeAccessorOwnerBody
+		        return string.IsNullOrEmpty(_storageFolder) ? Path.Combine(BaseDirectoryProject, "storageFolder") : _storageFolder;
+	        }
             set
             {
-                _storageFolder = PathHelper.AddBackslash(value);
+	            // ReSharper disable once ArrangeAccessorOwnerBody
+	            _storageFolder = PathHelper.AddBackslash(value);
             }
         }
 

--- a/starsky/starsky.foundation.sync/WatcherHelpers/SyncWatcherConnector.cs
+++ b/starsky/starsky.foundation.sync/WatcherHelpers/SyncWatcherConnector.cs
@@ -54,7 +54,12 @@ namespace starsky.foundation.sync.WatcherHelpers
 				DefaultJsonSerializer.CamelCase), CancellationToken.None);
 			
 			// And update the query Cache
-			_query.CacheUpdateItem(filtered);
+			_query.CacheUpdateItem(filtered.Where(p => p.Status == FileIndexItem.ExifStatus.Ok ||
+				p.Status == FileIndexItem.ExifStatus.Deleted).ToList());
+			
+			// remove files that are not in the index from cache
+			_query.RemoveCacheItem(filtered.Where(p => p.Status == FileIndexItem.ExifStatus.NotFoundNotInIndex || 
+				p.Status == FileIndexItem.ExifStatus.NotFoundSourceMissing).ToList());
 			
 			return syncData;
 		}

--- a/starsky/starsky.foundation.writemeta/Helpers/ExifToolDownload.cs
+++ b/starsky/starsky.foundation.writemeta/Helpers/ExifToolDownload.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Net.Http;

--- a/starsky/starsky/Controllers/AppSettingsController.cs
+++ b/starsky/starsky/Controllers/AppSettingsController.cs
@@ -56,6 +56,7 @@ namespace starsky.Controllers
 		{
 			AppSettingsCompareHelper.Compare(_appSettings, appSettingTransferObject);
 			
+			// should not forget app: prefix
 			var json = JsonSerializer.Serialize(new { app = _appSettings }, new JsonSerializerOptions
 			{
 				WriteIndented = true, 

--- a/starsky/starsky/Controllers/AppSettingsController.cs
+++ b/starsky/starsky/Controllers/AppSettingsController.cs
@@ -56,7 +56,7 @@ namespace starsky.Controllers
 		{
 			AppSettingsCompareHelper.Compare(_appSettings, appSettingTransferObject);
 			
-			var json = JsonSerializer.Serialize(_appSettings, new JsonSerializerOptions
+			var json = JsonSerializer.Serialize(new { app = _appSettings }, new JsonSerializerOptions
 			{
 				WriteIndented = true, 
 				Converters =
@@ -70,6 +70,7 @@ namespace starsky.Controllers
 			await _hostStorage.WriteStreamAsync(
 				new PlainTextFileHelper().StringToStream(jsonOutput),
 				_appSettings.AppSettingsPath);
+			
 			return Env();
 		}
 	}

--- a/starsky/starsky/starsky.csproj
+++ b/starsky/starsky/starsky.csproj
@@ -12,6 +12,7 @@
         <DebugType>Full</DebugType>
         <!-- due missing support of ts4.1-->
         <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
+        <SynchReleaseVersion>false</SynchReleaseVersion>
     </PropertyGroup>
     
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/starsky/starskytest/Controllers/AppSettingsControllerTest.cs
+++ b/starsky/starskytest/Controllers/AppSettingsControllerTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -50,7 +51,7 @@ namespace starskytest.Controllers
 			var storageProvider = new FakeSelectorStorage();
 			var appSettings = new AppSettings
 			{
-				AppSettingsPath = "/temp/appsettings.json"
+				AppSettingsPath = $"{Path.DirectorySeparatorChar}temp{Path.DirectorySeparatorChar}appsettings.json"
 			};
 			var controller = new AppSettingsController(appSettings, storageProvider);
 			await controller.UpdateAppSettings(

--- a/starsky/starskytest/Controllers/AppSettingsControllerTest.cs
+++ b/starsky/starskytest/Controllers/AppSettingsControllerTest.cs
@@ -70,7 +70,7 @@ namespace starskytest.Controllers
 				storage.ReadStream(appSettings.AppSettingsPath));
 			
 			Assert.IsTrue(jsonContent.Contains("app\": {"));
-			Assert.IsTrue(jsonContent.Contains("\"StorageFolder\": \"test,"));
+			Assert.IsTrue(jsonContent.Contains("\"StorageFolder\": \""));
 		}
 	}
 }

--- a/starsky/starskytest/Controllers/AppSettingsControllerTest.cs
+++ b/starsky/starskytest/Controllers/AppSettingsControllerTest.cs
@@ -68,6 +68,8 @@ namespace starskytest.Controllers
 
 			var jsonContent= await new PlainTextFileHelper().StreamToStringAsync(
 				storage.ReadStream(appSettings.AppSettingsPath));
+
+			Console.WriteLine(jsonContent);
 			
 			Assert.IsTrue(jsonContent.Contains("app\": {"));
 			Assert.IsTrue(jsonContent.Contains("\"StorageFolder\": \""));

--- a/starsky/starskytest/Controllers/AppSettingsControllerTest.cs
+++ b/starsky/starskytest/Controllers/AppSettingsControllerTest.cs
@@ -70,7 +70,7 @@ namespace starskytest.Controllers
 				storage.ReadStream(appSettings.AppSettingsPath));
 			
 			Assert.IsTrue(jsonContent.Contains("app\": {"));
-			Assert.IsTrue(jsonContent.Contains("\"StorageFolder\": \"test/\","));
+			Assert.IsTrue(jsonContent.Contains("\"StorageFolder\": \"test,"));
 		}
 	}
 }

--- a/starsky/starskytest/FakeMocks/FakeIQuery.cs
+++ b/starsky/starskytest/FakeMocks/FakeIQuery.cs
@@ -250,6 +250,10 @@ namespace starskytest.FakeMocks
 			Console.WriteLine("CacheUpdateItem is called");
 		}
 
+		public void RemoveCacheItem(List<FileIndexItem> updateStatusContent)
+		{
+		}
+
 		public async Task AddParentItemsAsync(string subPath)
 		{
 			var path = subPath == "/" || string.IsNullOrEmpty(subPath) ? "/" : PathHelper.RemoveLatestSlash(subPath);

--- a/starsky/starskytest/starsky.foundation.database/QueryTest/QueryTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/QueryTest/QueryTest.cs
@@ -1086,5 +1086,26 @@ namespace starskytest.starsky.foundation.database.QueryTest
 		    var itemItShouldBeNull = await dbContext2.FileIndex.FirstOrDefaultAsync(p => p.FilePath == "/test44.jpg");
 		    Assert.IsNull(itemItShouldBeNull);
 	    }
+
+	    [TestMethod]
+	    public void RemoveCacheItem_ShouldKeepOne()
+	    {
+		    var dirPath = "/__cache__remove_test";
+		    var demoItems =
+			    new List<FileIndexItem>
+			    {
+				    new FileIndexItem(dirPath+ "/01.jpg"),
+				    new FileIndexItem(dirPath+ "/02.jpg"),
+				    new FileIndexItem(dirPath+ "/03.jpg")
+			    };
+		    
+		    _query.AddCacheParentItem(dirPath,demoItems);
+		    
+		    _query.RemoveCacheItem(new List<FileIndexItem>{demoItems[0], demoItems[1]});
+
+		    var result = _query.DisplayFileFolders(dirPath).ToList();
+		    Assert.AreEqual(1,result.Count);
+		    Assert.AreEqual(dirPath+ "/03.jpg",result[0].FilePath);
+	    }
     }
 }

--- a/starsky/starskytest/starsky.foundation.database/QueryTest/QueryTestNoCacheTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/QueryTest/QueryTestNoCacheTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using starsky.foundation.database.Data;
@@ -41,6 +42,13 @@ namespace starskytest.starsky.foundation.database.QueryTest
 	    public void Query_IsCacheEnabled_False()
 	    {
 		    Assert.AreEqual(false, _query.IsCacheEnabled());
+	    }
+	    
+	    [TestMethod]
+	    public void RemoveCacheItem_Disabled()
+	    {
+		    _query.RemoveCacheItem(new List<FileIndexItem>());
+		    // it should not crash
 	    }
 	    
     }

--- a/starsky/starskytest/starsky.foundation.sync/SyncServices/SyncFolderTest.cs
+++ b/starsky/starskytest/starsky.foundation.sync/SyncServices/SyncFolderTest.cs
@@ -121,7 +121,7 @@ namespace starskytest.starsky.foundation.sync.SyncServices
 		}
 		
 		[TestMethod]
-		public async Task Folder_Duplicate()
+		public async Task Folder_DuplicateChildItems()
 		{
 			var storage =  new FakeIStorage(
 				new List<string>


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

- [x]   (Fixed) _Back-end_ When saving StorageFolder from Preferences its now saved in the right format
- [x]   (Fixed) _Back-end_ Files that are not in the index should not be listed in the cache


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
