### PR TITLE
Feature/202103 dir that exist op not sup

### DIFF
--- a/starsky-tools/end2end/cypress/integration/21-create-rename-directory/21-create-directory.ts
+++ b/starsky-tools/end2end/cypress/integration/21-create-rename-directory/21-create-directory.ts
@@ -103,6 +103,8 @@ describe('Create Rename Dir', () => {
       }
     })
 
+    cy.wait(1000)
+
     cy.request({
       failOnStatusCode: false,
       method: 'DELETE',
@@ -111,6 +113,8 @@ describe('Create Rename Dir', () => {
         f: '/starsky-end2end-test/z_test_auto_created_update'
       }
     })
+
     cy.visit(config.url)
+    cy.get('[data-filepath="/starsky-end2end-test/z_test_auto_created_update"] button').should('not.exist')
   })
 })

--- a/starsky-tools/end2end/cypress/integration/21-create-rename-directory/21-create-directory.ts
+++ b/starsky-tools/end2end/cypress/integration/21-create-rename-directory/21-create-directory.ts
@@ -20,6 +20,8 @@ describe('Create Rename Dir', () => {
     cy.resetStorage()
 
     cy.sendAuthenticationHeader()
+    // create parent directory if not exist
+    checkIfExistAndCreate(config)
   })
 
   it('Create Rename Dir - Check if folder is there & create', () => {
@@ -35,7 +37,6 @@ describe('Create Rename Dir', () => {
     cy.get('.item.item--more').click()
     cy.get('[data-test=mkdir]').click()
 
-    // dont include in starsky-end2end-test
     cy.get('[data-name=directoryname]').type('z_test_auto_created')
     cy.get('.btn.btn--default').click()
 
@@ -60,5 +61,27 @@ describe('Create Rename Dir', () => {
     if (!config.isEnabled) return
 
     cy.visit(config.url)
+
+    cy.get('.item.item--select').click()
+    cy.get('[data-filepath="/starsky-end2end-test/z_test_auto_created_update"] button').click()
+
+    cy.get('.item.item--more').click()
+    cy.get('[data-test=trash]').click()
+
+    cy.wait(3000)
+    cy.visit(config.trash)
+
+    cy.get('.item.item--select').click()
+    cy.get('[data-filepath="/starsky-end2end-test/z_test_auto_created_update"] button').click()
+
+    // verwijder onmiddelijk
+    cy.get('.modal .btn.btn--default').click()
+
+    // item should be in the trash
+    cy.get('[data-filepath="/starsky-end2end-test/z_test_auto_created_update"] button').should('not.exist')
+
+    // and not in the source folder
+    cy.visit(config.url)
+    cy.get('[data-filepath="/starsky-end2end-test/z_test_auto_created_update"] button').should('not.exist')
   })
 })

--- a/starsky-tools/end2end/cypress/integration/21-create-rename-directory/21-create-directory.ts
+++ b/starsky-tools/end2end/cypress/integration/21-create-rename-directory/21-create-directory.ts
@@ -89,4 +89,28 @@ describe('Create Rename Dir', () => {
     cy.visit(config.url)
     cy.get('[data-filepath="/starsky-end2end-test/z_test_auto_created_update"] button').should('not.exist')
   })
+
+  it('safe guard for other tests - if not deleted remove via the api', () => {
+    if (!config.isEnabled) return
+
+    cy.request({
+      failOnStatusCode: false,
+      method: 'POST',
+      url: '/starsky/api/update',
+      qs: {
+        f: '/starsky-end2end-test/z_test_auto_created_update',
+        tags: '!delete!'
+      }
+    })
+
+    cy.request({
+      failOnStatusCode: false,
+      method: 'DELETE',
+      url: '/starsky/api/delete',
+      qs: {
+        f: '/starsky-end2end-test/z_test_auto_created_update'
+      }
+    })
+    cy.visit(config.url)
+  })
 })

--- a/starsky-tools/end2end/cypress/integration/21-create-rename-directory/21-create-directory.ts
+++ b/starsky-tools/end2end/cypress/integration/21-create-rename-directory/21-create-directory.ts
@@ -55,4 +55,10 @@ describe('Create Rename Dir', () => {
 
     cy.request(config.urlMkdir + '/z_test_auto_created_update')
   })
