### PR TITLE
Rename service should now work with useDiskwatcher:true && remove floating folders on scan synchronize

### DIFF
--- a/history.md
+++ b/history.md
@@ -59,6 +59,8 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Fixed) _Back-end_ fix issue where rename did not work in combination with useDiskWatcher (issue #347 pull #349)
 - [x]   (Fixed) _Front-end_ input field when using safari you should not break words (pull #359)
 - [x]   (Changed) _Back-end_ Geo CLI downloads now on startup dependencies (Issue #340 / pull #351)
+- [x]   (Fixed)  _Back-end_ Rename service should now work with useDiskWatcher:true (Issue #352 / pull #354)
+- [x]   (Fixed)  _Back-end_ Delete floating folders in database on scan synchronize (pull #354)
 
 # version 0.4.6 - 2021-03-21
 - [x]   (Added) _Front-end_  add prefilled selected option for

--- a/starsky/starsky.feature.rename/Services/RenameService.cs
+++ b/starsky/starsky.feature.rename/Services/RenameService.cs
@@ -461,7 +461,9 @@ namespace starsky.feature.rename.Services
 			if ( !_iStorage.ExistFolder(toParentSubFolder) )
 			{
 				_iStorage.CreateDirectory(toParentSubFolder);
+				fileIndexResultsList.Add(new FileIndexItem(toParentSubFolder){Status = FileIndexItem.ExifStatus.Ok});
 			}
+			
 			_iStorage.FileMove(inputFileSubPath,toFileSubPath);
 			MoveSidecarFile(inputFileSubPath, toFileSubPath);
 			
@@ -481,11 +483,13 @@ namespace starsky.feature.rename.Services
 				});
 				return; //next
 			}
+			// when renaming a folder it should warn the UI that it should remove the source item
+			fileIndexResultsList.Add(new FileIndexItem(inputFileSubPath){Status = FileIndexItem.ExifStatus.NotFoundSourceMissing});
 			
 			// from/input cache should be cleared
 			var inputParentSubFolder = Breadcrumbs.BreadcrumbHelper(inputFileSubPath).LastOrDefault();
 			_query.RemoveCacheParentItem(inputParentSubFolder);
-					
+
 			// clear cache // parentSubFolder (to FileSubPath parents)
 			var toParentSubFolder = Breadcrumbs.BreadcrumbHelper(toFileSubPath).LastOrDefault();
 			_query.RemoveCacheParentItem(toParentSubFolder); 
@@ -496,11 +500,9 @@ namespace starsky.feature.rename.Services
 			await SaveToDatabaseAsync(fileIndexItems, fileIndexResultsList,
 				detailView, toFileSubPath);
 			
+			// First update database and then update for diskwatcher
 			_iStorage.FileMove(inputFileSubPath, toFileSubPath);
 			MoveSidecarFile(inputFileSubPath, toFileSubPath);
-			
-			// when renaming a folder it should warn the UI that it should remove the source item
-			fileIndexResultsList.Add(new FileIndexItem(inputFileSubPath){Status = FileIndexItem.ExifStatus.NotFoundSourceMissing});
 		}
 
     }

--- a/starsky/starsky.feature.rename/Services/RenameService.cs
+++ b/starsky/starsky.feature.rename/Services/RenameService.cs
@@ -65,7 +65,7 @@ namespace starsky.feature.rename.Services
 				else if ( inputFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Folder 
 					&& toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Folder)
 				{
-					FromFolderToFolder(inputFileSubPath, toFileSubPath, fileIndexItems);
+					await FromFolderToFolder(inputFileSubPath, toFileSubPath, fileIndexItems,fileIndexResultsList, detailView);
 				}
 				else if ( inputFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.File 
 				          && toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.File)
@@ -363,9 +363,13 @@ namespace starsky.feature.rename.Services
 		/// <param name="inputFileSubPath">from path</param>
 		/// <param name="toFileSubPath">to path</param>
 		/// <param name="fileIndexItems">list of results</param>
+		/// <param name="fileIndexResultsList"></param>
+		/// <param name="detailView"></param>
 		/// <exception cref="ArgumentNullException">fileIndexItems is null</exception>
