### PR TITLE
Issue #347

### DIFF
--- a/history.md
+++ b/history.md
@@ -55,6 +55,8 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Fixed) _Back-end_ Performance improvement by hash size limit (pull/348 issue/345)
 - [x]   (Fixed) _Back-end_ Fix for SQLite exception (pull/348 issue/344)
 - [x]   (Fixed) _Tools_ Make install scripts easier for the server in combination with PM2 (pull/348)
+- [x]   (Fixed) _Back-end_ DbUpdateConcurrencyException save after, instead of nothing (pull #349)
+- [x]   (Fixed) _Back-end_ fix issue where rename did not work in combination with useDiskWatcher (issue #347 pull #349)
 
 # version 0.4.6 - 2021-03-21
 - [x]   (Added) _Front-end_  add prefilled selected option for

--- a/starsky/starsky.foundation.database/Data/ApplicationDbContext.cs
+++ b/starsky/starsky.foundation.database/Data/ApplicationDbContext.cs
@@ -12,7 +12,7 @@ namespace starsky.foundation.database.Data
 		{
 		}
 
-		public DbSet<FileIndexItem> FileIndex { get; set; }
+		public virtual DbSet<FileIndexItem> FileIndex { get; set; }
 		public DbSet<ImportIndexItem> ImportIndex { get; set; }
 
 		public DbSet<User> Users { get; set; }

--- a/starsky/starsky.foundation.database/Interfaces/IQuery.cs
+++ b/starsky/starsky.foundation.database/Interfaces/IQuery.cs
@@ -117,9 +117,15 @@ namespace starsky.foundation.database.Interfaces
         /// <summary>
         /// And remove content from cache
         /// </summary>
-        /// <param name="updateStatusContent"></param>
+        /// <param name="updateStatusContent">list of items</param>
         void RemoveCacheItem(List<FileIndexItem> updateStatusContent);
 
+        /// <summary>
+        /// Single remove content item from cache
+        /// </summary>
+        /// <param name="updateStatusContent">item</param>
+        void RemoveCacheItem(FileIndexItem updateStatusContent);
+        
         /// <summary>
         /// Add Sub Path Folder - Parent Folders
         ///  root(/)

--- a/starsky/starsky.foundation.database/Query/Query.cs
+++ b/starsky/starsky.foundation.database/Query/Query.cs
@@ -381,7 +381,7 @@ namespace starsky.foundation.database.Query
         }
         
         /// <summary>
-        /// Delegate to abstract OriginalValues Settter
+        /// Delegate to abstract OriginalValues Setter
         /// </summary>
         /// <param name="propertyValues"> propertyValues</param>
         internal delegate void OriginalValuesSetValuesDelegate(PropertyValues propertyValues);

--- a/starsky/starsky.foundation.database/Query/Query.cs
+++ b/starsky/starsky.foundation.database/Query/Query.cs
@@ -610,7 +610,8 @@ namespace starsky.foundation.database.Query
 
 		    async Task<FileIndexItem> LocalQuery(ApplicationDbContext context)
 		    {
-			    await context.FileIndex.AddAsync(fileIndexItem);
+			    // only in test case fileIndex is null
+			    if ( context.FileIndex != null ) await context.FileIndex.AddAsync(fileIndexItem);
 			    await context.SaveChangesAsync();
 			    // Fix for: The instance of entity type 'Item' cannot be tracked because
 			    // another instance with the same key value for {'Id'} is already being tracked
@@ -756,14 +757,13 @@ namespace starsky.foundation.database.Query
 	    {
 		    async Task<bool> LocalRemoveDefaultQuery()
 		    {
-			    await LocalRemoveQuery(new InjectServiceScope(_scopeFactory)
-				    .Context());
+			    await LocalRemoveQuery(new InjectServiceScope(_scopeFactory).Context());
 			    return true;
 		    }
 
 		    async Task LocalRemoveQuery(ApplicationDbContext context)
 		    {
-			    context.FileIndex.Remove(updateStatusContent);
+			    context.FileIndex?.Remove(updateStatusContent);
 			    await context.SaveChangesAsync();
 		    }
 

--- a/starsky/starsky.foundation.database/Query/Query.cs
+++ b/starsky/starsky.foundation.database/Query/Query.cs
@@ -214,7 +214,8 @@ namespace starsky.foundation.database.Query
 	        catch ( DbUpdateConcurrencyException concurrencyException)
 	        {
 		        SolveConcurrencyExceptionLoop(concurrencyException.Entries);
-		        await LocalQuery(_context, updateStatusContent);
+		        _logger?.LogInformation("going to save after UpdateItemAsync");
+		        await _context.SaveChangesAsync();
 	        }
             
 	        return updateStatusContent;
@@ -301,33 +302,30 @@ namespace starsky.foundation.database.Query
 		        context.Attach(updateStatusContent).State = EntityState.Modified;
 				context.SaveChanges();
 		        context.Attach(updateStatusContent).State = EntityState.Detached;
+		        CacheUpdateItem(new List<FileIndexItem>{updateStatusContent});
 	        }
 	        
 	        try
 	        {
-		        try
-		        {
-			        LocalUpdateItemQuery(_context);
-		        }
-		        catch ( ObjectDisposedException error)
-		        {
-			        _logger?.LogInformation(error,"catch-ed ObjectDisposedException");
-			        var context = new InjectServiceScope(_scopeFactory).Context();
-			        LocalUpdateItemQuery(context);
-		        }
-		        catch (InvalidOperationException)
-		        {
-			        var context = new InjectServiceScope(_scopeFactory).Context();
-			        LocalUpdateItemQuery(context);
-		        }
+		        LocalUpdateItemQuery(_context);
+	        }
+	        catch ( ObjectDisposedException error)
+	        {
+		        _logger?.LogInformation(error,"catch-ed ObjectDisposedException");
+		        var context = new InjectServiceScope(_scopeFactory).Context();
+		        LocalUpdateItemQuery(context);
+	        }
+	        catch (InvalidOperationException)
+	        {
+		        var context = new InjectServiceScope(_scopeFactory).Context();
+		        LocalUpdateItemQuery(context);
 	        }
 	        catch (DbUpdateConcurrencyException concurrencyException)
 	        {
 		        SolveConcurrencyExceptionLoop(concurrencyException.Entries);
-		        LocalUpdateItemQuery(_context);
+		        _logger?.LogInformation("going to safe after UpdateItem");
+		        _context.SaveChanges();
 	        }
-            
-            CacheUpdateItem(new List<FileIndexItem>{updateStatusContent});
 
             return updateStatusContent;
         }
@@ -367,7 +365,8 @@ namespace starsky.foundation.database.Query
 	        catch (DbUpdateConcurrencyException concurrencyException)
 	        {
 		        SolveConcurrencyExceptionLoop(concurrencyException.Entries);
-		        LocalQuery(_context);
+		        _logger?.LogInformation("going to save UpdateItem for DbUpdateConcurrencyException");
+		        _context.SaveChanges();
 	        }
 	        
 	        CacheUpdateItem(updateStatusContentList);
@@ -747,7 +746,8 @@ namespace starsky.foundation.database.Query
 	        {
 		        _logger?.LogInformation("catch-ed concurrencyException:",concurrencyException);
 		        SolveConcurrencyExceptionLoop(concurrencyException.Entries);
-		        LocalQuery(_context);
+		        _logger?.LogInformation("going to save RemoveItem for DbUpdateConcurrencyException");
+		        _context.SaveChanges();
 	        }
 	        
 	        // remove parent directory cache

--- a/starsky/starsky.foundation.database/Query/Query.cs
+++ b/starsky/starsky.foundation.database/Query/Query.cs
@@ -380,43 +380,48 @@ namespace starsky.foundation.database.Query
 	        }
         }
         