+
+  it('delete it afterwards', () => {
+    if (!config.isEnabled) return
+
+    cy.visit(config.url)
+  })
 })

--- a/starsky-tools/end2end/cypress/integration/21-create-rename-directory/21-create-directory.ts
+++ b/starsky-tools/end2end/cypress/integration/21-create-rename-directory/21-create-directory.ts
@@ -54,6 +54,7 @@ describe('Create Rename Dir', () => {
     cy.get('[data-name=foldername]').type('_update')
     cy.get('.btn.btn--default').click()
 
+    cy.wait(500)
     cy.request(config.urlMkdir + '/z_test_auto_created_update')
   })
 
@@ -73,6 +74,10 @@ describe('Create Rename Dir', () => {
 
     cy.get('.item.item--select').click()
     cy.get('[data-filepath="/starsky-end2end-test/z_test_auto_created_update"] button').click()
+
+    // menu ->
+    cy.get('.item.item--more').click()
+    cy.get('[data-test=delete]').click()
 
     // verwijder onmiddelijk
     cy.get('.modal .btn.btn--default').click()

--- a/starsky-tools/end2end/cypress/integration/21-create-rename-directory/config.json
+++ b/starsky-tools/end2end/cypress/integration/21-create-rename-directory/config.json
@@ -1,32 +1,35 @@
 {
     "starsky": {
       "local": {
-        "isEnabled": false,
+        "isEnabled": true,
         "url": "/?f=/starsky-end2end-test",
         "mkdirName": "starsky-end2end-test",
         "mkdirPath": "/starsky-end2end-test",
         "urlMkdir": "/api/index/?f=/starsky-end2end-test",
         "mkdirApi": "/api/sync/mkdir",
+        "searchClearCache": "/api/search/remove-cache?t=-isDirectory:true -filepath=/starsky-end2end-test",
         "checkIfDirExistApi": "/starsky/api/search?json=true&t=-isDirectory:true -filepath=/starsky-end2end-test&p=0",
         "successUrl" : "/?f=/"
       },
       "heroku-demo" : {
-        "isEnabled": false,
+        "isEnabled": true,
         "url": "/?f=/starsky-end2end-test",
         "mkdirName": "starsky-end2end-test",
         "mkdirPath": "/starsky-end2end-test",
         "urlMkdir": "/api/index/?f=/starsky-end2end-test",
         "mkdirApi": "/api/sync/mkdir",
+        "searchClearCache": "/api/search/remove-cache?t=-isDirectory:true -filepath=/starsky-end2end-test",
         "checkIfDirExistApi": "/starsky/api/search?json=true&t=-isDirectory:true -filepath=/starsky-end2end-test&p=0",
         "successUrl" : "/?f=/"
       },
       "no-create-account" : {
-        "isEnabled": false,
+        "isEnabled": true,
         "url": "/?f=/starsky-end2end-test",
         "mkdirName": "starsky-end2end-test",
         "mkdirPath": "/starsky-end2end-test",
         "urlMkdir": "/api/index/?f=/starsky-end2end-test",
         "mkdirApi": "/api/sync/mkdir",
+        "searchClearCache": "/api/search/remove-cache?t=-isDirectory:true -filepath=/starsky-end2end-test",
         "checkIfDirExistApi": "/starsky/api/search?json=true&t=-isDirectory:true -filepath=/starsky-end2end-test&p=0",
         "successUrl" : "/?f=/"
       }

--- a/starsky-tools/end2end/cypress/integration/21-create-rename-directory/config.json
+++ b/starsky-tools/end2end/cypress/integration/21-create-rename-directory/config.json
@@ -9,7 +9,8 @@
         "mkdirApi": "/api/sync/mkdir",
         "searchClearCache": "/api/search/remove-cache?t=-isDirectory:true -filepath=/starsky-end2end-test",
         "checkIfDirExistApi": "/starsky/api/search?json=true&t=-isDirectory:true -filepath=/starsky-end2end-test&p=0",
-        "successUrl" : "/?f=/"
+        "successUrl" : "/?f=/",
+        "trash": "/trash"
       },
       "heroku-demo" : {
         "isEnabled": true,
@@ -20,7 +21,8 @@
         "mkdirApi": "/api/sync/mkdir",
         "searchClearCache": "/api/search/remove-cache?t=-isDirectory:true -filepath=/starsky-end2end-test",
         "checkIfDirExistApi": "/starsky/api/search?json=true&t=-isDirectory:true -filepath=/starsky-end2end-test&p=0",
-        "successUrl" : "/?f=/"
+        "successUrl" : "/?f=/",
+        "trash": "/trash"
       },
       "no-create-account" : {
         "isEnabled": true,
@@ -31,7 +33,8 @@
         "mkdirApi": "/api/sync/mkdir",
         "searchClearCache": "/api/search/remove-cache?t=-isDirectory:true -filepath=/starsky-end2end-test",
         "checkIfDirExistApi": "/starsky/api/search?json=true&t=-isDirectory:true -filepath=/starsky-end2end-test&p=0",
-        "successUrl" : "/?f=/"
+        "successUrl" : "/?f=/",
+        "trash": "/trash"
       }
     }
   }

--- a/starsky/starsky.feature.metaupdate/Services/DeleteItem.cs
+++ b/starsky/starsky.feature.metaupdate/Services/DeleteItem.cs
@@ -123,8 +123,10 @@ namespace starsky.feature.metaupdate.Services
 				if ( detailViewItem.FileIndexItem.IsDirectory != true )
 					continue;
 				
-				foreach ( var item in _query.GetAllRecursive(collectionSubPath) )
+				foreach ( var item in _query.GetAllRecursive(collectionSubPath).Where(p => p.IsDirectory == true) )
 				{
+					item.Status = FileIndexItem.ExifStatus.Deleted;
+					fileIndexResultsList.Add(item.Clone());
 					_query.RemoveItem(item);
 				}
 			}