-		internal async Task FromFolderToFolder(string inputFileSubPath, string toFileSubPath,
-			List<FileIndexItem> fileIndexItems)
+		internal async Task FromFolderToFolder(string inputFileSubPath, 
+			string toFileSubPath, List<FileIndexItem> fileIndexItems, 
+			List<FileIndexItem> fileIndexResultsList, DetailView detailView)
+
 		{
 			if ( fileIndexItems == null ) throw new ArgumentNullException(nameof(fileIndexItems), 
 				"Should contain value");
@@ -385,7 +389,7 @@ namespace starsky.feature.rename.Services
 			
 			// Replace all Recursive items in Query
 			// Does only replace in existing database items
-			fileIndexItems = _query.GetAllRecursive(inputFileSubPath);
+			fileIndexItems = await _query.GetAllRecursiveAsync(inputFileSubPath);
 					
 			// Rename child items
 			fileIndexItems.ForEach(p =>
@@ -399,7 +403,6 @@ namespace starsky.feature.rename.Services
 			// save before changing on disk
 			await SaveToDatabaseAsync(fileIndexItems, fileIndexResultsList,
 				detailView, toFileSubPath);
-
 			
 			// rename child folders
 			foreach ( var inputChildFolder in directChildFolders )

--- a/starsky/starsky.feature.rename/Services/RenameService.cs
+++ b/starsky/starsky.feature.rename/Services/RenameService.cs
@@ -451,6 +451,7 @@ namespace starsky.feature.rename.Services
 			// Check if the parent folder exist in the database
 			await _query.AddParentItemsAsync(toParentSubFolder);
 
+			// Save in database before change on disk
 			await SaveToDatabaseAsync(fileIndexItems, fileIndexResultsList,
 				detailView, toFileSubPath);
 					

--- a/starsky/starsky.feature.rename/Services/RenameService.cs
+++ b/starsky/starsky.feature.rename/Services/RenameService.cs
@@ -39,14 +39,18 @@ namespace starsky.feature.rename.Services
 			for (var i = 0; i < toFileSubPaths.Length; i++)
 			{
 				// options
-				// 1. file to direct folder file.jpg /folder/ (not covered)
-				// 2. folder to folder (not covered)
-				// 3. folder with child folders to folder (not covered)
-				// 4. folder merge parent folder with current folder (not covered), /test/ => /test/test/
-				// 5. folder to existing folder > merge (not covered)
-				// 6. file to file
-				// 7. file to existing file > skip
-
+				// 1. FromFolderToDeleted:
+				//		folder rename
+				// 2. FromFolderToFolder:
+				//		folder with child folders to folder
+				// 3. Not named
+				//		file to file
+				//		- overwrite a file is not supported
+				// 4. FromFileToDeleted:
+				//		rename a file to new location
+				// 5. FromFileToFolder:
+				//		file to direct folder file.jpg  -> /folder/ 
+				// 6. folder merge parent folder with current folder (not covered), /test/ => /test/test/
 				
 				var inputFileSubPath = inputFileSubPaths[i];
 				var toFileSubPath = toFileSubPaths[i];

--- a/starsky/starsky.feature.rename/Services/RenameService.cs
+++ b/starsky/starsky.feature.rename/Services/RenameService.cs
@@ -57,38 +57,31 @@ namespace starsky.feature.rename.Services
 				var toFileFolderStatus = _iStorage.IsFolderOrFile(toFileSubPath);
 
 				var fileIndexItems = new List<FileIndexItem>();
-				if ( inputFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Folder 
-				     && toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Deleted)
+				switch ( inputFileFolderStatus )
 				{
-					await FromFolderToDeleted(inputFileSubPath, toFileSubPath, fileIndexResultsList, detailView);
-				}
-				else if ( inputFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Folder 
-					&& toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Folder)
-				{
-					await FromFolderToFolder(inputFileSubPath, toFileSubPath, fileIndexResultsList, detailView);
-				}
-				else if ( inputFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.File 
-				          && toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.File)
-				{
-					// overwrite a file is not supported
-					fileIndexResultsList.Add(new FileIndexItem
-					{
-						Status = FileIndexItem.ExifStatus.OperationNotSupported
-					});
-				}
-				else if ( inputFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.File
-				          && toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Deleted) 
-				{
-					// toFileSubPath should contain the full subPath
-					await FromFileToDeleted(inputFileSubPath, toFileSubPath, 
-						fileIndexResultsList, fileIndexItems, detailView);
-				}
-				else if ( inputFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.File
-				          && toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Folder )
-				{
-					toFileSubPath = GetFileName(toFileSubPath, inputFileSubPath);
-					// toFileSubPath must be the to copy directory, the filename is kept the same
-					await FromFileToFolder(inputFileSubPath, toFileSubPath, fileIndexResultsList, fileIndexItems, detailView);
+					case FolderOrFileModel.FolderOrFileTypeList.Folder when toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Deleted:
+						await FromFolderToDeleted(inputFileSubPath, toFileSubPath, fileIndexResultsList, detailView);
+						break;
+					case FolderOrFileModel.FolderOrFileTypeList.Folder when toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Folder:
+						await FromFolderToFolder(inputFileSubPath, toFileSubPath, fileIndexResultsList, detailView);
+						break;
+					case FolderOrFileModel.FolderOrFileTypeList.File when toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.File:
+						// overwrite a file is not supported
+						fileIndexResultsList.Add(new FileIndexItem
+						{
+							Status = FileIndexItem.ExifStatus.OperationNotSupported
+						});
+						break;
+					case FolderOrFileModel.FolderOrFileTypeList.File when toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Deleted:
+						// toFileSubPath should contain the full subPath
+						await FromFileToDeleted(inputFileSubPath, toFileSubPath, 
+							fileIndexResultsList, fileIndexItems, detailView);
+						break;
+					case FolderOrFileModel.FolderOrFileTypeList.File when toFileFolderStatus == FolderOrFileModel.FolderOrFileTypeList.Folder:
+						toFileSubPath = GetFileName(toFileSubPath, inputFileSubPath);
+						// toFileSubPath must be the to copy directory, the filename is kept the same
+						await FromFileToFolder(inputFileSubPath, toFileSubPath, fileIndexResultsList, fileIndexItems, detailView);
+						break;
 				} 
 			}
 	        return fileIndexResultsList;

--- a/starsky/starsky.foundation.database/Interfaces/IQuery.cs
+++ b/starsky/starsky.foundation.database/Interfaces/IQuery.cs
@@ -70,9 +70,25 @@ namespace starsky.foundation.database.Interfaces
             bool hideDeleted = true, 
             SortType sort = SortType.FileName);
         
+        /// <summary>
+        /// Get FirstOrDefault for that filePath
+        /// </summary>
+        /// <param name="filePath">subPath style</param>
+        /// <returns>item</returns>
         FileIndexItem GetObjectByFilePath(string filePath);
+        
+        /// <summary>
+        /// Get FirstOrDefault for that filePath
+        /// </summary>
+        /// <param name="filePath">subPath style</param>
+        /// <returns>item</returns>
         Task<FileIndexItem> GetObjectByFilePathAsync(string filePath);
 
+        /// <summary>
+        /// Get FirstOrDefault for that filePath list
+        /// </summary>
+        /// <param name="filePathList">subPath style list</param>
+        /// <returns>items</returns>
         Task<List<FileIndexItem>> GetObjectsByFilePathAsync(List<string> filePathList);
 
         FileIndexItem RemoveItem(FileIndexItem updateStatusContent);
@@ -87,8 +103,21 @@ namespace starsky.foundation.database.Interfaces
         string GetSubPathByHash(string fileHash);
 	    void ResetItemByHash(string fileHash);
 
+	    /// <summary>
+	    /// Only global search for all folder
+	    /// </summary>
+	    /// <returns></returns>
         List<FileIndexItem> GetAllFolders();
 
+	    /// <summary>
+	    /// 
+	    /// </summary>
+	    /// <param name="subPath"></param>
+	    /// <returns></returns>
+	    Task<List<FileIndexItem>> GetAllObjectsAsync(string subPath);
+
+	    Task<List<FileIndexItem>> GetAllObjectsAsync(List<string> filePaths);
+	    
         FileIndexItem AddItem(FileIndexItem updateStatusContent);
         Task<FileIndexItem> AddItemAsync(FileIndexItem fileIndexItem);
 

--- a/starsky/starsky.foundation.database/Interfaces/IQuery.cs
+++ b/starsky/starsky.foundation.database/Interfaces/IQuery.cs
@@ -109,14 +109,7 @@ namespace starsky.foundation.database.Interfaces
 	    /// <returns></returns>
         List<FileIndexItem> GetAllFolders();
 
-	    /// <summary>
-	    /// 
-	    /// </summary>
-	    /// <param name="subPath"></param>
-	    /// <returns></returns>
-	    Task<List<FileIndexItem>> GetAllObjectsAsync(string subPath);
-
-	    Task<List<FileIndexItem>> GetAllObjectsAsync(List<string> filePaths);
+	    Task<List<FileIndexItem>> GetFoldersAsync(string subPath);
 	    
         FileIndexItem AddItem(FileIndexItem updateStatusContent);
         Task<FileIndexItem> AddItemAsync(FileIndexItem fileIndexItem);

--- a/starsky/starsky.foundation.database/Interfaces/IQuery.cs
+++ b/starsky/starsky.foundation.database/Interfaces/IQuery.cs
@@ -110,6 +110,9 @@ namespace starsky.foundation.database.Interfaces
         List<FileIndexItem> GetAllFolders();
 
 	    Task<List<FileIndexItem>> GetFoldersAsync(string subPath);
+
+	    Task<List<FileIndexItem>> GetAllObjectsAsync(string subPath);
+	    Task<List<FileIndexItem>> GetAllObjectsAsync(List<string> filePaths);
 	    
         FileIndexItem AddItem(FileIndexItem updateStatusContent);
         Task<FileIndexItem> AddItemAsync(FileIndexItem fileIndexItem);

--- a/starsky/starsky.foundation.database/Query/QueryFolder.cs
+++ b/starsky/starsky.foundation.database/Query/QueryFolder.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using starsky.foundation.database.Data;
 using starsky.foundation.database.Models;
@@ -15,6 +17,7 @@ namespace starsky.foundation.database.Query
         /// Query all FileIndexItems with the type folder
         /// </summary>
         /// <returns>List of all folders in database, including content</returns>
+        [Obsolete("replace by async variant")]
         public List<FileIndexItem> GetAllFolders()
         {
 	        try

--- a/starsky/starsky.foundation.database/Query/QueryFolder.cs
+++ b/starsky/starsky.foundation.database/Query/QueryFolder.cs
@@ -15,7 +15,6 @@ namespace starsky.foundation.database.Query
         /// Query all FileIndexItems with the type folder
         /// </summary>
         /// <returns>List of all folders in database, including content</returns>
-        [Obsolete("replace by async variant")]
         public List<FileIndexItem> GetAllFolders()
         {
 	        try

--- a/starsky/starsky.foundation.database/Query/QueryFolder.cs
+++ b/starsky/starsky.foundation.database/Query/QueryFolder.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using starsky.foundation.database.Data;
 using starsky.foundation.database.Models;

--- a/starsky/starsky.foundation.database/Query/QueryGetAllObjects.cs
+++ b/starsky/starsky.foundation.database/Query/QueryGetAllObjects.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using starsky.foundation.database.Data;
+using starsky.foundation.database.Helpers;
+using starsky.foundation.database.Interfaces;
+using starsky.foundation.database.Models;
+using starsky.foundation.platform.Helpers;
+
+namespace starsky.foundation.database.Query
+{
+	/// <summary>
+	/// QueryGetAllObjects
+	/// </summary>
+	public partial class Query : IQuery
+	{
+
+		public async Task<List<FileIndexItem>> GetAllObjectsAsync(string subPath)
+		{
+			return await GetAllObjectsAsync(new List<string> {subPath});
+		}
+
+		public async Task<List<FileIndexItem>> GetAllObjectsAsync(List<string> filePaths)
+		{
+			try
+			{
+				return FormatOk(await GetAllObjectsQuery(_context, filePaths).ToListAsync());
+			}
+			catch ( ObjectDisposedException )
+			{
+				return FormatOk(await GetAllObjectsQuery(new InjectServiceScope(_scopeFactory).Context(),filePaths).ToListAsync());
+			}
+		}
+		
+		private IOrderedQueryable<FileIndexItem> GetAllObjectsQuery(ApplicationDbContext context, List<string> filePathList)
+		{
+			var predicates = new List<Expression<Func<FileIndexItem,bool>>>();  
+
+			// ReSharper disable once ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator
+			foreach ( var filePath in filePathList )
+			{
+				var subPath = PathHelper.RemoveLatestSlash(filePath);
+				if ( filePath == "/" ) subPath = "/";
+				predicates.Add(p => p.ParentDirectory == subPath);
+			}
+				
+			var predicate = PredicateBuilder.OrLoop(predicates);
+					
+			return context.FileIndex.Where(predicate).OrderBy(r => r.FileName);
+		}
+	}
+}

--- a/starsky/starsky.foundation.database/Query/QueryGetFoldersAsync.cs
+++ b/starsky/starsky.foundation.database/Query/QueryGetFoldersAsync.cs
@@ -13,28 +13,28 @@ using starsky.foundation.platform.Helpers;
 namespace starsky.foundation.database.Query
 {
 	/// <summary>
-	/// QueryGetAllObjects
+	/// QueryGetFoldersAsync
 	/// </summary>
 	public partial class Query : IQuery
 	{
-		public async Task<List<FileIndexItem>> GetAllObjectsAsync(string subPath)
+		public async Task<List<FileIndexItem>> GetFoldersAsync(string subPath)
 		{
-			return await GetAllObjectsAsync(new List<string> {subPath});
+			return await GetFoldersAsync(new List<string> {subPath});
 		}
 
-		public async Task<List<FileIndexItem>> GetAllObjectsAsync(List<string> filePaths)
+		public async Task<List<FileIndexItem>> GetFoldersAsync(List<string> filePaths)
 		{
 			try
 			{
-				return FormatOk(await GetAllObjectsQuery(_context, filePaths).ToListAsync());
+				return FormatOk(await GetAllFoldersQuery(_context, filePaths).ToListAsync());
 			}
 			catch ( ObjectDisposedException )
 			{
-				return FormatOk(await GetAllObjectsQuery(new InjectServiceScope(_scopeFactory).Context(),filePaths).ToListAsync());
+				return FormatOk(await GetAllFoldersQuery(new InjectServiceScope(_scopeFactory).Context(),filePaths).ToListAsync());
 			}
 		}
 		
-		private IOrderedQueryable<FileIndexItem> GetAllObjectsQuery(ApplicationDbContext context, List<string> filePathList)
+		private IOrderedQueryable<FileIndexItem> GetAllFoldersQuery(ApplicationDbContext context, List<string> filePathList)
 		{
 			var predicates = new List<Expression<Func<FileIndexItem,bool>>>();  
 
@@ -43,7 +43,7 @@ namespace starsky.foundation.database.Query
 			{
 				var subPath = PathHelper.RemoveLatestSlash(filePath);
 				if ( filePath == "/" ) subPath = "/";
-				predicates.Add(p => p.ParentDirectory == subPath);
+				predicates.Add(p => p.ParentDirectory == subPath && p.IsDirectory == true);
 			}
 				
 			var predicate = PredicateBuilder.OrLoop(predicates);

--- a/starsky/starskytest/Controllers/SyncControllerTest.cs
+++ b/starsky/starskytest/Controllers/SyncControllerTest.cs
@@ -282,8 +282,8 @@ namespace starskytest.Controllers
 			var result = await controller.Rename(_createAnImage.DbPath, "/test.jpg", true, false) as JsonResult;
 			var list = result.Value as List<FileIndexItem>;
 
-			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing,list[0].Status);
-			Assert.AreEqual(FileIndexItem.ExifStatus.Ok,list[1].Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok,list[0].Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing,list[1].Status);
 
 			await _query.RemoveItemAsync(await _query.GetObjectByFilePathAsync("/test.jpg"));
 		}

--- a/starsky/starskytest/FakeMocks/FakeIQuery.cs
+++ b/starsky/starskytest/FakeMocks/FakeIQuery.cs
@@ -186,9 +186,14 @@ namespace starskytest.FakeMocks
 			return _fakeContext.Where(p => p.IsDirectory == true).ToList();
 		}
 
+		public Task<List<FileIndexItem>> GetFoldersAsync(string subPath)
+		{
+			return Task.FromResult(_fakeContext.Where(p => p.ParentDirectory == subPath && p.IsDirectory == true).ToList());
+		}
+
 		public Task<List<FileIndexItem>> GetAllObjectsAsync(string subPath)
 		{
-			return Task.FromResult(_fakeContext.Where(p => p.ParentDirectory == subPath && p.IsDirectory == false).ToList());
+			return Task.FromResult(_fakeContext.Where(p => p.ParentDirectory == subPath).ToList());
 		}
 
 		public async Task<List<FileIndexItem>> GetAllObjectsAsync(List<string> filePaths)

--- a/starsky/starskytest/FakeMocks/FakeIQuery.cs
+++ b/starsky/starskytest/FakeMocks/FakeIQuery.cs
@@ -186,6 +186,16 @@ namespace starskytest.FakeMocks
 			return _fakeContext.Where(p => p.IsDirectory == true).ToList();
 		}
 
+		public Task<List<FileIndexItem>> GetAllObjectsAsync(string subPath)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task<List<FileIndexItem>> GetAllObjectsAsync(List<string> filePaths)
+		{
+			throw new NotImplementedException();
+		}
+
 		public FileIndexItem AddItem(FileIndexItem updateStatusContent)
 		{
 			_fakeContext.Add(updateStatusContent);

--- a/starsky/starskytest/FakeMocks/FakeIQuery.cs
+++ b/starsky/starskytest/FakeMocks/FakeIQuery.cs
@@ -188,12 +188,17 @@ namespace starskytest.FakeMocks
 
 		public Task<List<FileIndexItem>> GetAllObjectsAsync(string subPath)
 		{
-			throw new NotImplementedException();
+			return Task.FromResult(_fakeContext.Where(p => p.ParentDirectory == subPath && p.IsDirectory == false).ToList());
 		}
 
-		public Task<List<FileIndexItem>> GetAllObjectsAsync(List<string> filePaths)
+		public async Task<List<FileIndexItem>> GetAllObjectsAsync(List<string> filePaths)
 		{
-			throw new NotImplementedException();
+			var result = new List<FileIndexItem>();
+			foreach ( var subPath in filePaths )
+			{
+				result.AddRange(await GetAllObjectsAsync(subPath));
+			}
+			return result;
 		}
 
 		public FileIndexItem AddItem(FileIndexItem updateStatusContent)

--- a/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
+++ b/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
@@ -578,11 +578,18 @@ namespace starskytest.starsky.feature.rename.Services
 			Assert.IsTrue(iStorage.ExistFile(toItemJpg));
 			Assert.IsTrue(iStorage.ExistFile(toItemDng));
 			
-			// and the result is ok
-			Assert.AreEqual(toItemJpg, renameFs[0].FilePath);
-			Assert.AreEqual(toItemDng, renameFs[1].FilePath);
+			var toItemJpgItem = renameFs
+				.FirstOrDefault(p => p.FilePath == toItemJpg);
+			var toItemDngItem = renameFs
+				.FirstOrDefault(p => p.FilePath == toItemDng);
+			
+			Assert.AreEqual(toItemJpg, toItemJpgItem.FilePath);
+			Assert.AreEqual(toItemDng, toItemDngItem.FilePath);
 
-			// and the database is ok
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok, toItemJpgItem.Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok, toItemDngItem.Status);
+			
+			// // and the database is ok
 			Assert.AreEqual(toItemJpg, 
 				_query.SingleItem(toItemJpg).FileIndexItem.FilePath);
 			Assert.AreEqual(toItemDng, 
@@ -901,8 +908,19 @@ namespace starskytest.starsky.feature.rename.Services
 			
 			Assert.AreEqual(1, countTargetFolder.Count);
 			
-			Assert.AreEqual("/source_folder", renameFs[0].FilePath);
-			Assert.AreEqual("/target_folder_3", renameFs[1].FilePath);
+			Assert.AreEqual("/source_folder", renameFs[1].FilePath);
+			Assert.AreEqual("/target_folder_3", renameFs[0].FilePath);
+			
+			var sourceFolder = renameFs
+				.FirstOrDefault(p => p.FilePath == "/source_folder");
+			var targetFolder = renameFs
+				.FirstOrDefault(p => p.FilePath == "/target_folder_3");
+			
+			Assert.AreEqual("/source_folder", sourceFolder.FilePath);
+			Assert.AreEqual("/target_folder_3", targetFolder.FilePath);
+
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing, sourceFolder.Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok, targetFolder.Status);
 		}
 		
 		[TestMethod]
@@ -937,17 +955,29 @@ namespace starskytest.starsky.feature.rename.Services
 				.Where(p => p.FilePath == "/target_folder_4").ToList();
 			
 			Assert.AreEqual(1, countTargetFolder.Count);
+
+			var sourceFolder = renameFs
+				.FirstOrDefault(p => p.FilePath == "/source_folder_2");
+			var targetFile = renameFs
+				.FirstOrDefault(p => p.FilePath == "/target_folder_4/test.jpg");
+			var targetFolder = renameFs
+				.FirstOrDefault(p => p.FilePath == "/target_folder_4");
 			
-			Assert.AreEqual("/source_folder_2", renameFs[0].FilePath);
-			Assert.AreEqual( "/target_folder_4/test.jpg", renameFs[1].FilePath);
-			Assert.AreEqual( "/target_folder_4", renameFs[2].FilePath);
+			Assert.AreEqual("/source_folder_2", sourceFolder.FilePath);
+			Assert.AreEqual("/target_folder_4/test.jpg", targetFile.FilePath);
+			Assert.AreEqual("/target_folder_4", targetFolder.FilePath);
+
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing, sourceFolder.Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok, targetFile.Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok, targetFolder.Status);
 		}
 		
 		[TestMethod]
 		[ExpectedException(typeof(ArgumentNullException))]
