### PR TITLE
Replace api en update api cache and update issues

### DIFF
--- a/history.md
+++ b/history.md
@@ -44,7 +44,9 @@ node starsky-tools/build-tools/app-version-update.js
 - remove newtonsoft.json references
 
 # version 0.4.10 _(Unreleased)_ - 2021-06-??
-- [x]   (Fixed) _Back-end_ Performance change, FileIndexItem uses less memory in the application
+- [x]   (Fixed) _Back-end_ Performance change, FileIndexItem uses less memory in the application (PR #410)
+- [x]   (Fixed) _Back-end_ Change Replace to use a single database query and update to empty string (PR #412)
+- [x]   (Fixed) _Back-end_ Fix fast updating items to update the cache before update (PR #412)
 
 # version 0.4.9 - 2021-06-17
 - [x]   (Fixed) _Front-end_ Show error when update fails in archive list (PR #391)

--- a/history.md
+++ b/history.md
@@ -47,6 +47,7 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Fixed) _Back-end_ Performance change, FileIndexItem uses less memory in the application (PR #410)
 - [x]   (Fixed) _Back-end_ Change Replace to use a single database query and update to empty string (PR #412)
 - [x]   (Fixed) _Back-end_ Fix fast updating items to update the cache before update (PR #412)
+- [x]   (Change) _Back-end_ Push direct to socket when update or replace to avoid undo after a second (PR #412)
 
 # version 0.4.9 - 2021-06-17
 - [x]   (Fixed) _Front-end_ Show error when update fails in archive list (PR #391)

--- a/starsky/starsky.feature.metaupdate/Helpers/AddNotFoundInIndexStatus.cs
+++ b/starsky/starsky.feature.metaupdate/Helpers/AddNotFoundInIndexStatus.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using starsky.foundation.database.Helpers;
+using starsky.foundation.database.Models;
+
+namespace starsky.feature.metaupdate.Helpers
+{
+	public static class AddNotFoundInIndexStatus
+	{
+		internal static void Update(string[] inputFilePaths, List<FileIndexItem> fileIndexResultsList)
+		{
+			foreach (var subPath in inputFilePaths)
+			{
+				// when item is not in the database
+				if ( fileIndexResultsList.All(p => p.FilePath != subPath) )
+				{
+					new StatusCodesHelper().ReturnExifStatusError(new FileIndexItem(subPath), 
+						FileIndexItem.ExifStatus.NotFoundNotInIndex,
+						fileIndexResultsList);
+				}
+			}
+		}
+	}
+}

--- a/starsky/starsky.feature.metaupdate/Helpers/AddParentCacheIfNotExist.cs
+++ b/starsky/starsky.feature.metaupdate/Helpers/AddParentCacheIfNotExist.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using starsky.foundation.database.Interfaces;
+using starsky.foundation.platform.Helpers;
+using starsky.foundation.platform.Interfaces;
+
+namespace starsky.feature.metaupdate.Helpers
+{
+	public class AddParentCacheIfNotExist
+	{
+		private readonly IQuery _query;
+		private readonly IWebLogger _logger;
+
+		public AddParentCacheIfNotExist(IQuery query, IWebLogger logger)
+		{
+			_query = query;
+			_logger = logger;
+		}
+		
+		internal async Task<List<string>> AddParentCacheIfNotExistAsync(IEnumerable<string> updatedPaths)
+		{
+			var parentDirectoryList = new HashSet<string>();
+
+			foreach ( var path in updatedPaths )
+			{
+				parentDirectoryList.Add(FilenamesHelper.GetParentPath(path));
+			}
+
+			var shouldAddParentDirectoriesToCache = parentDirectoryList.Where(parentDirectory => 
+				!_query.CacheGetParentFolder(parentDirectory).Item1).ToList();
+			if ( !shouldAddParentDirectoriesToCache.Any() ) return new List<string>();
+
+			var databaseQueryResult = await _query.GetAllObjectsAsync(shouldAddParentDirectoriesToCache);
+			
+			_logger.LogInformation("[AddParentCacheIfNotExist] files added to cache " + 
+			                       string.Join(",", shouldAddParentDirectoriesToCache));
+			
+			foreach ( var directory in shouldAddParentDirectoriesToCache )
+			{
+				var byDirectory = databaseQueryResult.Where(p => p.ParentDirectory == directory).ToList();
+				_query.AddCacheParentItem(directory, byDirectory);
+			}
+			return shouldAddParentDirectoriesToCache; 
+		}
+	}
+}

--- a/starsky/starsky.feature.metaupdate/Interfaces/IMetaReplaceService.cs
+++ b/starsky/starsky.feature.metaupdate/Interfaces/IMetaReplaceService.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using starsky.foundation.database.Models;
 
 namespace starsky.feature.metaupdate.Interfaces
 {
 	public interface IMetaReplaceService
 	{
-		List<FileIndexItem> Replace(string f, string fieldName, string search, string replace,
-			bool collections);
+		Task<List<FileIndexItem>> Replace(string f, string fieldName, 
+			string search, string replace, bool collections);
 	}
 }

--- a/starsky/starsky.feature.metaupdate/Services/MetaPreflight.cs
+++ b/starsky/starsky.feature.metaupdate/Services/MetaPreflight.cs
@@ -77,8 +77,11 @@ namespace starsky.feature.metaupdate.Services
 					fileIndexItem, inputModel, append, rotateClock);
 						
 				// this one is good :)
-				fileIndexItem.Status = FileIndexItem.ExifStatus.Ok;
-					
+				if ( fileIndexItem.Status == FileIndexItem.ExifStatus.Default )
+				{
+					fileIndexItem.Status = FileIndexItem.ExifStatus.Ok;
+				}
+				
 				// Deleted is allowed but the status need be updated
 				if (( new StatusCodesHelper(_appSettings).IsDeletedStatus(fileIndexItem) 
 				      == FileIndexItem.ExifStatus.Deleted) )

--- a/starsky/starsky.feature.metaupdate/Services/MetaReplaceService.cs
+++ b/starsky/starsky.feature.metaupdate/Services/MetaReplaceService.cs
@@ -73,6 +73,7 @@ namespace starsky.feature.metaupdate.Services
 			// Prefill cache to avoid fast updating issues
 			await new AddParentCacheIfNotExist(_query,_logger).AddParentCacheIfNotExistAsync(inputFilePaths);
 			
+			// Assumes that this give status Ok back by default
 			var queryFileIndexItemsList = await _query.GetObjectsByFilePathAsync(
 				inputFilePaths.ToList(), collections);
 			
@@ -106,12 +107,7 @@ namespace starsky.feature.metaupdate.Services
 			var fileIndexResultList = new List<FileIndexItem>();
 			foreach ( var fileIndexItem in fileIndexUpdatedList )
 			{
-				// current item is also ok
-				if ( fileIndexItem.Status == FileIndexItem.ExifStatus.Default )
-				{
-					fileIndexItem.Status = FileIndexItem.ExifStatus.Ok;
-				}
-				
+
 				// Deleted is allowed but the status need be updated
 				if ((fileIndexItem.Status == FileIndexItem.ExifStatus.Ok) && 
 				    new StatusCodesHelper(_appSettings).IsDeletedStatus(fileIndexItem) == 

--- a/starsky/starsky.feature.metaupdate/Services/MetaReplaceService.cs
+++ b/starsky/starsky.feature.metaupdate/Services/MetaReplaceService.cs
@@ -107,7 +107,8 @@ namespace starsky.feature.metaupdate.Services
 			var fileIndexResultList = new List<FileIndexItem>();
 			foreach ( var fileIndexItem in fileIndexUpdatedList )
 			{
-
+				// Status Ok is already set
+				
 				// Deleted is allowed but the status need be updated
 				if ((fileIndexItem.Status == FileIndexItem.ExifStatus.Ok) && 
 				    new StatusCodesHelper(_appSettings).IsDeletedStatus(fileIndexItem) == 

--- a/starsky/starsky/Controllers/MetaUpdateController.cs
+++ b/starsky/starsky/Controllers/MetaUpdateController.cs
@@ -107,8 +107,9 @@ namespace starsky.Controllers
 		{
 			// for debug
 			stopwatch.Stop();
-			_logger.LogInformation($"[{name}] f: {f} response collections: " +
-			                       $"{collections} duration: {DateTime.UtcNow} {stopwatch.Elapsed.TotalMilliseconds}");
+			_logger.LogInformation($"[{name}] f: {f} Stopwatch response collections: " +
+			                       $"{collections} {DateTime.UtcNow} duration: {stopwatch.Elapsed.TotalMilliseconds} ms or:" +
+			                       $" {stopwatch.Elapsed.TotalSeconds} sec");
 		}
 
 		/// <summary>
@@ -119,7 +120,7 @@ namespace starsky.Controllers
 		/// <param name="search">text to search for</param>
 		/// <param name="replace">replace [search] with this text</param>
 		/// <param name="collections">enable collections</param>
-		/// <returns>list of changed files</returns>
+		/// <returns>list of changed files (IActionResult Replace)</returns>
 		/// <response code="200">Initialized replace job</response>
 		/// <response code="404">item(s) not found</response>
 		/// <response code="401">User unauthorized</response>
@@ -127,53 +128,44 @@ namespace starsky.Controllers
 		[ProducesResponseType(typeof(List<FileIndexItem>),200)]
 		[ProducesResponseType(typeof(List<FileIndexItem>),404)]
 		[Produces("application/json")]
-		public IActionResult Replace(string f, string fieldName, string search,
+		public async Task<IActionResult> Replace(string f, string fieldName, string search,
 			string replace, bool collections = true)
 		{
 			var stopwatch = StartUpdateReplaceStopWatch();
 
-			var fileIndexResultsList = _metaReplaceService
+			var fileIndexResultsList = await _metaReplaceService
 				.Replace(f, fieldName, search, replace, collections);
 		    
+			var resultsOkOrDeleteList = fileIndexResultsList.Where(
+				p => p.Status == FileIndexItem.ExifStatus.Ok || 
+				     p.Status == FileIndexItem.ExifStatus.Deleted).ToList();
+			
+			var changedFileIndexItemName = resultsOkOrDeleteList.
+				ToDictionary(item => item.FilePath, item => new List<string> {fieldName});
+
 			// Update >
 			_bgTaskQueue.QueueBackgroundWorkItem(async token =>
 			{
-				var resultsOkList =
-					fileIndexResultsList.Where(p => p.Status
-					                                == FileIndexItem.ExifStatus.Ok).ToList();
-				
-				foreach ( var inputModel in resultsOkList )
-				{
-					await _metaUpdateService
-						.Update(null, new List<FileIndexItem>{inputModel},
-							inputModel, collections, false, 0);
-				}
+				await _metaUpdateService
+					.Update(changedFileIndexItemName, resultsOkOrDeleteList,
+						null, collections, false, 0);
 
-				if ( resultsOkList.Any() )
+				if ( resultsOkOrDeleteList.Any() )
 				{
-					await _connectionsService.SendToAllAsync(JsonSerializer.Serialize(resultsOkList,
+					await _connectionsService.SendToAllAsync(JsonSerializer.Serialize(resultsOkOrDeleteList,
 						DefaultJsonSerializer.CamelCase), token);
 				}
-
 			});
 
 			StopUpdateReplaceStopWatch("replace", f, collections, stopwatch);
 			
 			// When all items are not found
-			if (fileIndexResultsList.All(p => p.Status != FileIndexItem.ExifStatus.Ok))
+			if (!resultsOkOrDeleteList.Any())
 			{
 				return NotFound(fileIndexResultsList);
 			}
-
-			// Clone an new item in the list to display
-			var returnNewResultList = new List<FileIndexItem>();
-			foreach ( var clonedItem in fileIndexResultsList.Select(item => item.Clone()) )
-			{
-				clonedItem.FileHash = null;
-				returnNewResultList.Add(clonedItem);
-			}
 			
-			return Json(returnNewResultList);
+			return Json(fileIndexResultsList);
 		}
 	}
 }

--- a/starsky/starsky/Controllers/MetaUpdateController.cs
+++ b/starsky/starsky/Controllers/MetaUpdateController.cs
@@ -90,6 +90,7 @@ namespace starsky.Controllers
 
 			StopUpdateReplaceStopWatch("update", f,collections, stopwatch);
 
+			// Push direct to socket when update or replace to avoid undo after a second
 			_logger.LogInformation($"[UpdateController] send to socket {f}");
 			await _connectionsService.SendToAllAsync("[system] /api/update called",CancellationToken.None);
 			await _connectionsService.SendToAllAsync(JsonSerializer.Serialize(fileIndexResultsList, 
@@ -161,6 +162,7 @@ namespace starsky.Controllers
 				return NotFound(fileIndexResultsList);
 			}
 			
+			// Push direct to socket when update or replace to avoid undo after a second
 			await _connectionsService.SendToAllAsync("[system] /api/replace called",CancellationToken.None);
 			await _connectionsService.SendToAllAsync(JsonSerializer.Serialize(resultsOkOrDeleteList,
 				DefaultJsonSerializer.CamelCase), CancellationToken.None);

--- a/starsky/starskytest/Controllers/MetaUpdateControllerTest.cs
+++ b/starsky/starskytest/Controllers/MetaUpdateControllerTest.cs
@@ -187,9 +187,9 @@ namespace starskytest.Controllers
 		}
 
 		[TestMethod]
-		public void Replace_SourceImageMissingOnDisk_WithFakeExifTool()
+		public async Task Replace_SourceImageMissingOnDisk_WithFakeExifTool()
 		{
-			_query.AddItem(new FileIndexItem
+			await _query.AddItemAsync(new FileIndexItem
 			{
 				FileName = "345678765434567.jpg",
 				ParentDirectory = "/",
@@ -209,19 +209,19 @@ namespace starskytest.Controllers
 				ControllerContext = {HttpContext = new DefaultHttpContext()}
 			};
 
-			var notFoundResult = controller.Replace( "/345678765434567.jpg", "test", "search", 
+			var notFoundResult = await controller.Replace( "/345678765434567.jpg", "test", "search", 
 				string.Empty) as NotFoundObjectResult;
 			if ( notFoundResult == null ) throw new NullReferenceException(nameof(notFoundResult));
 
 			Assert.AreEqual(404,notFoundResult.StatusCode);
 
-			_query.RemoveItem(_query.SingleItem("/345678765434567.jpg").FileIndexItem);
+			await _query.RemoveItemAsync(_query.SingleItem("/345678765434567.jpg").FileIndexItem);
 		}
         
 		[TestMethod]
-		public void Replace_AllDataIncluded_WithFakeExifTool()
+		public async Task Replace_AllDataIncluded_WithFakeExifTool()
 		{
-			var item = _query.AddItem(new FileIndexItem
+			var item = await _query.AddItemAsync(new FileIndexItem
 			{
 				FileName = "test09.jpg",
 				ParentDirectory = "/",
@@ -239,7 +239,7 @@ namespace starskytest.Controllers
 			var controller = new MetaUpdateController(metaPreflight,metaUpdateService, metaReplaceService, _bgTaskQueue, 
 				new FakeIWebSocketConnectionsService(), new FakeIWebLogger());
 
-			var jsonResult =  controller.Replace("/test09.jpg","Tags", "test", 
+			var jsonResult =  await controller.Replace("/test09.jpg","Tags", "test", 
 				string.Empty) as JsonResult;
 			if ( jsonResult == null ) throw new NullReferenceException(nameof(jsonResult));
 			var fileModel = jsonResult.Value as List<FileIndexItem>;
@@ -248,7 +248,7 @@ namespace starskytest.Controllers
 			Assert.AreNotEqual(null,fileModel.FirstOrDefault()?.Tags);
 			Assert.AreEqual("7", fileModel.FirstOrDefault()?.Tags);
 
-			_query.RemoveItem(item);
+			await _query.RemoveItemAsync(item);
 		}
 
 		[TestMethod]

--- a/starsky/starskytest/Controllers/MetaUpdateControllerTest.cs
+++ b/starsky/starskytest/Controllers/MetaUpdateControllerTest.cs
@@ -256,12 +256,15 @@ namespace starskytest.Controllers
 		{
 			var fakeFakeIWebSocketConnectionsService =
 				new FakeIWebSocketConnectionsService();
-			var controller = new MetaUpdateController(new FakeMetaPreflight(),
+			
+			var controller = new MetaUpdateController(
+				new FakeMetaPreflight(),
 				new FakeIMetaUpdateService(), 
-				new FakeIMetaReplaceService(), new FakeIBackgroundTaskQueue(), 
+				new FakeIMetaReplaceService(), 
+				new FakeIBackgroundTaskQueue(), 
 				fakeFakeIWebSocketConnectionsService, new FakeIWebLogger());
 
-			await controller.UpdateAsync(new FileIndexItem(), "/test09.jpg",
+			await controller.UpdateAsync(new FileIndexItem{ Status =  FileIndexItem.ExifStatus.Ok}, "/test09.jpg",
 				true);
 
 			Assert.AreEqual(1,fakeFakeIWebSocketConnectionsService
@@ -282,7 +285,7 @@ namespace starskytest.Controllers
 
 			controller.Replace("/test09.jpg", "tags", "test", "");
 
-			Assert.AreEqual(1, fakeFakeIWebSocketConnectionsService.FakeSendToAllAsync.Count);
+			Assert.AreEqual(2, fakeFakeIWebSocketConnectionsService.FakeSendToAllAsync.Count);
 		}
         
 		[TestMethod]

--- a/starsky/starskytest/Controllers/MetaUpdateControllerTest.cs
+++ b/starsky/starskytest/Controllers/MetaUpdateControllerTest.cs
@@ -131,7 +131,7 @@ namespace starskytest.Controllers
 				selectorStorage,new FakeIWebLogger());
 			var metaUpdateService = new MetaUpdateService(_query,_exifTool,new FakeReadMeta(), 
 				selectorStorage, metaPreflight, new FakeIWebLogger());
-			var metaReplaceService = new MetaReplaceService(_query,_appSettings,selectorStorage);
+			var metaReplaceService = new MetaReplaceService(_query,_appSettings,selectorStorage, new FakeIWebLogger());
 			var controller = new MetaUpdateController(metaPreflight,metaUpdateService, metaReplaceService, _bgTaskQueue, 
 				new FakeIWebSocketConnectionsService(), new FakeIWebLogger());
 
@@ -168,7 +168,7 @@ namespace starskytest.Controllers
 				_appSettings,selectorStorage,new FakeIWebLogger());
 			var metaUpdateService = new MetaUpdateService(_query,_exifTool,new FakeReadMeta(), 
 				selectorStorage, metaPreflight, new FakeIWebLogger());
-			var metaReplaceService = new MetaReplaceService(_query,_appSettings,selectorStorage);
+			var metaReplaceService = new MetaReplaceService(_query,_appSettings,selectorStorage, new FakeIWebLogger());
 	        
 			var controller = new MetaUpdateController(metaPreflight,metaUpdateService, metaReplaceService, _bgTaskQueue, 
 				new FakeIWebSocketConnectionsService(), new FakeIWebLogger())
@@ -201,7 +201,7 @@ namespace starskytest.Controllers
 				_appSettings,selectorStorage,new FakeIWebLogger());
 			var metaUpdateService = new MetaUpdateService(_query,_exifTool,new FakeReadMeta(), selectorStorage, 
 				metaPreflight, new FakeIWebLogger());
-			var metaReplaceService = new MetaReplaceService(_query,_appSettings,selectorStorage);
+			var metaReplaceService = new MetaReplaceService(_query,_appSettings,selectorStorage, new FakeIWebLogger());
 	        
 			var controller = new MetaUpdateController(metaPreflight,metaUpdateService, metaReplaceService, _bgTaskQueue, 
 				new FakeIWebSocketConnectionsService(), new FakeIWebLogger())
@@ -235,7 +235,7 @@ namespace starskytest.Controllers
 				_appSettings,selectorStorage,new FakeIWebLogger());
 			var metaUpdateService = new MetaUpdateService(_query,_exifTool,new FakeReadMeta(), selectorStorage, 
 				metaPreflight, new FakeIWebLogger());
-			var metaReplaceService = new MetaReplaceService(_query,_appSettings,selectorStorage);
+			var metaReplaceService = new MetaReplaceService(_query,_appSettings,selectorStorage, new FakeIWebLogger());
 			var controller = new MetaUpdateController(metaPreflight,metaUpdateService, metaReplaceService, _bgTaskQueue, 
 				new FakeIWebSocketConnectionsService(), new FakeIWebLogger());
 

--- a/starsky/starskytest/FakeMocks/FakeIMetaReplaceService.cs
+++ b/starsky/starskytest/FakeMocks/FakeIMetaReplaceService.cs
@@ -22,7 +22,8 @@ namespace starskytest.FakeMocks
 		public Task<List<FileIndexItem>> Replace(string f, string fieldName, string search, string replace,
 			bool collections)
 		{
-			return Task.FromResult(new MetaReplaceService(null, null, null).SearchAndReplace(
+			return Task.FromResult(new MetaReplaceService(null, null, 
+				null, new FakeIWebLogger()).SearchAndReplace(
 				_input.Where(p => p.FilePath == f).ToList(), fieldName, search,
 				replace));
 		}

--- a/starsky/starskytest/FakeMocks/FakeIMetaReplaceService.cs
+++ b/starsky/starskytest/FakeMocks/FakeIMetaReplaceService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using starsky.feature.metaupdate.Interfaces;
 using starsky.feature.metaupdate.Services;
 using starsky.foundation.database.Models;
@@ -18,12 +19,12 @@ namespace starskytest.FakeMocks
 			}
 		}
 		
-		public List<FileIndexItem> Replace(string f, string fieldName, string search, string replace,
+		public Task<List<FileIndexItem>> Replace(string f, string fieldName, string search, string replace,
 			bool collections)
 		{
-			return new MetaReplaceService(null, null, null).SearchAndReplace(
+			return Task.FromResult(new MetaReplaceService(null, null, null).SearchAndReplace(
 				_input.Where(p => p.FilePath == f).ToList(), fieldName, search,
-				replace);
+				replace));
 		}
 	}
 }

--- a/starsky/starskytest/FakeMocks/FakeIMetaUpdateService.cs
+++ b/starsky/starskytest/FakeMocks/FakeIMetaUpdateService.cs
@@ -17,7 +17,6 @@ namespace starskytest.FakeMocks
 
 		public void UpdateReadMetaCache(IEnumerable<FileIndexItem> returnNewResultList)
 		{
-			throw new System.NotImplementedException();
 		}
 	}
 }

--- a/starsky/starskytest/Services/ReplaceServiceTest.cs
+++ b/starsky/starskytest/Services/ReplaceServiceTest.cs
@@ -38,7 +38,7 @@ namespace starskytest.Services
 			_iStorage = new FakeIStorage(new List<string>{"/"}, 
 				new List<string>{"/test.jpg","/test2.jpg", "/readonly/test.jpg", "/test.dng"});
 			_metaReplace = new MetaReplaceService(_query,new AppSettings{ ReadOnlyFolders = new List<string>{"/readonly"}},
-				new FakeSelectorStorage(_iStorage));
+				new FakeSelectorStorage(_iStorage), new FakeIWebLogger());
 
 		}
 

--- a/starsky/starskytest/Services/ReplaceServiceTest.cs
+++ b/starsky/starskytest/Services/ReplaceServiceTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,50 +18,74 @@ namespace starskytest.Services
 	public class ReplaceServiceTest
 	{
 		
-		private MetaReplaceService _metaReplace;
+		private readonly MetaReplaceService _metaReplace;
 		private readonly Query _query;
-		private readonly IMemoryCache _memoryCache;
-		private FakeIStorage _iStorage;
+		private readonly FakeIStorage _iStorage;
 
 		public ReplaceServiceTest()
 		{
 			var provider = new ServiceCollection()
 				.AddMemoryCache()
 				.BuildServiceProvider();
-			_memoryCache = provider.GetService<IMemoryCache>();
+			var memoryCache = provider.GetService<IMemoryCache>();
             
 			var builder = new DbContextOptionsBuilder<ApplicationDbContext>();
 			builder.UseInMemoryDatabase(nameof(MetaReplaceService));
 			var options = builder.Options;
 			var dbContext = new ApplicationDbContext(options);
-			_query = new Query(dbContext,_memoryCache);
+			_query = new Query(dbContext,memoryCache);
 
 			_iStorage = new FakeIStorage(new List<string>{"/"}, 
-				new List<string>{"/test.jpg","/test2.jpg", "/readonly/test.jpg"});
+				new List<string>{"/test.jpg","/test2.jpg", "/readonly/test.jpg", "/test.dng"});
 			_metaReplace = new MetaReplaceService(_query,new AppSettings{ ReadOnlyFolders = new List<string>{"/readonly"}},
 				new FakeSelectorStorage(_iStorage));
 
 		}
-		
-		// todo: not found
 
 		[TestMethod]
-		public void ReplaceServiceTest_replaceString()
+		public async Task ReplaceServiceTest_NotFound()
 		{
-	
-			var item1 = _query.AddItem(new FileIndexItem
+			var output = await _metaReplace.Replace("/not-found.jpg",
+				nameof(FileIndexItem.Tags),"!delete!",string.Empty,false);
+			
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundNotInIndex,output[0].Status);
+		}
+		
+		[TestMethod]
+		public async Task ReplaceServiceTest_ToDeleteStatus()
+		{
+			var item1 = await _query.AddItemAsync(new FileIndexItem
+			{
+				FileName = "test2.jpg",
+				ParentDirectory = "/",
+				Tags = "test1, test"
+			}); 
+			
+			var output = await _metaReplace.Replace("/test2.jpg",
+				nameof(FileIndexItem.Tags),"test1","!delete!",false);
+			
+			Assert.AreEqual(FileIndexItem.ExifStatus.Deleted,output[0].Status);
+			Assert.AreEqual("!delete!, test",output[0].Tags);
+
+			await _query.RemoveItemAsync(item1);
+		}
+
+		[TestMethod]
+		public async Task ReplaceServiceTest_replaceString()
+		{
+			var item1 = await _query.AddItemAsync(new FileIndexItem
 			{
 				FileName = "test2.jpg",
 				ParentDirectory = "/",
 				Tags = "test1, !delete!, test"
 			}); 
 			
-			var output = _metaReplace.Replace("/test2.jpg",
+			var output = await _metaReplace.Replace("/test2.jpg",
 				nameof(FileIndexItem.Tags),"!delete!",string.Empty,false);
 
 			Assert.AreEqual(FileIndexItem.ExifStatus.Ok,output[0].Status);
 			Assert.AreEqual("test1, test",output[0].Tags);
-			_query.RemoveItem(item1);
+			await _query.RemoveItemAsync(item1);
 		}
 
 		[TestMethod]
@@ -74,30 +99,63 @@ namespace starskytest.Services
 		}
 
 		[TestMethod]
-		public void ReplaceServiceTest_replaceStringMultipleItems()
+		public async Task ReplaceServiceTest_replaceStringMultipleItems()
 		{
-			var item0 = _query.AddItem(new FileIndexItem
+			var item0 = await _query.AddItemAsync(new FileIndexItem
 			{
 				FileName = "test.jpg",
 				ParentDirectory = "/",
 				Tags = "!delete!"
 			});
 			
-			var item1 = _query.AddItem(new FileIndexItem
+			var item1 = await _query.AddItemAsync(new FileIndexItem
 			{
 				FileName = "test2.jpg",
 				ParentDirectory = "/",
 				Tags = "test1, !delete!, test"
 			}); 
-			var output = _metaReplace.Replace("/test2.jpg;/test.jpg",
+			
+			var output = await _metaReplace.Replace("/test2.jpg;/test.jpg",
 				nameof(FileIndexItem.Tags),"!delete!",string.Empty,false);
 			
 			Assert.AreEqual(FileIndexItem.ExifStatus.Ok,output[0].Status);
 
-			Assert.AreEqual(string.Empty,output[1].Tags);
+			Assert.AreEqual(string.Empty,output.FirstOrDefault(p => p.FilePath == "/test.jpg").Tags);
+			Assert.AreEqual("test1, test",output.FirstOrDefault(p => p.FilePath == "/test2.jpg").Tags);
 
-			_query.RemoveItem(item0);
-			_query.RemoveItem(item1);
+			await _query.RemoveItemAsync(item0);
+			await _query.RemoveItemAsync(item1);
+		}
+		
+		
+		[TestMethod]
+		public async Task ReplaceServiceTest_replaceStringMultipleItemsCollections()
+		{
+			var item0 = await _query.AddItemAsync(new FileIndexItem
+			{
+				FileName = "test.jpg",
+				ParentDirectory = "/",
+				Tags = "!delete!"
+			});
+			
+			var item1 = await _query.AddItemAsync(new FileIndexItem
+			{
+				FileName = "test.dng",
+				ParentDirectory = "/",
+				Tags = "!delete!"
+			}); 
+			
+			var output = await _metaReplace.Replace("/test.jpg",
+				nameof(FileIndexItem.Tags),"!delete!",string.Empty,true);
+			
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok,output[0].Status);
+			Assert.AreEqual(FileIndexItem.ExifStatus.Ok,output[1].Status);
+
+			Assert.AreEqual(string.Empty,output.FirstOrDefault(p => p.FilePath == "/test.jpg").Tags);
+			Assert.AreEqual(string.Empty,output.FirstOrDefault(p => p.FilePath == "/test.dng").Tags);
+
+			await _query.RemoveItemAsync(item0);
+			await _query.RemoveItemAsync(item1);
 		}
 
 		[TestMethod]
@@ -118,50 +176,50 @@ namespace starskytest.Services
 		}
 
 		[TestMethod]
-		public void ReplaceServiceTest_replaceSearchNull()
+		public async Task ReplaceServiceTest_replaceSearchNull()
 		{
 			// When you search for nothing, there is nothing to replace 
-			var output = _metaReplace.Replace("/nothing.jpg", nameof(FileIndexItem.Tags), 
+			var output = await _metaReplace.Replace("/nothing.jpg", nameof(FileIndexItem.Tags), 
 				null, "test", false);
 			Assert.AreEqual(FileIndexItem.ExifStatus.OperationNotSupported,output[0].Status);
 		}
 
 
 		[TestMethod]
-		public void ReplaceServiceTest_replace_LowerCaseTagName()
+		public async Task ReplaceServiceTest_replace_LowerCaseTagName()
 		{
-			var item1 = _query.AddItem(new FileIndexItem
+			var item1 = await _query.AddItemAsync(new FileIndexItem
 			{
 				FileName = "test2.jpg",
 				ParentDirectory = "/",
 				Tags = "test1, !delete!, test"
 			}); 
 			
-			var output = _metaReplace.Replace("/test2.jpg",
+			var output = await _metaReplace.Replace("/test2.jpg",
 				nameof(FileIndexItem.Tags).ToLowerInvariant(),"!delete!",string.Empty,false);
 
 			Assert.AreEqual(FileIndexItem.ExifStatus.Ok,output[0].Status);
 			Assert.AreEqual("test1, test",output[0].Tags);
 			
-			_query.RemoveItem(item1);
+			await _query.RemoveItemAsync(item1);
 		}
 
 		[TestMethod]
-		public void ReplaceServiceTest_Readonly()
+		public async Task ReplaceServiceTest_Readonly()
 		{
-			var item0 = _query.AddItem(new FileIndexItem
+			var item0 = await _query.AddItemAsync(new FileIndexItem
 			{
 				FileName = "test.jpg",
 				ParentDirectory = "/readonly",
 				Tags = "!delete!"
 			});
 			
-			var output = _metaReplace.Replace("/readonly/test.jpg",
+			var output = await _metaReplace.Replace("/readonly/test.jpg",
 				nameof(FileIndexItem.Tags),"!delete!",null,false);
 			
 			Assert.AreEqual(FileIndexItem.ExifStatus.ReadOnly, output.FirstOrDefault().Status);
 			
-			_query.RemoveItem(item0);
+			await _query.RemoveItemAsync(item0);
 		}
 
 		[TestMethod]

--- a/starsky/starskytest/Services/ReplaceServiceTest.cs
+++ b/starsky/starskytest/Services/ReplaceServiceTest.cs
@@ -52,6 +52,24 @@ namespace starskytest.Services
 		}
 		
 		[TestMethod]
+		public async Task ReplaceServiceTest_NotFoundOnDiskButFoundInDatabase()
+		{
+			var item1 = await _query.AddItemAsync(new FileIndexItem
+			{
+				FileName = "only-found-in-db.jpg",
+				ParentDirectory = "/",
+				Tags = "test1, test"
+			}); 
+			
+			var output = await _metaReplace.Replace("/only-found-in-db.jpg",
+				nameof(FileIndexItem.Tags),"!delete!",string.Empty,false);
+			
+			Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing,output[0].Status);
+			
+			await _query.RemoveItemAsync(item1);
+		}
+		
+		[TestMethod]
 		public async Task ReplaceServiceTest_ToDeleteStatus()
 		{
 			var item1 = await _query.AddItemAsync(new FileIndexItem

--- a/starsky/starskytest/starsky.feature.metaupdate/Helpers/AddParentCacheIfNotExistTest.cs
+++ b/starsky/starskytest/starsky.feature.metaupdate/Helpers/AddParentCacheIfNotExistTest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using starsky.feature.metaupdate.Helpers;
+using starsky.feature.metaupdate.Services;
+using starsky.foundation.database.Models;
+using starsky.foundation.platform.Models;
+using starskytest.FakeMocks;
+
+namespace starskytest.starsky.feature.metaupdate.Helpers
+{
+	[TestClass]
+	public class AddParentCacheIfNotExistTest
+	{
+		
+		[TestMethod]
+		public async Task AddParentCacheIfNotExist_ignore_nothing()
+		{
+			var element = new AddParentCacheIfNotExist(new FakeIQuery(
+				new List<FileIndexItem>{new FileIndexItem("/test.jpg")}), new FakeIWebLogger());
+
+			var result = await element.AddParentCacheIfNotExistAsync(
+				new List<string>());
+			Assert.AreEqual(0,result.Count);
+		}
+		
+		[TestMethod]
+		public async Task AddParentCacheIfNotExist_TriggerCacheSync()
+		{
+			var fakeContent =
+				new List<FileIndexItem> {new FileIndexItem("/test.jpg")};
+
+			var fakeQuery = new FakeIQuery(fakeContent);
+			var metaPreflight = new AddParentCacheIfNotExist(fakeQuery, new FakeIWebLogger());
+
+			await metaPreflight.AddParentCacheIfNotExistAsync(
+				fakeContent.Select(p => p.FilePath));
+
+			var (_, cacheGetParentFolder) = fakeQuery.CacheGetParentFolder("/");
+			
+			Assert.AreEqual(1,cacheGetParentFolder.Count);
+		}
+		
+		[TestMethod]
+		public async Task AddParentCacheIfNotExist_IgnoreWhenCacheExists()
+		{
+			var fakeContent =
+				new List<FileIndexItem> {new FileIndexItem("/test.jpg"){FileHash = "test1"}};
+			var fakeContentCache =
+				new List<FileIndexItem> {new FileIndexItem("/test.jpg"){FileHash = "__old_key__"}};
+			
+			var fakeQuery = new FakeIQuery(fakeContent,fakeContentCache);
+			var metaPreflight = new AddParentCacheIfNotExist(fakeQuery, new FakeIWebLogger());
+
+			await metaPreflight.AddParentCacheIfNotExistAsync(
+				fakeContent.Select(p => p.FilePath));
+
+			var (_, cacheGetParentFolder) = fakeQuery.CacheGetParentFolder("/");
+			
+			Assert.AreEqual(1,cacheGetParentFolder.Count);
+			Assert.AreEqual("__old_key__",cacheGetParentFolder[0].FileHash);
+		}
+	}
+}

--- a/starsky/starskytest/starsky.feature.metaupdate/Services/MetaPreflightTest.cs
+++ b/starsky/starskytest/starsky.feature.metaupdate/Services/MetaPreflightTest.cs
@@ -375,56 +375,6 @@ namespace starskytest.starsky.feature.metaupdate.Services
 				result.fileIndexResultsList.FirstOrDefault().Status);
 		}
 
-		[TestMethod]
-		public async Task AddParentCacheIfNotExist_ignore_nothing()
-		{
-			var metaPreflight = new MetaPreflight(new FakeIQuery(
-					new List<FileIndexItem>{new FileIndexItem("/test.jpg")}), new AppSettings(), 
-				new FakeSelectorStorage(),new FakeIWebLogger());
-
-			var result = await metaPreflight.AddParentCacheIfNotExist(
-				new List<string>());
-			Assert.AreEqual(0,result.Count);
-		}
-		
-		[TestMethod]
-		public async Task AddParentCacheIfNotExist_TriggerCacheSync()
-		{
-			var fakeContent =
-				new List<FileIndexItem> {new FileIndexItem("/test.jpg")};
-
-			var fakeQuery = new FakeIQuery(fakeContent);
-			var metaPreflight = new MetaPreflight(fakeQuery, new AppSettings(), 
-				new FakeSelectorStorage(),new FakeIWebLogger());
-
-			await metaPreflight.AddParentCacheIfNotExist(
-				fakeContent.Select(p => p.FilePath));
-
-			var (_, cacheGetParentFolder) = fakeQuery.CacheGetParentFolder("/");
-			
-			Assert.AreEqual(1,cacheGetParentFolder.Count);
-		}
-		
-		[TestMethod]
-		public async Task AddParentCacheIfNotExist_IgnoreWhenCacheExists()
-		{
-			var fakeContent =
-				new List<FileIndexItem> {new FileIndexItem("/test.jpg"){FileHash = "test1"}};
-			var fakeContentCache =
-				new List<FileIndexItem> {new FileIndexItem("/test.jpg"){FileHash = "__old_key__"}};
-			
-			var fakeQuery = new FakeIQuery(fakeContent,fakeContentCache);
-			var metaPreflight = new MetaPreflight(fakeQuery, new AppSettings(), 
-				new FakeSelectorStorage(),new FakeIWebLogger());
-
-			await metaPreflight.AddParentCacheIfNotExist(
-				fakeContent.Select(p => p.FilePath));
-
-			var (_, cacheGetParentFolder) = fakeQuery.CacheGetParentFolder("/");
-			
-			Assert.AreEqual(1,cacheGetParentFolder.Count);
-			Assert.AreEqual("__old_key__",cacheGetParentFolder[0].FileHash);
-		}
 
 	}
 }

--- a/starsky/starskytest/starsky.feature.metaupdate/Services/MetaPreflightTest.cs
+++ b/starsky/starskytest/starsky.feature.metaupdate/Services/MetaPreflightTest.cs
@@ -383,7 +383,7 @@ namespace starskytest.starsky.feature.metaupdate.Services
 				new FakeSelectorStorage(),new FakeIWebLogger());
 
 			var result = await metaPreflight.AddParentCacheIfNotExist(
-				new List<FileIndexItem>());
+				new List<string>());
 			Assert.AreEqual(0,result.Count);
 		}
 		
@@ -398,7 +398,7 @@ namespace starskytest.starsky.feature.metaupdate.Services
 				new FakeSelectorStorage(),new FakeIWebLogger());
 
 			await metaPreflight.AddParentCacheIfNotExist(
-				fakeContent);
+				fakeContent.Select(p => p.FilePath));
 
 			var (_, cacheGetParentFolder) = fakeQuery.CacheGetParentFolder("/");
 			
@@ -418,7 +418,7 @@ namespace starskytest.starsky.feature.metaupdate.Services
 				new FakeSelectorStorage(),new FakeIWebLogger());
 
 			await metaPreflight.AddParentCacheIfNotExist(
-				fakeContent);
+				fakeContent.Select(p => p.FilePath));
 
 			var (_, cacheGetParentFolder) = fakeQuery.CacheGetParentFolder("/");
 			
@@ -426,49 +426,5 @@ namespace starskytest.starsky.feature.metaupdate.Services
 			Assert.AreEqual("__old_key__",cacheGetParentFolder[0].FileHash);
 		}
 
-		[TestMethod]
-		public async Task AddParentCacheIfNotExist_ShouldMergeContent()
-		{
-			var fakeQueryContent =
-				new List<FileIndexItem>
-				{
-					new FileIndexItem("/test.jpg"){FileHash = "test1"},
-					new FileIndexItem("/test2.jpg"){FileHash = "test2"},
-					new FileIndexItem("/test3.jpg"){FileHash = "test3"},
-					new FileIndexItem("/test/test.jpg"){FileHash = "test4"},
-
-				};
-			
-			var fakeUpdatedContent =
-				new List<FileIndexItem>
-				{
-					new FileIndexItem("/test.jpg")
-					{
-						Tags = "updated", 
-						FileHash = "test1"
-					},
-					new FileIndexItem("/test3.jpg")
-					{
-						Tags = "updated", 
-						FileHash = "test3"
-					},
-					new FileIndexItem("/test/test.jpg")
-					{
-						Tags = "updated", 
-						FileHash = "test4"
-					},
-				};
-			
-			var fakeQuery = new FakeIQuery(fakeQueryContent);
-			var metaPreflight = new MetaPreflight(fakeQuery, new AppSettings(), 
-				new FakeSelectorStorage(),new FakeIWebLogger());
-
-			await metaPreflight.AddParentCacheIfNotExist(fakeUpdatedContent);
-
-			var (_, cacheGetParentFolder) = fakeQuery.CacheGetParentFolder("/");
-			
-			Assert.AreEqual(3,cacheGetParentFolder.Count);
-			Assert.AreEqual("updated",cacheGetParentFolder[0].Tags);
-		}
 	}
 }


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

- [x]   (Fixed) _Back-end_ Change Replace to use a single database query and update to empty string (PR #412)
- [x]   (Fixed) _Back-end_ Fix fast updating items to update the cache before update (PR #412)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