--- a/starsky/starsky.feature.metaupdate/Services/DeleteItem.cs
+++ b/starsky/starsky.feature.metaupdate/Services/DeleteItem.cs
@@ -118,8 +118,16 @@ namespace starsky.feature.metaupdate.Services
 				RemoveXmpSideCarFile(detailViewItem);
 				RemoveJsonSideCarFile(detailViewItem);
 				RemoveFileOrFolderFromDisk(detailViewItem);
+				
+				// the child directories are still stored in the database
+				if ( detailViewItem.FileIndexItem.IsDirectory != true )
+					continue;
+				
+				foreach ( var item in _query.GetAllRecursive(collectionSubPath) )
+				{
+					_query.RemoveItem(item);
+				}
 			}
-
 			return fileIndexResultsList;
 		}
 

--- a/starsky/starsky.feature.rename/Services/RenameService.cs
+++ b/starsky/starsky.feature.rename/Services/RenameService.cs
@@ -59,20 +59,8 @@ namespace starsky.feature.rename.Services
 				if ( inputFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Folder 
 				     && toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Deleted)
 				{
-					// move entire folder
-					_iStorage.FolderMove(inputFileSubPath,toFileSubPath);
-					
-					fileIndexItems = _query.GetAllRecursive(inputFileSubPath);
-					// Rename child items
-					fileIndexItems.ForEach(p =>
-						{
-							var parentDirectory = p.ParentDirectory
-								.Replace(inputFileSubPath, toFileSubPath);
-							p.ParentDirectory = parentDirectory;
-							p.Status = FileIndexItem.ExifStatus.Ok;
-						}
-					);
-
+					fileIndexItems = FromFolderToDeleted(inputFileSubPath, toFileSubPath,
+						fileIndexItems);
 				}
 				else if ( inputFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Folder 
 					&& toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Folder)
@@ -118,6 +106,29 @@ namespace starsky.feature.rename.Services
 
 	        return fileIndexResultsList;
         }