-		public void FromFolderToFolder_Null_exception()
+		public async Task FromFolderToFolder_Null_exception()
 		{
-			new RenameService(null, null).FromFolderToFolder(null, null, null);
+			await new RenameService(null, null).FromFolderToFolder(null, 
+				null, null,null);
 			// expect exception
 		}
 

--- a/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
+++ b/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
@@ -282,9 +282,9 @@ namespace starskytest.starsky.feature.rename.Services
 			Assert.AreEqual("/exist/.starsky.test2.jpg.json", 
 				values.FirstOrDefault(p => p == "/exist/.starsky.test2.jpg.json"));
 			Assert.AreEqual(FileIndexItem.ExifStatus.Ok, 
-				renameFs.FirstOrDefault(p => p.FilePath == _folderExist.FilePath + "/test2.jpg").Status );
+				renameFs.FirstOrDefault(p => p.FilePath == "/exist/test2.jpg").Status );
 			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing, 
-				renameFs.FirstOrDefault(p => p.FilePath == _fileInExist.FilePath).Status );
+				renameFs.FirstOrDefault(p => p.FilePath == "/exist/file.jpg").Status );
 
 			RemoveFoldersAndFilesInDatabase();
 		}
@@ -478,8 +478,25 @@ namespace starskytest.starsky.feature.rename.Services
 				all2.FirstOrDefault(p => p.FileName == "subfolder" && p.Status != FileIndexItem.ExifStatus.NotFoundSourceMissing).FilePath);
 			Assert.AreEqual("/folder1/subfolder/child.jpg",
 				all2.FirstOrDefault(p => p.FileName == "child.jpg" &&  p.Status != FileIndexItem.ExifStatus.NotFoundSourceMissing).FilePath);