-        internal delegate void OriginalValuesSetValuesDelegate(PropertyValues t);
+        /// <summary>
+        /// Delegate to abstract OriginalValues Settter
+        /// </summary>
+        /// <param name="propertyValues"> propertyValues</param>
+        internal delegate void OriginalValuesSetValuesDelegate(PropertyValues propertyValues);
 
         /// <summary>
+        /// Database concurrency refers to situations in which multiple processes or users access or change the same data in a database at the same time.
         /// @see: https://docs.microsoft.com/en-us/ef/core/saving/concurrency
         /// </summary>
-        /// <param name="entryEntity"></param>
-        /// <param name="proposedValues"></param>
-        /// <param name="databaseValues"></param>
-        /// <param name="entryMetadataName"></param>
-        /// <param name="entryOriginalValuesSetValues"></param>
-        /// <exception cref="NotSupportedException"></exception>
+        /// <param name="entryEntity">item</param>
+        /// <param name="proposedValues">new update</param>
+        /// <param name="databaseValues">old database item</param>
+        /// <param name="entryMetadataName">meta name</param>
+        /// <param name="entryOriginalValuesSetValues">entry item</param>
+        /// <exception cref="NotSupportedException">unknown how to fix</exception>
         internal void SolveConcurrencyException(object entryEntity, 
 	        PropertyValues proposedValues, PropertyValues databaseValues, string entryMetadataName, 
 	        OriginalValuesSetValuesDelegate entryOriginalValuesSetValues)
         {
-	        if (entryEntity is FileIndexItem)
-	        {
-		        foreach (var property in proposedValues.Properties)
-		        {
-			        var proposedValue = proposedValues[property];
-			        proposedValues[property] = proposedValue;
-		        }
-
-		        // Refresh original values to bypass next concurrency check
-		        if ( databaseValues != null )
-		        {
-			        entryOriginalValuesSetValues(databaseValues);
-		        }
-	        }
-	        else
-	        {
+	        if ( !( entryEntity is FileIndexItem ) )
 		        throw new NotSupportedException(
 			        "Don't know how to handle concurrency conflicts for "
 			        + entryMetadataName);
+	        
+	        foreach (var property in proposedValues.Properties)
+	        {
+		        var proposedValue = proposedValues[property];
+		        proposedValues[property] = proposedValue;
+	        }
+
+	        // Refresh original values to bypass next concurrency check
+	        if ( databaseValues != null )
+	        {
+		        entryOriginalValuesSetValues(databaseValues);
 	        }
         }
         
+        /// <summary>
+        /// Is Cache enabled, null object or feature toggle disabled
+        /// </summary>
+        /// <returns>true when enabled</returns>
 	    internal bool IsCacheEnabled()
 	    {
 		    if( _cache == null || _appSettings?.AddMemoryCache == false) return false;

--- a/starsky/starsky.foundation.database/Query/Query.cs
+++ b/starsky/starsky.foundation.database/Query/Query.cs
@@ -259,7 +259,12 @@ namespace starsky.foundation.database.Query
 	        catch ( DbUpdateConcurrencyException concurrencyException)
 	        {
 		        SolveConcurrencyExceptionLoop(concurrencyException.Entries);
-		        return await LocalQuery(_context, updateStatusContentList);
+		        _logger?.LogInformation("going to call save changes after DbUpdateConcurrencyException");
+		        await _context.SaveChangesAsync();
+
+		        var items = await GetObjectsByFilePathAsync(
+			        updateStatusContentList.Select(p => p.FilePath).ToList());
+		        return items;
 	        }
         }
 

--- a/starsky/starsky/Controllers/SyncController.cs
+++ b/starsky/starsky/Controllers/SyncController.cs
@@ -197,7 +197,7 @@ namespace starsky.Controllers
 	    [Produces("application/json")]	    
 		public async Task<IActionResult> Rename(string f, string to, bool collections = true, bool currentStatus = true)
 	    {
-		    var rename = new RenameService(_query, _iStorage).Rename(f, to, collections);
+		    var rename = await new RenameService(_query, _iStorage).Rename(f, to, collections);
 		    
 		    // When all items are not found
 		    if (rename.All(p => p.Status != FileIndexItem.ExifStatus.Ok))

--- a/starsky/starsky/clientapp/src/components/organisms/menu-archive/menu-archive.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/menu-archive/menu-archive.spec.tsx
@@ -221,6 +221,72 @@ describe("MenuArchive", () => {
       globalHistory.navigate("/");
     });
 
+    it("menu click rename should call dispatch(dir)", () => {
+      globalHistory.navigate("/?f=/test");
+
+      var state = {
+        subPath: "/test",
+        fileIndexItems: [
+          {
+            status: IExifStatus.Ok,
+            filePath: "/trashed/test1.jpg",
+            fileName: "test1.jpg"
+          }
+        ]
+      } as IArchive;
+      const dispatch = jest.fn();
+      var contextValues = { state, dispatch };
+
+      jest
+        .spyOn(ModalArchiveRename, "default")
+        .mockImplementationOnce((props) => {
+          return (
+            <button
+              id="test-btn-fake"
+              onClick={() => props.handleExit("t")}
+            ></button>
+          );
+        });
+
+      jest
+        .spyOn(React, "useContext")
+        .mockImplementationOnce(() => contextValues)
+        .mockImplementationOnce(() => contextValues)
+        .mockImplementationOnce(() => contextValues);
+
+      var component = mount(<MenuArchive>t</MenuArchive>);
+
+      act(() => {
+        component.find('[data-test="rename"]').simulate("click");
+      });
+      act(() => {
+        component.update();
+      });
+
+      act(() => {
+        component.find("#test-btn-fake").simulate("click");
+      });
+
+      expect(dispatch).toBeCalled();
+      expect(dispatch).toBeCalledWith({
+        payload: {
+          fileIndexItems: [
+            {
+              fileName: "test1.jpg",
+              filePath: "/trashed/test1.jpg",
+              status: "Ok"
+            }
+          ],
+          subPath: "t"
+        },
+        type: "force-reset"
+      });
+
+      component.unmount();
+
+      globalHistory.navigate("/");
+    });
+
     it("display options (default menu)", () => {
       jest.spyOn(React, "useContext").mockReset();
 

--- a/starsky/starsky/clientapp/src/components/organisms/menu-archive/menu-archive.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/menu-archive/menu-archive.tsx
@@ -185,17 +185,13 @@ const MenuArchive: React.FunctionComponent<IMenuArchiveProps> = memo(() => {
       {isModalRenameFolder && !isReadOnly && state.subPath !== "/" ? (
         <ModalArchiveRename
           subPath={state.subPath}
-          handleExit={(payload) => {
-            console.log("payload", {
-              ...payload,
-              fileIndexItems: state.fileIndexItems
-            });
-
+          handleExit={(newSubPath) => {
             setModalRenameFolder(!isModalRenameFolder);
-            if (!payload) return;
+            if (!newSubPath) return;
+            // only the path is changed
             dispatch({
               type: "force-reset",
-              payload: { ...payload, fileIndexItems: state.fileIndexItems }
+              payload: { ...state, subPath: newSubPath }
             });
           }}
           isOpen={isModalRenameFolder}

--- a/starsky/starsky/clientapp/src/components/organisms/menu-archive/menu-archive.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/menu-archive/menu-archive.tsx
@@ -185,7 +185,19 @@ const MenuArchive: React.FunctionComponent<IMenuArchiveProps> = memo(() => {
       {isModalRenameFolder && !isReadOnly && state.subPath !== "/" ? (
         <ModalArchiveRename
           subPath={state.subPath}
-          handleExit={() => setModalRenameFolder(!isModalRenameFolder)}
+          handleExit={(payload) => {
+            console.log("payload", {
+              ...payload,
+              fileIndexItems: state.fileIndexItems
+            });
+
+            setModalRenameFolder(!isModalRenameFolder);
+            if (!payload) return;
+            dispatch({
+              type: "force-reset",
+              payload: { ...payload, fileIndexItems: state.fileIndexItems }
+            });
+          }}
           isOpen={isModalRenameFolder}
         />
       ) : null}

--- a/starsky/starsky/clientapp/src/components/organisms/modal-archive-rename/modal-archive-rename.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/modal-archive-rename/modal-archive-rename.tsx
@@ -1,17 +1,20 @@
 import React from "react";
 import useGlobalSettings from "../../../hooks/use-global-settings";
 import useLocation from "../../../hooks/use-location";
+import { IArchiveProps } from "../../../interfaces/IArchiveProps";
+import FetchGet from "../../../shared/fetch-get";
 import FetchPost from "../../../shared/fetch-post";
 import { FileExtensions } from "../../../shared/file-extensions";
 import { FileListCache } from "../../../shared/filelist-cache";
 import { Language } from "../../../shared/language";
+import { URLPath } from "../../../shared/url-path";
 import { UrlQuery } from "../../../shared/url-query";
 import FormControl from "../../atoms/form-control/form-control";
 import Modal from "../../atoms/modal/modal";
 
 interface IModalRenameFolderProps {
   isOpen: boolean;
-  handleExit: Function;
+  handleExit: (state?: IArchiveProps) => void;
   subPath: string;
 }
 
@@ -121,8 +124,12 @@ const ModalArchiveRename: React.FunctionComponent<IModalRenameFolderProps> = (
     );
     await history.navigate(replacePath, { replace: true });
 
+    // and fetch new data
+    const url = new UrlQuery().UrlIndexServerApi(
+      new URLPath().StringToIUrl(replacePath)
+    );
     // Close window
-    props.handleExit();
+    props.handleExit((await FetchGet(url)).data);
   }
 
   return (

--- a/starsky/starsky/clientapp/src/components/organisms/modal-archive-rename/modal-archive-rename.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/modal-archive-rename/modal-archive-rename.tsx
@@ -1,20 +1,17 @@
 import React from "react";
 import useGlobalSettings from "../../../hooks/use-global-settings";
 import useLocation from "../../../hooks/use-location";
-import { IArchiveProps } from "../../../interfaces/IArchiveProps";
-import FetchGet from "../../../shared/fetch-get";
 import FetchPost from "../../../shared/fetch-post";
 import { FileExtensions } from "../../../shared/file-extensions";
 import { FileListCache } from "../../../shared/filelist-cache";
 import { Language } from "../../../shared/language";
-import { URLPath } from "../../../shared/url-path";
 import { UrlQuery } from "../../../shared/url-query";
 import FormControl from "../../atoms/form-control/form-control";
 import Modal from "../../atoms/modal/modal";
 
 interface IModalRenameFolderProps {
   isOpen: boolean;
-  handleExit: (state?: IArchiveProps) => void;
+  handleExit: (state?: string) => void;
   subPath: string;
 }
 
@@ -124,12 +121,8 @@ const ModalArchiveRename: React.FunctionComponent<IModalRenameFolderProps> = (
     );
     await history.navigate(replacePath, { replace: true });
 
-    // and fetch new data
-    const url = new UrlQuery().UrlIndexServerApi(
-      new URLPath().StringToIUrl(replacePath)
-    );
     // Close window
-    props.handleExit((await FetchGet(url)).data);
+    props.handleExit(replacePath);
   }
 
   return (

--- a/starsky/starsky/clientapp/src/contexts/archive-context.spec.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.spec.tsx
@@ -587,6 +587,50 @@ describe("ArchiveContext", () => {
     ]);
   });
 
+  it("add -- change order for raw files", () => {
+    console.log("-change order for raw files");
+
+    // current state
+    var state = {
+      fileIndexItems: newIFileIndexItemArray(),
+      collections: true
+    } as IArchiveProps;
+
+    // to add/remove this
+    var add = [
+      {
+        fileName: "test0.arw",
+        fileCollectionName: "test0",
+        filePath: "/test0.arw",
+        imageFormat: ImageFormat.tiff,
+        status: IExifStatus.Ok
+      },
+      {
+        fileName: "test0.jpg",
+        fileCollectionName: "test0",
+        filePath: "/test0.jpg",
+        imageFormat: ImageFormat.jpg,
+        status: IExifStatus.Ok
+      }
+    ];
+
+    var action = { type: "add", add } as any;
+    var result = archiveReducer(state, action);
+
+    console.log("<--");
+
+    expect(result.fileIndexItems.length).toBe(1);
+    expect(result.fileIndexItems).toStrictEqual([
+      {
+        fileName: "test0.jpg",
+        fileCollectionName: "test0",
+        filePath: "/test0.jpg",
+        imageFormat: "jpg",
+        status: IExifStatus.Ok
+      }
+    ]);
+  });
+
   it("add -- and check if is ordered", () => {
     // current state
     var state = {

--- a/starsky/starsky/clientapp/src/contexts/archive-context.spec.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.spec.tsx
@@ -535,7 +535,8 @@ describe("ArchiveContext", () => {
       {
         fileName: "test0.jpg",
         filePath: "/test0.jpg",
-        status: IExifStatus.Ok
+        status: IExifStatus.Ok,
+        imageFormat: ImageFormat.unknown
       }
     ]);
   });

--- a/starsky/starsky/clientapp/src/contexts/archive-context.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.tsx
@@ -167,8 +167,6 @@ export function archiveReducer(state: State, action: ArchiveAction): State {
           )
         )
       };
-      console.log(forceResetUpdated.colorClassUsage);
-
       return updateCache(forceResetUpdated);
     case "add":
       if (!action.add) return state;

--- a/starsky/starsky/clientapp/src/contexts/archive-context.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.tsx
@@ -158,7 +158,7 @@ export function archiveReducer(state: State, action: ArchiveAction): State {
       };
     case "force-reset":
       // also update the cache
-      return updateCache({
+      const forceResetUpdated = {
         ...action.payload,
         fileIndexItems: sorter(
           new ArrayHelper().UniqueResults(
@@ -166,10 +166,13 @@ export function archiveReducer(state: State, action: ArchiveAction): State {
             "filePath"
           )
         )
-      });
+      };
+      console.log(forceResetUpdated.colorClassUsage);
+
+      return updateCache(forceResetUpdated);
     case "add":
       if (!action.add) return state;
-
+      console.log(state.colorClassUsage);
       const filterOkCondition = (value: IFileIndexItem) => {
         return (
           value.status === IExifStatus.Ok ||
@@ -179,8 +182,11 @@ export function archiveReducer(state: State, action: ArchiveAction): State {
       };
 
       const actionAdd = filterColorClassBeforeAdding(state, action.add);
+      console.log("actionAdd", actionAdd);
+
       // when adding items outside current colorclass filter
       if (actionAdd.length === 0) {
+        console.log("--len0");
         new FileListCache().CacheCleanEverything();
         return state;
       }

--- a/starsky/starsky/clientapp/src/contexts/archive-context.tsx
+++ b/starsky/starsky/clientapp/src/contexts/archive-context.tsx
@@ -170,7 +170,6 @@ export function archiveReducer(state: State, action: ArchiveAction): State {
       return updateCache(forceResetUpdated);
     case "add":
       if (!action.add) return state;
-      console.log(state.colorClassUsage);
       const filterOkCondition = (value: IFileIndexItem) => {
         return (
           value.status === IExifStatus.Ok ||
@@ -180,11 +179,9 @@ export function archiveReducer(state: State, action: ArchiveAction): State {
       };
 
       const actionAdd = filterColorClassBeforeAdding(state, action.add);
-      console.log("actionAdd", actionAdd);
 
       // when adding items outside current colorclass filter
       if (actionAdd.length === 0) {
-        console.log("--len0");
         new FileListCache().CacheCleanEverything();
         return state;
       }

--- a/starsky/starskytest/FakeMocks/FakeIQuery.cs
+++ b/starsky/starskytest/FakeMocks/FakeIQuery.cs
@@ -265,6 +265,10 @@ namespace starskytest.FakeMocks
 		{
 		}
 
+		public void RemoveCacheItem(FileIndexItem updateStatusContent)
+		{
+		}
+
 		public async Task AddParentItemsAsync(string subPath)
 		{
 			var path = subPath == "/" || string.IsNullOrEmpty(subPath) ? "/" : PathHelper.RemoveLatestSlash(subPath);

--- a/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
+++ b/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
@@ -559,9 +559,9 @@ namespace starskytest.starsky.feature.rename.Services
 			var toItemJpg = "/child_folder/test_21_edit.jpg";
 			var toItemDng = "/child_folder/test_21_edit.dng";
 
-			_query.AddItem(new FileIndexItem(fromItemJpg));
-			_query.AddItem(new FileIndexItem(fromItemDng));
-			_query.AddParentItemsAsync(fromItemDng).ConfigureAwait(false);
+			await _query.AddItemAsync(new FileIndexItem(fromItemJpg));
+			await _query.AddItemAsync(new FileIndexItem(fromItemDng));
+			await _query.AddParentItemsAsync(fromItemDng);
 			
 			var iStorage = new FakeIStorage(new List<string>{"/","/child_folder","/child_folder2"}, 
 				new List<string>{fromItemJpg, fromItemDng});

--- a/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
+++ b/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
@@ -506,8 +506,8 @@ namespace starskytest.starsky.feature.rename.Services
 		public async Task Rename_MoveFileToRootFolder()
 		{
 			var itemInChildFolderPath = "/child_folder/test_01.jpg";
-			_query.AddItem(new FileIndexItem(itemInChildFolderPath));
-			_query.AddParentItemsAsync(itemInChildFolderPath).ConfigureAwait(false);
+			await _query.AddItemAsync(new FileIndexItem(itemInChildFolderPath));
+			await _query.AddParentItemsAsync(itemInChildFolderPath);
 			var iStorage = new FakeIStorage(new List<string>{"/","/child_folder"}, 
 				new List<string>{"/child_folder/test_01.jpg"});
 

--- a/starsky/starskytest/starsky.foundation.database/QueryTest/QueryUpdateItem_Error.cs
+++ b/starsky/starskytest/starsky.foundation.database/QueryTest/QueryUpdateItem_Error.cs
@@ -250,8 +250,6 @@ namespace starskytest.starsky.foundation.database.QueryTest
 				.Options;
 
 			var scope = CreateNewScopeSqliteException();
-			var context = scope.CreateScope().ServiceProvider
-				.GetService<ApplicationDbContext>();
 
 			var sqLiteFailContext = new SqliteExceptionDbContext(options);
 			Assert.AreEqual(sqLiteFailContext.Count, 0);


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

- [x]   (Fixed) _Back-end_ DbUpdateConcurrencyException save after, instead of nothing (pull #349)
- [x]   (Fixed) _Back-end_ fix issue where rename did not work in combination with useDiskWatcher (issue #347 pull #349)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] C# Unit tests 
- [x] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
