### PR TITLE
 In select mode press delete key should move to trash in archive view #357 

### DIFF
--- a/history.md
+++ b/history.md
@@ -45,6 +45,7 @@ node starsky-tools/build-tools/app-version-update.js
 
 # version 0.4.8 _(Unreleased)_ - 2021-03-??
 - [x]   (Changed) _Front-end_ Make Archive UI more white & Dark mode UI fixes (PR #358)
+- [x]   (Added) _Front-end_  In select mode press delete key should move to trash in archive & search view (PR #360 / Issue #357)
 
 # version 0.4.7 - 2021-03-11
 - [x]   (Changed) _Back-end_  add cache for health check and timeout for 10 seconds on health calls (PR #332)

--- a/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.spec.tsx
@@ -85,7 +85,7 @@ describe("MenuOptionMoveToTrash", () => {
       component.unmount();
     });
 
-    it("check if when pressing key", () => {
+    it("check if when pressing Delete key", () => {
       jest.spyOn(FetchPost, "default").mockReset();
       var test = {
         ...newIArchive(),
@@ -141,6 +141,7 @@ describe("MenuOptionMoveToTrash", () => {
       });
 
       expect(fetchPostSpy).toBeCalled();
+      // dont know why dispatch is not called
 
       component.unmount();
     });

--- a/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.spec.tsx
@@ -1,6 +1,7 @@
 import { mount, shallow } from "enzyme";
 import React from "react";
 import { act } from "react-dom/test-utils";
+import * as useHotKeys from "../../../hooks/use-keyboard/use-hotkeys";
 import { newIArchive } from "../../../interfaces/IArchive";
 import { IArchiveProps } from "../../../interfaces/IArchiveProps";
 import {
@@ -73,6 +74,57 @@ describe("MenuOptionMoveToTrash", () => {
       await act(async () => {
         await component.find("li").simulate("click");
       });
+
+      expect(fetchPostSpy).toBeCalled();
+      expect(dispatch).toBeCalled();
+      expect(dispatch).toBeCalledWith({
+        toRemoveFileList: ["/test.jpg"],
+        type: "remove"
+      });
+    });
+
+    it("check if when pressing key", async () => {
+      jest.spyOn(FetchPost, "default").mockReset();
+      var test = {
+        ...newIArchive(),
+        fileIndexItems: [
+          {
+            ...newIFileIndexItem(),
+            parentDirectory: "/",
+            fileName: "test.jpg"
+          } as IFileIndexItem
+        ]
+      } as IArchiveProps;
+
+      const mockIConnectionDefault: Promise<IConnectionDefault> = Promise.resolve(
+        {
+          ...newIConnectionDefault(),
+          data: null,
+          statusCode: 200
+        }
+      );
+      var fetchPostSpy = jest
+        .spyOn(FetchPost, "default")
+        .mockImplementationOnce(() => mockIConnectionDefault);
+
+      const useHotkeysSpy = jest
+        .spyOn(useHotKeys, "default")
+        .mockImplementationOnce(() => {
+          return { key: "Delete" };
+        });
+
+      var dispatch = jest.fn();
+      var component = await mount(
+        <MenuOptionMoveToTrash
+          setSelect={jest.fn()}
+          select={["test.jpg"]}
+          isReadOnly={false}
+          state={test}
+          dispatch={dispatch}
+        >
+          t
+        </MenuOptionMoveToTrash>
+      );
 
       expect(fetchPostSpy).toBeCalled();
       expect(dispatch).toBeCalled();

--- a/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.tsx
@@ -86,6 +86,7 @@ const MenuOptionMoveToTrash: React.FunctionComponent<IMenuOptionMoveToTrashProps
      * When pressing delete its moved to the trash
      */
     useHotKeys({ key: "Delete" }, () => {
+      console.log("DEBUG: -delete");
       moveToTrashSelection();
     });
 

--- a/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import { ArchiveAction } from "../../../contexts/archive-context";
 import useGlobalSettings from "../../../hooks/use-global-settings";
 import useHotKeys from "../../../hooks/use-keyboard/use-hotkeys";
@@ -23,90 +23,86 @@ interface IMenuOptionMoveToTrashProps {
 /**
  * Used from Archive and Search
  */
-const MenuOptionMoveToTrash: React.FunctionComponent<IMenuOptionMoveToTrashProps> = ({
-  state,
-  dispatch,
-  select,
-  setSelect,
-  isReadOnly
-}) => {
-  const settings = useGlobalSettings();
-  const language = new Language(settings.language);
+const MenuOptionMoveToTrash: React.FunctionComponent<IMenuOptionMoveToTrashProps> = memo(
+  ({ state, dispatch, select, setSelect, isReadOnly }) => {
+    const settings = useGlobalSettings();
+    const language = new Language(settings.language);
 
-  var undoSelection = () =>
-    new Select(select, setSelect, state, history).undoSelection();
+    var undoSelection = () =>
+      new Select(select, setSelect, state, history).undoSelection();
 
-  const MessageMoveToTrash = language.text(
-    "Verplaats naar prullenmand",
-    "Move to Trash"
-  );
-
-  var history = useLocation();
-
-  async function moveToTrashSelection() {
-    if (!select || isReadOnly) return;
-
-    var toUndoTrashList = new URLPath().MergeSelectFileIndexItem(
-      select,
-      state.fileIndexItems
+    const MessageMoveToTrash = language.text(
+      "Verplaats naar prullenmand",
+      "Move to Trash"
     );
 
-    if (!toUndoTrashList) return;
-    var selectParams = new URLPath().ArrayToCommaSeperatedStringOneParent(
-      toUndoTrashList,
-      ""
-    );
-    if (selectParams.length === 0) return;
+    var history = useLocation();
 
-    var bodyParams = new URLSearchParams();
+    async function moveToTrashSelection() {
+      if (!select || isReadOnly) return;
 
-    bodyParams.append("f", selectParams);
-    bodyParams.set("Tags", "!delete!");
-    bodyParams.set("append", "true");
-    bodyParams.set("Colorclass", "8");
-    bodyParams.set(
-      "collections",
-      (
-        new URLPath().StringToIUrl(history.location.search).collections !==
-        false
-      ).toString()
-    );
+      var toUndoTrashList = new URLPath().MergeSelectFileIndexItem(
+        select,
+        state.fileIndexItems
+      );
 
-    var resultDo = await FetchPost(
-      new UrlQuery().UrlUpdateApi(),
-      bodyParams.toString()
-    );
-    if (resultDo.statusCode !== 404 && resultDo.statusCode !== 200) {
-      return;
+      if (!toUndoTrashList) return;
+      var selectParams = new URLPath().ArrayToCommaSeperatedStringOneParent(
+        toUndoTrashList,
+        ""
+      );
+      if (selectParams.length === 0) return;
+
+      var bodyParams = new URLSearchParams();
+
+      bodyParams.append("f", selectParams);
+      bodyParams.set("Tags", "!delete!");
+      bodyParams.set("append", "true");
+      bodyParams.set("Colorclass", "8");
+      bodyParams.set(
+        "collections",
+        (
+          new URLPath().StringToIUrl(history.location.search).collections !==
+          false
+        ).toString()
+      );
+
+      var resultDo = await FetchPost(
+        new UrlQuery().UrlUpdateApi(),
+        bodyParams.toString()
+      );
+      if (resultDo.statusCode !== 404 && resultDo.statusCode !== 200) {
+        return;
+      }
+
+      undoSelection();
+      dispatch({ type: "remove", toRemoveFileList: toUndoTrashList });
+      ClearSearchCache(history.location.search);
+      // Client side Caching: the order of files in a normal folder has changed
+      new FileListCache().CacheCleanEverything();
     }
 
-    undoSelection();
-    dispatch({ type: "remove", toRemoveFileList: toUndoTrashList });
-    ClearSearchCache(history.location.search);
-    // Client side Caching: the order of files in a normal folder has changed
-    new FileListCache().CacheCleanEverything();
+    /**
+     * When pressing delete its moved to the trash
+     */
+    useHotKeys({ key: "Delete" }, () => {
+      moveToTrashSelection();
+    });
+
+    return (
+      <>
+        {select.length >= 1 ? (
+          <li
+            data-test="trash"
+            className={!isReadOnly ? "menu-option" : "menu-option disabled"}
+            onClick={() => moveToTrashSelection()}
+          >
+            {MessageMoveToTrash}
+          </li>
+        ) : null}
+      </>
+    );
   }
-
-  /**
-   * When pressing delete its moved to the trash
-   */
-  useHotKeys({ key: "Delete" }, () => {
-    moveToTrashSelection();
-  });
-
-  return (
-    <>
-      {select.length >= 1 ? (
-        <li
-          data-test="trash"
-          className={!isReadOnly ? "menu-option" : "menu-option disabled"}
-          onClick={() => moveToTrashSelection()}
-        >
-          {MessageMoveToTrash}
-        </li>
-      ) : null}
-    </>
-  );
-};
+);
 
 export default MenuOptionMoveToTrash;

--- a/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React from "react";
 import { ArchiveAction } from "../../../contexts/archive-context";
 import useGlobalSettings from "../../../hooks/use-global-settings";
 import useHotKeys from "../../../hooks/use-keyboard/use-hotkeys";
@@ -23,87 +23,90 @@ interface IMenuOptionMoveToTrashProps {
 /**
  * Used from Archive and Search
  */
-const MenuOptionMoveToTrash: React.FunctionComponent<IMenuOptionMoveToTrashProps> = memo(
-  ({ state, dispatch, select, setSelect, isReadOnly }) => {
-    const settings = useGlobalSettings();
-    const language = new Language(settings.language);
+const MenuOptionMoveToTrash: React.FunctionComponent<IMenuOptionMoveToTrashProps> = ({
+  state,
+  dispatch,
+  select,
+  setSelect,
+  isReadOnly
+}) => {
+  const settings = useGlobalSettings();
+  const language = new Language(settings.language);
 
-    var undoSelection = () =>
-      new Select(select, setSelect, state, history).undoSelection();
+  var undoSelection = () =>
+    new Select(select, setSelect, state, history).undoSelection();
 
-    const MessageMoveToTrash = language.text(
-      "Verplaats naar prullenmand",
-      "Move to Trash"
+  const MessageMoveToTrash = language.text(
+    "Verplaats naar prullenmand",
+    "Move to Trash"
+  );
+
+  var history = useLocation();
+
+  async function moveToTrashSelection() {
+    if (!select || isReadOnly) return;
+
+    var toUndoTrashList = new URLPath().MergeSelectFileIndexItem(
+      select,
+      state.fileIndexItems
     );
 
-    var history = useLocation();
+    if (!toUndoTrashList) return;
+    var selectParams = new URLPath().ArrayToCommaSeperatedStringOneParent(
+      toUndoTrashList,
+      ""
+    );
+    if (selectParams.length === 0) return;
 
-    async function moveToTrashSelection() {
-      if (!select || isReadOnly) return;
+    var bodyParams = new URLSearchParams();
 
-      var toUndoTrashList = new URLPath().MergeSelectFileIndexItem(
-        select,
-        state.fileIndexItems
-      );
+    bodyParams.append("f", selectParams);
+    bodyParams.set("Tags", "!delete!");
+    bodyParams.set("append", "true");
+    bodyParams.set("Colorclass", "8");
+    bodyParams.set(
+      "collections",
+      (
+        new URLPath().StringToIUrl(history.location.search).collections !==
+        false
+      ).toString()
+    );
 
-      if (!toUndoTrashList) return;
-      var selectParams = new URLPath().ArrayToCommaSeperatedStringOneParent(
-        toUndoTrashList,
-        ""
-      );
-      if (selectParams.length === 0) return;
-
-      var bodyParams = new URLSearchParams();
-
-      bodyParams.append("f", selectParams);
-      bodyParams.set("Tags", "!delete!");
-      bodyParams.set("append", "true");
-      bodyParams.set("Colorclass", "8");
-      bodyParams.set(
-        "collections",
-        (
-          new URLPath().StringToIUrl(history.location.search).collections !==
-          false
-        ).toString()
-      );
-
-      var resultDo = await FetchPost(
-        new UrlQuery().UrlUpdateApi(),
-        bodyParams.toString()
-      );
-      if (resultDo.statusCode !== 404 && resultDo.statusCode !== 200) {
-        return;
-      }
-
-      undoSelection();
-      dispatch({ type: "remove", toRemoveFileList: toUndoTrashList });
-      ClearSearchCache(history.location.search);
-      // Client side Caching: the order of files in a normal folder has changed
-      new FileListCache().CacheCleanEverything();
+    var resultDo = await FetchPost(
+      new UrlQuery().UrlUpdateApi(),
+      bodyParams.toString()
+    );
+    if (resultDo.statusCode !== 404 && resultDo.statusCode !== 200) {
+      return;
     }
 
-    /**
-     * When pressing delete its moved to the trash
-     */
-    useHotKeys({ key: "Delete" }, () => {
-      console.log("DEBUG: -delete");
-      moveToTrashSelection();
-    });
-
-    return (
-      <>
-        {select.length >= 1 ? (
-          <li
-            data-test="trash"
-            className={!isReadOnly ? "menu-option" : "menu-option disabled"}
-            onClick={() => moveToTrashSelection()}
-          >
-            {MessageMoveToTrash}
-          </li>
-        ) : null}
-      </>
-    );
+    undoSelection();
+    dispatch({ type: "remove", toRemoveFileList: toUndoTrashList });
+    ClearSearchCache(history.location.search);
+    // Client side Caching: the order of files in a normal folder has changed
+    new FileListCache().CacheCleanEverything();
   }
-);
+
+  /**
+   * When pressing delete its moved to the trash
+   */
+  useHotKeys({ key: "Delete" }, () => {
+    moveToTrashSelection();
+  });
+
+  return (
+    <>
+      {select.length >= 1 ? (
+        <li
+          data-test="trash"
+          className={!isReadOnly ? "menu-option" : "menu-option disabled"}
+          onClick={() => moveToTrashSelection()}
+        >
+          {MessageMoveToTrash}
+        </li>
+      ) : null}
+    </>
+  );
+};
 
 export default MenuOptionMoveToTrash;

--- a/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.tsx
+++ b/starsky/starsky/clientapp/src/components/molecules/menu-option-move-to-trash/menu-option-move-to-trash.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from "react";
 import { ArchiveAction } from "../../../contexts/archive-context";
 import useGlobalSettings from "../../../hooks/use-global-settings";
+import useHotKeys from "../../../hooks/use-keyboard/use-hotkeys";
 import useLocation from "../../../hooks/use-location";
 import { IArchiveProps } from "../../../interfaces/IArchiveProps";
 import FetchPost from "../../../shared/fetch-post";
@@ -80,6 +81,13 @@ const MenuOptionMoveToTrash: React.FunctionComponent<IMenuOptionMoveToTrashProps
       // Client side Caching: the order of files in a normal folder has changed
       new FileListCache().CacheCleanEverything();
     }
+
+    /**
+     * When pressing delete its moved to the trash
+     */
+    useHotKeys({ key: "Delete" }, () => {
+      moveToTrashSelection();
+    });
 
     return (
       <>


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

 In select mode press delete key should move to trash in archive view #357 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [x] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