-			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing, renameFs[0].Status );
-			Assert.AreEqual(FileIndexItem.ExifStatus.Ok, renameFs[1].Status );
+			
+			// FileIndexItem.ExifStatus.Ok, /folder1/file.jpg -			
+			// FileIndexItem.ExifStatus.Ok, /folder1
+			// NotFoundSourceMissing /exist
+			
+			var file = renameFs
+				.FirstOrDefault(p => p.FilePath == "/folder1/file.jpg");
+			var folder1 = renameFs
+				.FirstOrDefault(p => p.FilePath == "/folder1");
+			var exist = renameFs
+				.FirstOrDefault(p => p.FilePath == "/exist");
+			
+			Assert.AreEqual("/folder1/file.jpg", file.FilePath);
+			Assert.AreEqual("/folder1", folder1.FilePath);
+			Assert.AreEqual("/exist", exist.FilePath);
+
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok, file.Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok, folder1.Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing, exist.Status);
 
 			await _query.RemoveItemAsync(existSubFolder);
 			await _query.RemoveItemAsync(existSubFolderChildJpg);
@@ -947,9 +964,9 @@ namespace starskytest.starsky.feature.rename.Services
 				new List<string>{"/source_folder_2/test.jpg"}
 				);
 
-			_query.AddItem(
+			await _query.AddItemAsync(
 				new FileIndexItem("/source_folder_2") {IsDirectory = true});
-			_query.AddItem(
+			await _query.AddItemAsync(
 				new FileIndexItem("/source_folder_2/test.jpg"));
 			await _query.AddItemAsync(
 				new FileIndexItem("/target_folder_4") {IsDirectory = true});

--- a/starsky/starskytest/starsky.foundation.database/QueryTest/QueryGetAllFolderAsyncTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/QueryTest/QueryGetAllFolderAsyncTest.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using starsky.foundation.database.Data;
+using starsky.foundation.database.Helpers;
+using starsky.foundation.database.Interfaces;
+using starsky.foundation.database.Models;
+using starsky.foundation.database.Query;
+using starsky.foundation.platform.Helpers;
+using starsky.foundation.platform.Models;
+
+namespace starskytest.starsky.foundation.database.QueryTest
+{
+	[TestClass]
+	public class QueryGetAllFolderAsyncTest
+	{
+		private readonly IMemoryCache _memoryCache;
+		private readonly IQuery _query;
+
+		public QueryGetAllFolderAsyncTest()
+		{
+			var provider = new ServiceCollection()
+				.AddMemoryCache()
+				.BuildServiceProvider();
+			_memoryCache = provider.GetService<IMemoryCache>();
+			var serviceScope = CreateNewScope();
+			var scope = serviceScope.CreateScope();
+			var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+			_query = new Query(dbContext,_memoryCache, 
+				new AppSettings{Verbose = true}, serviceScope);
+		}
+		
+		private IServiceScopeFactory CreateNewScope()
+		{
+			var services = new ServiceCollection();
+			services.AddDbContext<ApplicationDbContext>(options => options.UseInMemoryDatabase(nameof(QueryGetAllFilesTest)));
+			var serviceProvider = services.BuildServiceProvider();
+			return serviceProvider.GetRequiredService<IServiceScopeFactory>();
+		}
+
+		
+		[TestMethod]
+		public async Task QueryGetFoldersAsync_GetResult()
+		{
+			var appSettings = new AppSettings
+			{
+				DatabaseType = AppSettings.DatabaseTypeList.InMemoryDatabase
+			};
+			var dbContext = new SetupDatabaseTypes(appSettings, null).BuilderDbFactory();
+			var query = new Query(dbContext);
+
+			await dbContext.FileIndex.AddAsync(new FileIndexItem("/GetFoldersAsync") {IsDirectory = true});
+			await dbContext.FileIndex.AddAsync(new FileIndexItem("/GetFoldersAsync/test") {IsDirectory = true});
+			await dbContext.FileIndex.AddAsync(new FileIndexItem("/GetFoldersAsync/test.jpg"));
+			await dbContext.FileIndex.AddAsync(new FileIndexItem("/GetFoldersAsync/test/test.jpg"));
+			await dbContext.SaveChangesAsync();
+	        
+			var items = (await query.GetFoldersAsync("/GetFoldersAsync"))
+				.OrderBy(p => p.FileName).ToList();
+
+			Assert.AreEqual(1, items.Count);
+			Assert.AreEqual("/GetFoldersAsync/test", items[0].FilePath);
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok, items[0].Status);
+		}
+		
+		[TestMethod]
+		public async Task QueryGetFoldersAsync_MultiQuery_GetResult()
+		{
+			var appSettings = new AppSettings
+			{
+				DatabaseType = AppSettings.DatabaseTypeList.InMemoryDatabase
+			};
+			var dbContext = new SetupDatabaseTypes(appSettings, null).BuilderDbFactory();
+			var query = new Query(dbContext);
+
+			await dbContext.FileIndex.AddAsync(new FileIndexItem("/GetFolders_multi_01") {IsDirectory = true});
+			await dbContext.FileIndex.AddAsync(new FileIndexItem("/GetFolders_multi_01/test"){IsDirectory = true});
+			await dbContext.FileIndex.AddAsync(new FileIndexItem("/GetFolders_multi_02") {IsDirectory = true});
+			await dbContext.FileIndex.AddAsync(new FileIndexItem("/GetFolders_multi_02/test"){IsDirectory = true});
+			await dbContext.FileIndex.AddAsync(new FileIndexItem("/GetFolders_multi_02/test.jpg"));
+			await dbContext.SaveChangesAsync();
+	        
+			var items = (await query.GetFoldersAsync(
+					new List<string>{
+						"/GetFolders_multi_01",
+						"/GetFolders_multi_02"
+					}))
+				.OrderBy(p => p.FileName).ToList();
+
+			Assert.AreEqual(2, items.Count);
+			Assert.AreEqual("/GetFolders_multi_01/test", items[0].FilePath);
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok, items[0].Status);
+			
+			Assert.AreEqual("/GetFolders_multi_02/test", items[1].FilePath);
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok, items[1].Status);
+		}
+		
+		[TestMethod]
+		public async Task GetFoldersAsync_DisposedItem()
+		{
+			var serviceScope = CreateNewScope();
+			var scope = serviceScope.CreateScope();
+			var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+			var query = new Query(dbContext,_memoryCache, new AppSettings(), serviceScope);
+	        
+			// item sub folder
+			var item = new FileIndexItem("/test_324323423/test_3423434"){IsDirectory = true};
+			await dbContext.FileIndex.AddAsync(item);
+			await dbContext.SaveChangesAsync();
+	        
+			// Important to dispose!
+			await dbContext.DisposeAsync();
+
+			item.Tags = "test";
+			await query.UpdateItemAsync(item);
+
+			var getItem = await query.GetFoldersAsync("/test_324323423");
+			Assert.IsNotNull(getItem);
+			Assert.AreEqual("test", getItem.FirstOrDefault().Tags);
+
+			await query.RemoveItemAsync(getItem.FirstOrDefault());
+		}
+	}
+}
+