+
+		private List<FileIndexItem> FromFolderToDeleted(string inputFileSubPath, string toFileSubPath, List<FileIndexItem> fileIndexItems)
+		{
+			// move entire folder
+			_iStorage.FolderMove(inputFileSubPath,toFileSubPath);
+					
+			fileIndexItems = _query.GetAllRecursive(inputFileSubPath);
+			// Rename child items
+			fileIndexItems.ForEach(p =>
+				{
+					var parentDirectory = p.ParentDirectory
+						.Replace(inputFileSubPath, toFileSubPath);
+					p.ParentDirectory = parentDirectory;
+					p.Status = FileIndexItem.ExifStatus.Ok;
+				}
+			);
+			
+			// todo:
+			// todo: Move folder to location that does exist in database but not on disk. It now creates a duplicate folder
+			
+			
+			return fileIndexItems;
+		}
 
 		private string GetFileName(string toFileSubPath, string inputFileSubPath)
 		{

--- a/starsky/starsky.feature.rename/Services/RenameService.cs
+++ b/starsky/starsky.feature.rename/Services/RenameService.cs
@@ -46,9 +46,6 @@ namespace starsky.feature.rename.Services
 				// 7. file to existing file > skip
 
 				var inputFileSubPath = inputFileSubPaths[i];
-				// where its from
-				fileIndexResultsList.Add(new FileIndexItem(inputFileSubPath){Status = FileIndexItem.ExifStatus.Deleted});
-
 				var toFileSubPath = toFileSubPaths[i];
 				
 				var detailView = _query.SingleItem(inputFileSubPath, null, collections, false);
@@ -80,6 +77,8 @@ namespace starsky.feature.rename.Services
 					&& toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Folder)
 				{
 					FromFolderToFolder(inputFileSubPath, toFileSubPath, fileIndexItems);
+					// when renaming a folder it should warn the UI that it should remove the source item
+					fileIndexResultsList.Add(new FileIndexItem(inputFileSubPath){Status = FileIndexItem.ExifStatus.Deleted});
 				}
 				else if ( inputFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.File 
 				          && toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.File)
@@ -385,7 +384,7 @@ namespace starsky.feature.rename.Services
 					
 			// todo: remove folder from disk + remove duplicate database item 
 			// remove duplicate item from list
-			_query.GetObjectByFilePath(inputFileSubPath);
+			//_query.GetObjectByFilePath(inputFileSubPath);
 		}
 
 		private void FromFileToDeleted(string inputFileSubPath, string toFileSubPath,
@@ -422,6 +421,9 @@ namespace starsky.feature.rename.Services
 					
 			_iStorage.FileMove(inputFileSubPath,toFileSubPath);
 			MoveSidecarFile(inputFileSubPath, toFileSubPath);
+			
+			// when renaming a file it should warn the UI that it should remove the source item
+			fileIndexResultsList.Add(new FileIndexItem(inputFileSubPath){Status = FileIndexItem.ExifStatus.Deleted});
 		}
 
 		private void FromFileToFolder(string inputFileSubPath, string toFileSubPath, List<FileIndexItem> fileIndexResultsList)

--- a/starsky/starsky.feature.rename/Services/RenameService.cs
+++ b/starsky/starsky.feature.rename/Services/RenameService.cs
@@ -122,6 +122,7 @@ namespace starsky.feature.rename.Services
 						.Replace(inputFileSubPath, toFileSubPath);
 					p.ParentDirectory = parentDirectory;
 					p.Status = FileIndexItem.ExifStatus.Ok;
+					p.Tags = p.Tags.Replace("!delete!", string.Empty);
 				}
 			);
 

--- a/starsky/starsky.feature.rename/Services/RenameService.cs
+++ b/starsky/starsky.feature.rename/Services/RenameService.cs
@@ -407,7 +407,7 @@ namespace starsky.feature.rename.Services
 					
 			// todo: remove folder from disk + remove duplicate database item 
 			// remove duplicate item from list
