### PR TITLE
no filestream to log && add mac os script

### DIFF
--- a/starsky-tools/import/import.sh
+++ b/starsky-tools/import/import.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Mac OS only:
+# launchctl load -w ~/Library/LaunchAgents/starsky.importer.plist
+# launchctl unload ~/Library/LaunchAgents/starsky.importer.plist
+# chmod +x /opt/starsky/import.sh
+# replace data_disk with your disk name
+
+BACKUP_DIR="/Volumes/data_disk/storage/fotobiebbak"
+
+
+LOCKFILE="/tmp/importd.lock"
+
+# lock file
+if [ -f $LOCKFILE ]; then
+	# Control will enter here if file exists.
+	if [ "$(( $(date +"%s") - $(stat -f "%m" "$LOCKFILE") ))" -gt "3600" ]; then
+		echo "$LOCKFILE is older then 1 hour"
+		rm $LOCKFILE
+	fi
+
+	if [ -f $LOCKFILE ]; then
+		if [ "$(( $(date +"%s") - $(stat -f "%m" "$LOCKFILE") ))" -lt "3600" ]; then
+			echo "$LOCKFILE is younger than 1 hour"
+			exit 1
+		fi
+	fi
+fi
+
+if [ ! -f $LOCKFILE ]; then
+	touch $LOCKFILE
+fi
+
+echo "script started"
+# end lock file
+
+find /Volumes -type d -maxdepth 2 -name "DCIM" -print0 |
+  while IFS= read -r -d '' line;
+  do
+        echo "$line"
+        # just copy
+        /opt/starsky/starsky/starskyimportercli --recursive true -v true -i false --path $line --structure "/yyyyMMdd_HHmmss_{filenamebase}.ext" --basepath $BACKUP_DIR -x false
+
+        # import
+        /opt/starsky/starsky/starskyimportercli --recursive true -v true --move true -i true --path $line
+  done
+
+# lock file
+echo "script ended"
+
+if [ -f $LOCKFILE ]; then
+	echo "Lockfile removed"
+	rm $LOCKFILE
+fi
+# end lock file

--- a/starsky-tools/import/starsky.importer.plist
+++ b/starsky-tools/import/starsky.importer.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>starsky.importer</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>sh</string>
+      <string>-c</string>
+      <string>/opt/starsky/starsky-importer.sh</string>
+    </array>
+    <key>WatchPaths</key>
+    <array>
+       <string>/Volumes/</string>
+    </array>
+    <key>StartOnMount</key>
+    <true/>
+    <key>StandardErrorPath</key>
+    <string>/opt/starsky/z-log-starsky-importer.error.log</string>
+    <key>StandardOutPath</key>
+    <string>/opt/starsky/z-log-starsky-importer.out.log</string>
+  </dict>
+</plist>

--- a/starsky/starsky/Controllers/UploadController.cs
+++ b/starsky/starsky/Controllers/UploadController.cs
@@ -114,7 +114,7 @@ namespace starsky.Controllers
 
 				var writeStatus =
 					await _iStorage.WriteStreamAsync(tempFileStream, subPath);
-				_logger.LogInformation($"write {tempFileStream} is {writeStatus}");
+				_logger.LogInformation($"write {subPath} is {writeStatus}");
 				await tempFileStream.DisposeAsync();
 				
 				// clear directory cache


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

- add script for mac os
- add path instead of filestream to log

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