--- a/starsky/starskytest/starsky.foundation.sync/SyncServices/SyncFolderTest.cs
+++ b/starsky/starskytest/starsky.foundation.sync/SyncServices/SyncFolderTest.cs
@@ -371,5 +371,28 @@ namespace starskytest.starsky.foundation.sync.SyncServices
 
 			Assert.AreEqual(0,files.Count);
 		}
+		
+				
+		[TestMethod]
+		public async Task RemoveChildItems_Floating_items()
+		{
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk3"){IsDirectory = true});
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk3/test.jpg"));
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk3/test_dir"){IsDirectory = true});
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk3/test_dir/test.jpg"));
+
+			var storage = new FakeIStorage();
+			var syncFolder = new SyncFolder(_appSettings, _query, new FakeSelectorStorage(storage),
+				new ConsoleWrapper());
+
+			var rootItem = await _query.GetObjectByFilePathAsync("/Folder_InDbButNotOnDisk3");
+			var result = await syncFolder.RemoveChildItems(_query, rootItem);
+			
+			Assert.AreEqual("/Folder_InDbButNotOnDisk3", result.FilePath);
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing,result.Status);
+
+			var data = await _query.GetAllRecursiveAsync("/Folder_InDbButNotOnDisk3");
+			Assert.AreEqual(0, data.Count);
+		}
 	}
 }