-			//_query.GetObjectByFilePath(inputFileSubPath);
+			// _query GetObjectByFilePath (inputFileSubPath)
 		}
 
 		private void FromFileToDeleted(string inputFileSubPath, string toFileSubPath,

--- a/starsky/starsky.feature.rename/Services/RenameService.cs
+++ b/starsky/starsky.feature.rename/Services/RenameService.cs
@@ -46,6 +46,9 @@ namespace starsky.feature.rename.Services
 				// 7. file to existing file > skip
 
 				var inputFileSubPath = inputFileSubPaths[i];
+				// where its from
+				fileIndexResultsList.Add(new FileIndexItem(inputFileSubPath){Status = FileIndexItem.ExifStatus.Deleted});
+
 				var toFileSubPath = toFileSubPaths[i];
 				
 				var detailView = _query.SingleItem(inputFileSubPath, null, collections, false);

--- a/starsky/starsky.feature.rename/Services/RenameService.cs
+++ b/starsky/starsky.feature.rename/Services/RenameService.cs
@@ -23,7 +23,8 @@ namespace starsky.feature.rename.Services
 			_iStorage = iStorage;
 		}
 
-		/// <summary>Move or rename files and update the database</summary>
+		/// <summary>Move or rename files and update the database.
+		/// The services also returns the source folders/files as NotFoundSourceMissing</summary>
 		/// <param name="f">subPath to file or folder</param>
 		/// <param name="to">subPath location to move</param>
 		/// <param name="collections">true = copy files with the same name</param>
@@ -78,7 +79,7 @@ namespace starsky.feature.rename.Services
 				{
 					FromFolderToFolder(inputFileSubPath, toFileSubPath, fileIndexItems);
 					// when renaming a folder it should warn the UI that it should remove the source item
-					fileIndexResultsList.Add(new FileIndexItem(inputFileSubPath){Status = FileIndexItem.ExifStatus.Deleted});
+					fileIndexResultsList.Add(new FileIndexItem(inputFileSubPath){Status = FileIndexItem.ExifStatus.NotFoundSourceMissing});
 				}
 				else if ( inputFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.File 
 				          && toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.File)
@@ -422,8 +423,8 @@ namespace starsky.feature.rename.Services
 			_iStorage.FileMove(inputFileSubPath,toFileSubPath);
 			MoveSidecarFile(inputFileSubPath, toFileSubPath);
 			
-			// when renaming a file it should warn the UI that it should remove the source item
-			fileIndexResultsList.Add(new FileIndexItem(inputFileSubPath){Status = FileIndexItem.ExifStatus.Deleted});
+			// when renaming a folder it should warn the UI that it should remove the source item
+			fileIndexResultsList.Add(new FileIndexItem(inputFileSubPath){Status = FileIndexItem.ExifStatus.NotFoundSourceMissing});
 		}
 
 		private void FromFileToFolder(string inputFileSubPath, string toFileSubPath, List<FileIndexItem> fileIndexResultsList)
@@ -451,6 +452,9 @@ namespace starsky.feature.rename.Services
 					
 			_iStorage.FileMove(inputFileSubPath, toFileSubPath);
 			MoveSidecarFile(inputFileSubPath, toFileSubPath);
+			
+			// when renaming a folder it should warn the UI that it should remove the source item
+			fileIndexResultsList.Add(new FileIndexItem(inputFileSubPath){Status = FileIndexItem.ExifStatus.NotFoundSourceMissing});
 		}
 
     }

--- a/starsky/starsky/Controllers/IndexController.cs
+++ b/starsky/starsky/Controllers/IndexController.cs
@@ -65,7 +65,9 @@ namespace starsky.Controllers
 
             var fileIndexItems = SortHelper.Helper(
 	            _query.DisplayFileFolders(subPath, colorClassActiveList,
-		            collections, hidedelete), sort);
+		            collections, hidedelete), sort).ToList();
+            var fileIndexItemsWithoutCollections = _query.DisplayFileFolders(
+	            subPath, null, false, hidedelete).ToList();
             
             // (singleItem.IsDirectory) or not found
             var directoryModel = new ArchiveViewModel
@@ -76,11 +78,10 @@ namespace starsky.Controllers
                 Breadcrumb = Breadcrumbs.BreadcrumbHelper(subPath),
                 SearchQuery = subPath.Split("/").LastOrDefault(),
                 SubPath = subPath,
