### PR TITLE
only check on last edit time

### DIFF
--- a/history.md
+++ b/history.md
@@ -46,6 +46,8 @@ node starsky-tools/build-tools/app-version-update.js
 # version 0.4.8 _(Unreleased)_ - 2021-03-??
 - [x]   (Changed) _Front-end_ Make Archive UI more white & Dark mode UI fixes (PR #358)
 - [x]   (Added) _Front-end_  In select mode press delete key should move to trash in archive & search view (PR #360 / Issue #357)
+- [x]   (Fixed)  _Back-end_ Remove check if byte size is the same for example when updating colorClass is the same (PR #362)
+- [x]   (Fixed)  _Back-end_ Change Byte size to datetime last-edited (PR #362)
 
 # version 0.4.7 - 2021-03-11
 - [x]   (Changed) _Back-end_  add cache for health check and timeout for 10 seconds on health calls (PR #332)

--- a/starsky/starsky.foundation.storage/Models/StorageInfo.cs
+++ b/starsky/starsky.foundation.storage/Models/StorageInfo.cs
@@ -1,8 +1,15 @@
+using System;
+
 namespace starsky.foundation.storage.Models
 {
 	public class StorageInfo
 	{
 		public FolderOrFileModel.FolderOrFileTypeList IsFolderOrFile { get; set; }
 		public long Size { get; set; }
+
+		/// <summary>
+		/// In UTC
+		/// </summary>
+		public DateTime LastWriteTime { get; set; }
 	}
 }

--- a/starsky/starsky.foundation.storage/Models/StorageInfo.cs
+++ b/starsky/starsky.foundation.storage/Models/StorageInfo.cs
@@ -8,7 +8,7 @@ namespace starsky.foundation.storage.Models
 		public long Size { get; set; }
 
 		/// <summary>
-		/// In UTC
+		/// Input in UTC, witten down local
 		/// </summary>
 		public DateTime LastWriteTime { get; set; }
 	}

--- a/starsky/starsky.foundation.storage/Services/FileHash.cs
+++ b/starsky/starsky.foundation.storage/Services/FileHash.cs
@@ -124,12 +124,12 @@ namespace starsky.foundation.storage.Services
         /// <returns>Task with a md5 hash</returns>
         private async Task<string> CalculateMd5Async(string fullFilePath)
         {
-            var block = ArrayPool<byte>.Shared.Rent(8192 ); // 8 Kilobytes each
+            var block = ArrayPool<byte>.Shared.Rent(16384 ); // 16 Kilobytes each (7 times)
             try
             {
                 using (var md5 = MD5.Create())
                 {
-                    using (var stream = _iStorage.ReadStream(fullFilePath,65536)) // reading 64 Kilobytes
+                    using (var stream = _iStorage.ReadStream(fullFilePath,114688)) // 114Kb
                     {
                         int length;
                         while ((length = await stream.ReadAsync(block, 0, block.Length)

--- a/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
@@ -30,6 +30,7 @@ namespace starsky.foundation.storage.Storage
 		{
 			if ( !ExistFile(path) )
 			{
+				// when NOT found
 				return new StorageInfo
 				{
 					IsFolderOrFile = FolderOrFileModel.FolderOrFileTypeList.Deleted,
@@ -41,6 +42,7 @@ namespace starsky.foundation.storage.Storage
 			{
 				IsFolderOrFile = IsFolderOrFile(path),
 				Size = new FileInfo(path).Length,
+				LastWriteTime = File.GetLastWriteTime(path).ToUniversalTime()
 			};
 		}
 		

--- a/starsky/starsky.foundation.sync/SyncServices/SyncSingleFile.cs
+++ b/starsky/starsky.foundation.sync/SyncServices/SyncSingleFile.cs
@@ -102,7 +102,7 @@ namespace starsky.foundation.sync.SyncServices
 		/// </summary>
 		/// <param name="dbItem">item that contain size and fileHash</param>
 		/// <returns>database item</returns>
-		private async Task<Tuple<bool,FileIndexItem>> SizeFileHashIsTheSame(FileIndexItem dbItem)
+		internal async Task<Tuple<bool,FileIndexItem>> SizeFileHashIsTheSame(FileIndexItem dbItem)
 		{
 			// when last edited is the same
 			var (isLastEditTheSame, lastEdit) = CompareLastEditIsTheSame(dbItem);

--- a/starsky/starsky.foundation.sync/SyncServices/SyncSingleFile.cs
+++ b/starsky/starsky.foundation.sync/SyncServices/SyncSingleFile.cs
@@ -104,9 +104,10 @@ namespace starsky.foundation.sync.SyncServices
 		/// <returns>database item</returns>
 		private async Task<Tuple<bool,FileIndexItem>> SizeFileHashIsTheSame(FileIndexItem dbItem)
 		{
+			// when last edited is the same
 			var (isLastEditTheSame, lastEdit) = CompareLastEditIsTheSame(dbItem);
 			dbItem.LastEdited = lastEdit;
-			dbItem.Size = _subPathStorage.Info(dbItem.FilePath).Size;;
+			dbItem.Size = _subPathStorage.Info(dbItem.FilePath).Size;
 
 			if (isLastEditTheSame) return new Tuple<bool, FileIndexItem>(true ,dbItem);
 			

--- a/starsky/starsky.foundation.sync/SyncServices/SyncSingleFile.cs
+++ b/starsky/starsky.foundation.sync/SyncServices/SyncSingleFile.cs
@@ -104,11 +104,12 @@ namespace starsky.foundation.sync.SyncServices
 		/// <returns>database item</returns>
 		private async Task<Tuple<bool,FileIndexItem>> SizeFileHashIsTheSame(FileIndexItem dbItem)
 		{
-			// when size is the same dont update
-			var (isByteSizeTheSame, size) = CompareByteSizeIsTheSame(dbItem);
-			dbItem.Size = size;
-			if (isByteSizeTheSame) return new Tuple<bool, FileIndexItem>(true ,dbItem);
+			var (isLastEditTheSame, lastEdit) = CompareLastEditIsTheSame(dbItem);
+			dbItem.LastEdited = lastEdit;
+			dbItem.Size = _subPathStorage.Info(dbItem.FilePath).Size;;
 
+			if (isLastEditTheSame) return new Tuple<bool, FileIndexItem>(true ,dbItem);
+			
 			// when byte hash is different update
 			var (fileHashTheSame,_ ) = await CompareFileHashIsTheSame(dbItem);
 
@@ -213,12 +214,17 @@ namespace starsky.foundation.sync.SyncServices
 		/// </summary>
 		/// <param name="dbItem"></param>
 		/// <returns></returns>
-		private Tuple<bool,long> CompareByteSizeIsTheSame(FileIndexItem dbItem)
+		private Tuple<bool,DateTime> CompareLastEditIsTheSame(FileIndexItem dbItem)
 		{
-			var storageByteSize = _subPathStorage.Info(dbItem.FilePath).Size;
-			var isTheSame = dbItem.Size == storageByteSize;
-			dbItem.Size = storageByteSize;
-			return new Tuple<bool, long>(isTheSame, storageByteSize);
+			var lastWriteTime = _subPathStorage.Info(dbItem.FilePath).LastWriteTime;
+			if ( lastWriteTime.Year == 1 )
+			{
+				return new Tuple<bool, DateTime>(false, lastWriteTime);
+			}
+			
+			var isTheSame = dbItem.LastEdited == lastWriteTime;
+			dbItem.LastEdited = lastWriteTime;
+			return new Tuple<bool, DateTime>(isTheSame, lastWriteTime);
 		}
 
 		/// <summary>

--- a/starsky/starskytest/FakeMocks/FakeIStorage.cs
+++ b/starsky/starskytest/FakeMocks/FakeIStorage.cs
@@ -16,6 +16,9 @@ namespace starskytest.FakeMocks
 	{
 		private List<string> _outputSubPathFolders = new List<string>();
 		private List<string> _outputSubPathFiles  = new List<string>();
+
+		private readonly  Dictionary<string, DateTime> _lastEditDict = new Dictionary<string, DateTime>();
+
 		private readonly  Dictionary<string, byte[]> _byteList = new Dictionary<string, byte[]>();
 
 		/// <summary>
@@ -26,7 +29,7 @@ namespace starskytest.FakeMocks
 		/// <param name="byteListSource"></param>
 		/// <param name="fileHashPerThumbnail">for mock fileHash=subPath</param>
 		public FakeIStorage(List<string> outputSubPathFolders = null, List<string> outputSubPathFiles = null, 
-			IReadOnlyList<byte[]> byteListSource = null)
+			IReadOnlyList<byte[]> byteListSource = null, List<DateTime> lastEdited = null)
 		{
 	
 			if ( outputSubPathFolders != null )
@@ -53,6 +56,13 @@ namespace starskytest.FakeMocks
 				}
 			}
 
+			if ( lastEdited != null && lastEdited.Any() )
+			{
+				for ( int i = 0; i < _outputSubPathFiles.Count; i++ )
+				{
+					_lastEditDict.Add(_outputSubPathFiles[i],lastEdited[i]);
+				}
+			}
 		}
 
 		private readonly Exception _exception;
@@ -299,10 +309,18 @@ namespace starskytest.FakeMocks
 			}
 			
 			var result = _byteList.FirstOrDefault(p => p.Key == path).Value;
+
+			var lastEdit = new DateTime();
+			if ( _lastEditDict != null )
+			{
+				lastEdit = _lastEditDict.FirstOrDefault(p => p.Key == path).Value;
+			}
+			
 			return new StorageInfo
 			{
 				IsFolderOrFile = FolderOrFileModel.FolderOrFileTypeList.File,
-				Size = result.Length
+				Size = result.Length,
+				LastWriteTime = lastEdit
 			};
 
 		}

--- a/starsky/starskytest/starsky.foundation.sync/SyncServices/SyncSingleFileTest.cs
+++ b/starsky/starskytest/starsky.foundation.sync/SyncServices/SyncSingleFileTest.cs
@@ -19,13 +19,15 @@ namespace starskytest.starsky.foundation.sync.SyncServices
 	public class SyncSingleFileTest
 	{
 		private readonly IStorage _iStorageFake;
+		private readonly DateTime _dateTime;
 
 		public SyncSingleFileTest()
 		{
+			_dateTime = new DateTime(2020, 02, 02);
 			_iStorageFake = new FakeIStorage(new List<string>{"/"},
 				new List<string>{"/test.jpg","/color_class_test.jpg", "/status_deleted.jpg"},
 				new List<byte[]>{CreateAnImageNoExif.Bytes, 
-					CreateAnImageColorClass.Bytes, CreateAnImageStatusDeleted.Bytes});
+					CreateAnImageColorClass.Bytes, CreateAnImageStatusDeleted.Bytes}, new List<DateTime>{_dateTime,new DateTime(),new DateTime()});
 		}
 
 		[TestMethod]
@@ -464,5 +466,32 @@ namespace starskytest.starsky.foundation.sync.SyncServices
 			Assert.AreEqual(FileIndexItem.ExifStatus.Deleted,result.Status);
 		}
 
+		[TestMethod]
+		public async Task SizeFileHashIsTheSame_true()
+		{
+			var sync = new SyncSingleFile(new AppSettings(), new FakeIQuery(),
+				_iStorageFake, new ConsoleWrapper());
+			
+			var theSame = await sync.SizeFileHashIsTheSame(new FileIndexItem("/test.jpg")
+			{
+				LastEdited = _dateTime
+			});
+
+			Assert.IsTrue(theSame.Item1);
+		}
+		[TestMethod]
+		
+		public async Task SizeFileHashIsTheSame_NotFoundFalse()
+		{
+			var sync = new SyncSingleFile(new AppSettings(), new FakeIQuery(),
+				_iStorageFake, new ConsoleWrapper());
+			
+			var theSame = await sync.SizeFileHashIsTheSame(new FileIndexItem("/not-found.jpg")
+			{
+				LastEdited = _dateTime
+			});
+
+			Assert.IsFalse(theSame.Item1);
+		}
 	}
 }


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

- [x]   (Fixed)  _Back-end_ Remove check if byte size is the same for example when updating colorClass is the same (PR #362)
- [x]   (Fixed)  _Back-end_ Change Byte size to datetime last-edited (PR #362)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