--- a/starsky/starskytest/starsky.foundation.sync/SyncServices/SyncFolderTest_InMemoryDb.cs
+++ b/starsky/starskytest/starsky.foundation.sync/SyncServices/SyncFolderTest_InMemoryDb.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -101,6 +103,44 @@ namespace starskytest.starsky.foundation.sync.SyncServices
 				_query.SingleItem("/Folder_InDbButNotOnDisk/test.jpg"));
 			Assert.AreEqual(null, 
 				_query.SingleItem("/Folder_InDbButNotOnDisk/test2.jpg"));
+		}
+		
+		[TestMethod]
+		public async Task Folder_InDbButNotOnDisk_Floating_directories()
+		{
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk2/test.jpg"));
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk2/test_dir"){IsDirectory = true});
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk2/test_dir/test.jpg"));
+
+			var storage = new FakeIStorage();
+			var syncFolder = new SyncFolder(_appSettings, _query, new FakeSelectorStorage(storage),
+				new ConsoleWrapper());
+			var result = await syncFolder.Folder("/Folder_InDbButNotOnDisk2");
+
+			
+			Assert.AreEqual("/Folder_InDbButNotOnDisk2/test.jpg", 
+				result.FirstOrDefault(p => p.FilePath == "/Folder_InDbButNotOnDisk2/test.jpg").FilePath);
+			Assert.AreEqual("/Folder_InDbButNotOnDisk2/test_dir",
+				result.FirstOrDefault(p => p.FilePath == "/Folder_InDbButNotOnDisk2/test_dir").FilePath);
+			Assert.AreEqual("/Folder_InDbButNotOnDisk2/test_dir/test.jpg",
+				result.FirstOrDefault(p => p.FilePath == "/Folder_InDbButNotOnDisk2").FilePath);
+
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing,result[0].Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing,result[1].Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing,result[2].Status);
+			
+			var data = await _query.GetAllRecursiveAsync("/Folder_InDbButNotOnDisk2");
+			Assert.AreEqual(0, data.Count);
+			
+			// Check for database
+			Assert.AreEqual(null, 
+				await _query.GetObjectByFilePathAsync("/Folder_InDbButNotOnDisk2"));
+			Assert.AreEqual(null, 
+				await _query.GetObjectByFilePathAsync("/Folder_InDbButNotOnDisk2/test.jpg"));
+			Assert.AreEqual(null, 
+				await _query.GetObjectByFilePathAsync("/Folder_InDbButNotOnDisk2/test_dir/test.jpg"));
+			Assert.AreEqual(null, 
+				await _query.GetObjectByFilePathAsync("/Folder_InDbButNotOnDisk2/test_dir"));
 		}
 	}
 }