-                CollectionsCount = _query.DisplayFileFolders(
-	                subPath,null,false,hidedelete).
+                CollectionsCount = fileIndexItemsWithoutCollections.
 	                Count(p => p.IsDirectory == false),
-                ColorClassUsage = _query.DisplayFileFolders(
-	                subPath,null,false,hidedelete)
+                // when change colorclass selection you should see all options
+                ColorClassUsage = fileIndexItemsWithoutCollections
 	                .Select( p => p.ColorClass).Distinct()
 	                .OrderBy(p => (int) (p)).ToList(),
                 IsReadOnly =  _appSettings.IsReadOnly(subPath),

--- a/starsky/starsky/Controllers/SyncController.cs
+++ b/starsky/starsky/Controllers/SyncController.cs
@@ -201,11 +201,10 @@ namespace starsky.Controllers
 		    // When all items are not found
 		    if (rename.All(p => p.Status != FileIndexItem.ExifStatus.Ok))
 			    return NotFound(rename);
-
 		    await _connectionsService.SendToAllAsync(JsonSerializer.Serialize(rename,
 			    DefaultJsonSerializer.CamelCase), CancellationToken.None);
 
-			return Json(rename);
+			return Json(rename.Where(p => p.Status != FileIndexItem.ExifStatus.Deleted));
 		}
 
     }

--- a/starsky/starsky/Controllers/SyncController.cs
+++ b/starsky/starsky/Controllers/SyncController.cs
@@ -204,7 +204,7 @@ namespace starsky.Controllers
 		    await _connectionsService.SendToAllAsync(JsonSerializer.Serialize(rename,
 			    DefaultJsonSerializer.CamelCase), CancellationToken.None);
 
-			return Json(rename.Where(p => p.Status != FileIndexItem.ExifStatus.Deleted));
+			return Json(rename.Where(p => p.Status != FileIndexItem.ExifStatus.Deleted).ToList());
 		}
 
     }

--- a/starsky/starsky/Controllers/SyncController.cs
+++ b/starsky/starsky/Controllers/SyncController.cs
@@ -186,6 +186,7 @@ namespace starsky.Controllers
 	    /// <param name="f">from subPath</param>
 	    /// <param name="to">to subPath</param>
 	    /// <param name="collections">is collections bool</param>
+	    /// <param name="currentStatus">default is to not included files that are removed in result </param>
 	    /// <returns>list of details form changed files (IActionResult Rename)</returns>
 	    /// <response code="200">the item including the updated content</response>
 	    /// <response code="404">item not found in the database or on disk</response>
@@ -194,7 +195,7 @@ namespace starsky.Controllers
 	    [ProducesResponseType(typeof(List<FileIndexItem>),404)]
 		[HttpPost("/api/sync/rename")]
 	    [Produces("application/json")]	    
-		public async Task<IActionResult> Rename(string f, string to, bool collections = true)
+		public async Task<IActionResult> Rename(string f, string to, bool collections = true, bool currentStatus = true)
 	    {
 		    var rename = new RenameService(_query, _iStorage).Rename(f, to, collections);
 		    
@@ -204,8 +205,9 @@ namespace starsky.Controllers
 		    await _connectionsService.SendToAllAsync(JsonSerializer.Serialize(rename,
 			    DefaultJsonSerializer.CamelCase), CancellationToken.None);
 
-			return Json(rename.Where(p => p.Status != FileIndexItem.ExifStatus.Deleted).ToList());
-		}
+		    return Json(currentStatus ? rename.Where(p => p.Status 
+				    != FileIndexItem.ExifStatus.NotFoundSourceMissing).ToList() : rename);
+	    }
 
     }
 }