--- a/starsky/starskytest/starsky.foundation.sync/SyncServices/SyncFolderTest_InMemoryDb.cs
+++ b/starsky/starskytest/starsky.foundation.sync/SyncServices/SyncFolderTest_InMemoryDb.cs
@@ -111,6 +111,8 @@ namespace starskytest.starsky.foundation.sync.SyncServices
 			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk2/test.jpg"));
 			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk2/test_dir"){IsDirectory = true});
 			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk2/test_dir/test.jpg"));
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk2/test_dir/child"){IsDirectory = true});
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk2/test_dir/child/test.jpg"));
 
 			var storage = new FakeIStorage();
 			var syncFolder = new SyncFolder(_appSettings, _query, new FakeSelectorStorage(storage),
@@ -122,7 +124,7 @@ namespace starskytest.starsky.foundation.sync.SyncServices
 				result.FirstOrDefault(p => p.FilePath == "/Folder_InDbButNotOnDisk2/test.jpg").FilePath);
 			Assert.AreEqual("/Folder_InDbButNotOnDisk2/test_dir",
 				result.FirstOrDefault(p => p.FilePath == "/Folder_InDbButNotOnDisk2/test_dir").FilePath);
-			Assert.AreEqual("/Folder_InDbButNotOnDisk2/test_dir/test.jpg",
+			Assert.AreEqual("/Folder_InDbButNotOnDisk2",
 				result.FirstOrDefault(p => p.FilePath == "/Folder_InDbButNotOnDisk2").FilePath);
 
 			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing,result[0].Status);

--- a/starsky/starskytest/starsky.foundation.sync/SyncServices/SyncFolderTest_InMemoryDb.cs
+++ b/starsky/starskytest/starsky.foundation.sync/SyncServices/SyncFolderTest_InMemoryDb.cs
@@ -144,5 +144,45 @@ namespace starskytest.starsky.foundation.sync.SyncServices
 			Assert.AreEqual(null, 
 				await _query.GetObjectByFilePathAsync("/Folder_InDbButNotOnDisk2/test_dir"));
 		}
+		
+		[TestMethod]
+		public async Task Folder_InDbButNotOnDisk_Floating_directoriesWithinScanDir()
+		{
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk4/test.jpg"));
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk4/test_dir"){IsDirectory = true});
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk4/test_dir/test.jpg"));
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk4/test_dir/child"){IsDirectory = true});
+			await _query.AddItemAsync(new FileIndexItem("/Folder_InDbButNotOnDisk4/test_dir/child/test.jpg"));
+
+			var storage = new FakeIStorage(new List<string>{
+				"/Folder_InDbButNotOnDisk4", 
+				"/Folder_InDbButNotOnDisk4/test_dir"
+			});
+			var syncFolder = new SyncFolder(_appSettings, _query, new FakeSelectorStorage(storage),
+				new ConsoleWrapper());
+			var result = await syncFolder.Folder("/Folder_InDbButNotOnDisk4");
+			
+			Assert.AreEqual("/Folder_InDbButNotOnDisk4/test.jpg", 
+				result.FirstOrDefault(p => p.FilePath == "/Folder_InDbButNotOnDisk4/test.jpg").FilePath);
+			Assert.AreEqual("/Folder_InDbButNotOnDisk4",
+				result.FirstOrDefault(p => p.FilePath == "/Folder_InDbButNotOnDisk4").FilePath);
+
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing,result[0].Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing,result[1].Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing,result[2].Status);
+			
+			var data = await _query.GetAllRecursiveAsync("/Folder_InDbButNotOnDisk4");
+			Assert.AreEqual(1, data.Count);
+			
+			// Check for database
+			Assert.AreEqual("/Folder_InDbButNotOnDisk4", 
+				(await _query.GetObjectByFilePathAsync("/Folder_InDbButNotOnDisk4")).FilePath);
+			Assert.AreEqual("/Folder_InDbButNotOnDisk4/test_dir", 
+				(await _query.GetObjectByFilePathAsync("/Folder_InDbButNotOnDisk4/test_dir")).FilePath);
+			Assert.AreEqual(null, 
+				await _query.GetObjectByFilePathAsync("/Folder_InDbButNotOnDisk4/test_dir/test.jpg"));
+			Assert.AreEqual(null, 
+				await _query.GetObjectByFilePathAsync("/Folder_InDbButNotOnDisk4/test.jpg"));
+		}
 	}
 }


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

- [x]   (Fixed)  _Back-end_ Rename service should now work with useDiskWatcher:true (Issue #352 / pull #354)
- [x]   (Fixed)  _Back-end_ Delete floating folders in database on scan synchronize (pull #354)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