--- a/starsky/starsky/clientapp/src/components/organisms/modal-force-delete/modal-force-delete.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/modal-force-delete/modal-force-delete.spec.tsx
@@ -75,7 +75,7 @@ describe("ModalForceDelete", () => {
     const fetchSpy = jest
       .spyOn(FetchPost, "default")
       .mockImplementationOnce(async () => {
-        return { statusCode: 404 } as IConnectionDefault;
+        return { statusCode: 500 } as IConnectionDefault;
       });
 
     const dispatch = jest.fn();

--- a/starsky/starsky/clientapp/src/components/organisms/modal-force-delete/modal-force-delete.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/modal-force-delete/modal-force-delete.tsx
@@ -74,7 +74,7 @@ const ModalForceDelete: React.FunctionComponent<IModalForceDeleteProps> = ({
       bodyParams.toString(),
       "delete"
     ).then((result) => {
-      if (result.statusCode === 200) {
+      if (result.statusCode === 200 || result.statusCode === 404) {
         dispatch({ type: "remove", toRemoveFileList: toUndoTrashList });
       }
 

--- a/starsky/starsky/clientapp/src/contexts/archive-context.spec.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.spec.tsx
@@ -3,7 +3,10 @@ import { IArchive, newIArchive, SortType } from "../interfaces/IArchive";
 import { IArchiveProps } from "../interfaces/IArchiveProps";
 import { PageType } from "../interfaces/IDetailView";
 import { IExifStatus } from "../interfaces/IExifStatus";
-import { ImageFormat } from "../interfaces/IFileIndexItem";
+import {
+  ImageFormat,
+  newIFileIndexItemArray
+} from "../interfaces/IFileIndexItem";
 import ArrayHelper from "../shared/array-helper";
 import { FileListCache } from "../shared/filelist-cache";
 import { ArchiveAction, archiveReducer } from "./archive-context";
@@ -233,6 +236,43 @@ describe("ArchiveContext", () => {
 
     // fullpath input
     var action = { type: "remove", toRemoveFileList: ["/test.jpg"] } as any;
+
+    var result = archiveReducer(state, action);
+
+    expect(result.fileIndexItems.length).toBe(0);
+    expect(result.colorClassUsage).toStrictEqual([]);
+  });
+
+  it("add - undefined", () => {
+    var state = { fileIndexItems: newIFileIndexItemArray() } as IArchiveProps;
+
+    // fullpath input
+    var action = { type: "add", add: undefined } as any;
+
+    var result = archiveReducer(state, action);
+
+    expect(result.fileIndexItems.length).toBe(0);
+  });
+
+  it("add - last colorClassUsage is removed", () => {
+    var state = {
+      fileIndexItems: [
+        {
+          filePath: "/test.jpg"
+        }
+      ],
+      colorClassUsage: [1, 2]
+    } as IArchiveProps;
+
+    const add = [
+      {
+        filePath: "/test.jpg",
+        status: IExifStatus.Deleted // <- say its deleted
+      }
+    ];
+
+    // fullpath input
+    var action = { type: "add", add } as any;
 
     var result = archiveReducer(state, action);
 

--- a/starsky/starsky/clientapp/src/contexts/archive-context.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.tsx
@@ -198,7 +198,10 @@ export function archiveReducer(state: State, action: ArchiveAction): State {
 
       // remove deleted items
       for (const deleteItem of Array.from(actionAdd).filter(
-        (value) => value.status === IExifStatus.Deleted
+        (value) =>
+          value.status === IExifStatus.Deleted ||
+          value.status === IExifStatus.NotFoundNotInIndex ||
+          value.status === IExifStatus.NotFoundSourceMissing
       )) {
         const index = fileIndexItems.findIndex(
           (x) => x.filePath === deleteItem.filePath
@@ -209,6 +212,10 @@ export function archiveReducer(state: State, action: ArchiveAction): State {
       }
 
       state = { ...state, fileIndexItems, lastUpdated: new Date() };
+      // when you remove the last item of the directory
+      if (state.fileIndexItems.length === 0) {
+        state.colorClassUsage = [];
+      }
       UpdateColorClassUsageActiveListLoop(state);
       return updateCache(state);
   }

--- a/starsky/starsky/clientapp/src/contexts/archive-context.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.tsx
@@ -169,7 +169,8 @@ export function archiveReducer(state: State, action: ArchiveAction): State {
       const filterOkCondition = (value: IFileIndexItem) => {
         return (
           value.status === IExifStatus.Ok ||
-          value.status === IExifStatus.Default
+          value.status === IExifStatus.Default ||
+          value.status === IExifStatus.OperationNotSupported // pushed when trying to create a map that already exist
         );
       };
 

--- a/starsky/starsky/clientapp/src/contexts/archive-context.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.tsx
@@ -166,6 +166,8 @@ export function archiveReducer(state: State, action: ArchiveAction): State {
         )
       });
     case "add":
+      if (!action.add) return state;
+
       const filterOkCondition = (value: IFileIndexItem) => {
         return (
           value.status === IExifStatus.Ok ||

--- a/starsky/starsky/clientapp/src/interfaces/IExifStatus.ts
+++ b/starsky/starsky/clientapp/src/interfaces/IExifStatus.ts
@@ -6,5 +6,6 @@ export enum IExifStatus {
   NotFoundSourceMissing = "NotFoundSourceMissing" as any,
   ServerError = "ServerError" as any,
   IgnoredAlreadyImported = "IgnoredAlreadyImported" as any,
+  OperationNotSupported = "OperationNotSupported" as any,
   FileError = "FileError" as any
 }

--- a/starsky/starsky/clientapp/src/interfaces/IExifStatus.ts
+++ b/starsky/starsky/clientapp/src/interfaces/IExifStatus.ts
@@ -7,5 +7,6 @@ export enum IExifStatus {
   ServerError = "ServerError" as any,
   IgnoredAlreadyImported = "IgnoredAlreadyImported" as any,
   OperationNotSupported = "OperationNotSupported" as any,
+  NotFoundNotInIndex = "NotFoundNotInIndex" as any,
   FileError = "FileError" as any
 }

--- a/starsky/starskytest/starsky.feature.metaupdate/Services/DeleteItemTest.cs
+++ b/starsky/starskytest/starsky.feature.metaupdate/Services/DeleteItemTest.cs
@@ -267,5 +267,30 @@ namespace starskytest.starsky.feature.metaupdate.Services
 			Assert.AreEqual(0, storage.GetAllFilesInDirectoryRecursive("/").Count());
 			Assert.AreEqual(0, fakeQuery.GetAllRecursive("/").Count);
 		}
+
+
+		[TestMethod]
+		public void Delete_ChildDirectories()
+		{
+			var storage = new FakeIStorage(new List<string> {"/test", "/", "/test/child", "/test/child/child"},
+				new List<string> (),
+				new List<byte[]>());
+			var selectorStorage = new FakeSelectorStorage(storage);
+			
+			var fakeQuery =
+				new FakeIQuery(new List<FileIndexItem> {
+					new FileIndexItem("/test") {IsDirectory = true, Tags = "!delete!"}, 
+					new FileIndexItem("/test/child") {IsDirectory = true}, 
+					new FileIndexItem("/test/child/child") {IsDirectory = true}, 
+				});
+			
+			var deleteItem = new DeleteItem( fakeQuery,new AppSettings(), selectorStorage);
+			var result = deleteItem.Delete("/test", false);
+			
+			Assert.AreEqual(3, result.Count);
+			Assert.AreEqual("/test", result[0].FilePath);
+			Assert.AreEqual("/test/child", result[1].FilePath);
+			Assert.AreEqual("/test/child/child", result[2].FilePath);
+		}
 	}
 }

--- a/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
+++ b/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
@@ -880,6 +880,12 @@ namespace starskytest.starsky.feature.rename.Services
 		}
 
 		[TestMethod]
+		public void RenameFolderToExistingFolderInDatabaseButNotOnDisk()
+		{
+			
+		}
+		
+		[TestMethod]
 		[ExpectedException(typeof(ArgumentNullException))]
 		public void FromFolderToFolder_Null_exception()
 		{


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

- [x]   (Fixed) _Back-end_  When use DeleteItem the child directories are not stored in the database (PR #314)
- [x]   (Fixed) _Back-end_ Give removed items back when using `/api/rename` as status NotFoundSourceMissing (PR #314)
- [x]   (Fixed) _Back-end_ Don't create duplicate database items when there is already a database item in the output folder, but not on disk (PR #314)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [x] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
