### PR TITLE
Feature/202110 ioexception

### DIFF
--- a/history.md
+++ b/history.md
@@ -52,8 +52,9 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Added) _Back-end_  Docker compose support (PR #469)
 - [x]   (Change) _Front-end_ Remove Enzeme as framework for unittests and use react testing framework (PR #463)
 - [x]   (Change) _Back-end_ Retry for DiskWatcher (PR #479)
-- [x]   (Change) _Back-end_ Max amount of retry for DiskWatcher when folders are not accessible (chown) 
-- [x]   (Changed) _Back-end_ DiskWatcher in combination with child folders that have no access keeps a known issue
+- [x]   (Change) _Back-end_ Max amount of retry for DiskWatcher when folders are not accessible (chown) (PR #490)
+- [x]   (Changed) _Back-end_ DiskWatcher in combination with child folders that have no access keeps a known issue 
+- [x]   (Fixed) _Back-end_ Skip folders with meta thumbnail tool when folder has no read rights (PR #490) 
 - todo: filter for import
 
 # version 0.4.11 - 2021-09-17

--- a/history.md
+++ b/history.md
@@ -54,6 +54,7 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Change) _Back-end_ Retry for DiskWatcher (PR #479)
 - [x]   (Change) _Back-end_ Max amount of retry for DiskWatcher when folders are not accessible (chown) 
 - [x]   (Changed) _Back-end_ DiskWatcher in combination with child folders that have no access keeps a known issue
+- todo: filter for import
 
 # version 0.4.11 - 2021-09-17
 - [x]   (Security) _Back-end_  Upgrade .NET Core (TargetFramework) to 3.1.17 (using SDK 3.1.411) (PR #428)

--- a/history.md
+++ b/history.md
@@ -55,7 +55,7 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Change) _Back-end_ Max amount of retry for DiskWatcher when folders are not accessible (chown) (PR #490)
 - [x]   (Changed) _Back-end_ DiskWatcher in combination with child folders that have no access keeps a known issue 
 - [x]   (Fixed) _Back-end_ Skip folders with meta thumbnail tool when folder has no read rights (PR #490) 
-- todo: filter for import
+- [x]   (Added) _Back-end_  Filter for import (ImportIgnore) (PR #490)
 
 # version 0.4.11 - 2021-09-17
 - [x]   (Security) _Back-end_  Upgrade .NET Core (TargetFramework) to 3.1.17 (using SDK 3.1.411) (PR #428)

--- a/history.md
+++ b/history.md
@@ -52,6 +52,8 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Added) _Back-end_  Docker compose support (PR #469)
 - [x]   (Change) _Front-end_ Remove Enzeme as framework for unittests and use react testing framework (PR #463)
 - [x]   (Change) _Back-end_ Retry for DiskWatcher (PR #479)
+- [x]   (Change) _Back-end_ Max amount of retry for DiskWatcher when folders are not accessible (chown) 
+- [x]   (Changed) _Back-end_ DiskWatcher in combination with child folders that have no access keeps a known issue
 
 # version 0.4.11 - 2021-09-17
 - [x]   (Security) _Back-end_  Upgrade .NET Core (TargetFramework) to 3.1.17 (using SDK 3.1.411) (PR #428)

--- a/starsky/starsky.feature.health/HealthCheck/DiskStorageHealthCheck.cs
+++ b/starsky/starsky.feature.health/HealthCheck/DiskStorageHealthCheck.cs
@@ -56,10 +56,15 @@ namespace starsky.feature.health.HealthCheck
 			{
 				drivesList = DriveInfo.GetDrives();
 			}
+			catch ( NullReferenceException )
+			{
+				return ( false, 0L );
+			}
 			catch ( Exception )
 			{
 				return ( false, 0L );
 			}
+
 			DriveInfo driveInfo = drivesList.FirstOrDefault(
 				drive => drive != null && 
 				         string.Equals(drive.Name, driveName, StringComparison.InvariantCultureIgnoreCase));

--- a/starsky/starsky.feature.health/HealthCheck/DiskStorageHealthCheck.cs
+++ b/starsky/starsky.feature.health/HealthCheck/DiskStorageHealthCheck.cs
@@ -56,11 +56,7 @@ namespace starsky.feature.health.HealthCheck
 			{
 				drivesList = DriveInfo.GetDrives();
 			}
-			catch ( NullReferenceException )
-			{
-				return ( false, 0L );
-			}
-			catch ( Exception )
+			catch
 			{
 				return ( false, 0L );
 			}

--- a/starsky/starsky.feature.import/Services/Import.cs
+++ b/starsky/starsky.feature.import/Services/Import.cs
@@ -214,6 +214,16 @@ namespace starsky.feature.import.Services
 		internal async Task<ImportIndexItem> PreflightPerFile(KeyValuePair<string,bool> inputFileFullPath, 
 			ImportSettingsModel importSettings)
 		{
+			if ( _appSettings.ImportIgnore.Any(p => inputFileFullPath.Key.Contains(p)) )
+			{
+				_console.WriteLine($"❌ skip due rules: {inputFileFullPath.Key} ");
+				return new ImportIndexItem{ 
+					Status = ImportStatus.Ignore, 
+					FilePath = inputFileFullPath.Key,
+					AddToDatabase = DateTime.UtcNow
+				};
+			}
+			
 			if ( !inputFileFullPath.Value || !_filesystemStorage.ExistFile(inputFileFullPath.Key) )
 			{
 				if ( _appSettings.IsVerbose() ) _console.WriteLine($"❌ not found: {inputFileFullPath.Key}");

--- a/starsky/starsky.feature.import/Services/ImportCli.cs
+++ b/starsky/starsky.feature.import/Services/ImportCli.cs
@@ -38,11 +38,11 @@ namespace starsky.feature.import.Services
 			_appSettings.Verbose = new ArgsHelper().NeedVerbose(args);
 
 			await _exifToolDownload.DownloadExifTool(_appSettings.IsWindows);
-			
+			_appSettings.ApplicationType = AppSettings.StarskyAppType.Importer;
+
 			if (new ArgsHelper().NeedHelp(args) || new ArgsHelper(_appSettings)
 				.GetPathFormArgs(args,false).Length <= 1)
 			{
-				_appSettings.ApplicationType = AppSettings.StarskyAppType.Importer;
 				new ArgsHelper(_appSettings, _console).NeedHelpShowDialog();
 				return;
 			}

--- a/starsky/starsky.foundation.database/Models/ImportIndexItem.cs
+++ b/starsky/starsky.foundation.database/Models/ImportIndexItem.cs
@@ -27,7 +27,8 @@ namespace starsky.foundation.database.Models
 		IgnoredAlreadyImported,
 		AgeToOld,
 		FileError,
-		NotFound
+		NotFound,
+		Ignore
 	}
 	
     public class ImportIndexItem

--- a/starsky/starsky.foundation.platform/Helpers/ArgsHelper.cs
+++ b/starsky/starsky.foundation.platform/Helpers/ArgsHelper.cs
@@ -293,6 +293,14 @@ namespace starsky.foundation.platform.Helpers
 			_console.WriteLine($"TempFolder {_appSettings.TempFolder} ");
 			_console.WriteLine($"BaseDirectoryProject {_appSettings.BaseDirectoryProject} ");
 
+			_console.Write("SyncIgnore ");
+			foreach ( var rule in _appSettings.SyncIgnore ) _console.Write($"{rule}, ");
+			_console.Write("\n");
+			
+			_console.Write("ImportIgnore ");
+			foreach ( var rule in _appSettings.ImportIgnore ) _console.Write($"{rule}, ");
+			_console.Write("\n");
+
 			if ( _appSettings.ApplicationType == AppSettings.StarskyAppType.Importer)
 				_console.WriteLine("Create xmp on import (ExifToolImportXmpCreate): " + _appSettings.ExifToolImportXmpCreate);
 			

--- a/starsky/starsky.foundation.platform/Models/AppSettings.cs
+++ b/starsky/starsky.foundation.platform/Models/AppSettings.cs
@@ -581,6 +581,13 @@ namespace starsky.foundation.platform.Models
 		/// Use always UNIX style
 		/// </summary>
 		public List<string> SyncIgnore { get; set; } = new List<string>{"/lost+found"};
+		
+		/// <summary>
+		/// Ignore this part of a path while importing
+		/// use env variable: app__importIgnore__0 - value
+		/// Use always UNIX style
+		/// </summary>
+		public List<string> ImportIgnore { get; set; } = new List<string> {"lost+found"};
 	    
 		// -------------------------------------------------
 		// ------------------- Modifiers -------------------

--- a/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
@@ -360,15 +360,22 @@ namespace starsky.foundation.storage.Storage
 		/// <param name="path">The path.</param>
 		/// <param name="list">The list of strings.</param>
 		private static void RecurseFind( string path, List<string> list )
-        {
-            var fl = Directory.GetFiles(path);
-            var dl = Directory.GetDirectories(path);
-            if ( fl.Length <= 0 && dl.Length <= 0 ) return;
+		{
+			var filesArray = new string[]{};
+	        try
+	        {
+		        filesArray = Directory.GetFiles(path);
+	        }
+	        catch ( IOException)
+	        {
+	        }
+            var directoriesArray = Directory.GetDirectories(path);
+            if ( filesArray.Length <= 0 && directoriesArray.Length <= 0 ) return;
             //I begin with the files, and store all of them in the list
-            list.AddRange(fl);
+            list.AddRange(filesArray);
             // I then add the directory and recurse that directory,
             // the process will repeat until there are no more files and directories to recurse
-            foreach(var s in dl)
+            foreach(var s in directoriesArray)
             {
 	            list.Add(s);
 	            RecurseFind(s, list);

--- a/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
@@ -147,7 +147,7 @@ namespace starsky.foundation.storage.Storage
 				}
 				catch(UnauthorizedAccessException e) 
 				{
-					_logger?.LogError("Catch-ed UnauthorizedAccessException => " + e.Message);
+					_logger?.LogError("[StorageHostFullPathFilesystem] Catch-ed UnauthorizedAccessException => " + e.Message);
 				}
 			}
 			return folderList.OrderBy(p => p);
@@ -354,6 +354,25 @@ namespace starsky.foundation.storage.Storage
             return findList.OrderBy(x => x).ToList();
         }
 
+		private Tuple<string[], string[]> GetFilesAndDirectories(string path)
+		{
+			try
+			{
+				var filesArray = Directory.GetFiles(path);
+				var directoriesArray = Directory.GetDirectories(path);
+				return new Tuple<string[], string[]>(filesArray,
+					directoriesArray);
+			}
+			catch ( Exception exception)
+			{
+				_logger?.LogInformation($"[StorageHostFullPathFilesystem] catch-ed ex: {exception.Message} -  {path}");
+				return new Tuple<string[], string[]>(
+					new List<string>().ToArray(),
+					new List<string>().ToArray()
+					);
+			}
+		}
+
 		/// <summary>
 		/// recursive find. (private)
 		/// </summary>
@@ -361,18 +380,8 @@ namespace starsky.foundation.storage.Storage
 		/// <param name="list">The list of strings.</param>
 		private void RecurseFind( string path, List<string> list )
 		{
-			var filesArray = new string[]{};
-	        try
-	        {
-		        filesArray = Directory.GetFiles(path);
-	        }
-	        catch ( IOException exception)
-	        {
-		        _logger.LogError($"SHostFileSystem catch-ed ex: {path} {exception.Message}");
-	        }
-	        
-            var directoriesArray = Directory.GetDirectories(path);
-            if ( filesArray.Length <= 0 && directoriesArray.Length <= 0 ) return;
+			var (filesArray, directoriesArray) = GetFilesAndDirectories(path);
+			if ( filesArray.Length <= 0 && directoriesArray.Length <= 0 ) return;
             //I begin with the files, and store all of them in the list
             list.AddRange(filesArray);
             // I then add the directory and recurse that directory,

--- a/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
@@ -354,7 +354,7 @@ namespace starsky.foundation.storage.Storage
             return findList.OrderBy(x => x).ToList();
         }
 
-		private Tuple<string[], string[]> GetFilesAndDirectories(string path)
+		internal Tuple<string[], string[]> GetFilesAndDirectories(string path)
 		{
 			try
 			{

--- a/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
@@ -359,16 +359,18 @@ namespace starsky.foundation.storage.Storage
 		/// </summary>
 		/// <param name="path">The path.</param>
 		/// <param name="list">The list of strings.</param>
-		private static void RecurseFind( string path, List<string> list )
+		private void RecurseFind( string path, List<string> list )
 		{
 			var filesArray = new string[]{};
 	        try
 	        {
 		        filesArray = Directory.GetFiles(path);
 	        }
-	        catch ( IOException)
+	        catch ( IOException exception)
 	        {
+		        _logger.LogError($"SHostFileSystem catch-ed ex: {path} {exception.Message}");
 	        }
+	        
             var directoriesArray = Directory.GetDirectories(path);
             if ( filesArray.Length <= 0 && directoriesArray.Length <= 0 ) return;
             //I begin with the files, and store all of them in the list

--- a/starsky/starsky.foundation.storage/Storage/StorageSubPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageSubPathFilesystem.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using starsky.foundation.injection;
+using starsky.foundation.platform.Interfaces;
 using starsky.foundation.platform.Models;
 using starsky.foundation.storage.Interfaces;
 using starsky.foundation.storage.Models;
@@ -14,10 +15,12 @@ namespace starsky.foundation.storage.Storage
 	public class StorageSubPathFilesystem : IStorage
 	{
 		private readonly AppSettings _appSettings;
+		private readonly IWebLogger _logger;
 
-		public StorageSubPathFilesystem(AppSettings appSettings)
+		public StorageSubPathFilesystem(AppSettings appSettings, IWebLogger logger)
 		{
 			_appSettings = appSettings;
+			_logger = logger;
 		}
 
 		/// <summary>
@@ -29,7 +32,7 @@ namespace starsky.foundation.storage.Storage
 		{
 			var subPath = _appSettings.DatabasePathToFilePath(path, false);
 			
-			return new StorageHostFullPathFilesystem().Info(subPath);
+			return new StorageHostFullPathFilesystem(_logger).Info(subPath);
 		}
 
 		/// <summary>
@@ -63,7 +66,7 @@ namespace starsky.foundation.storage.Storage
 		public FolderOrFileModel.FolderOrFileTypeList IsFolderOrFile(string path)
 		{
 			var fullFilePath = _appSettings.DatabasePathToFilePath(path,false);
-			return new StorageHostFullPathFilesystem().IsFolderOrFile(fullFilePath);
+			return new StorageHostFullPathFilesystem(_logger).IsFolderOrFile(fullFilePath);
 		}
 
 		/// <summary>
@@ -75,7 +78,7 @@ namespace starsky.foundation.storage.Storage
 		{
 			var inputFileFullPath = _appSettings.DatabasePathToFilePath(fromPath, false);
 			var toFileFullPath = _appSettings.DatabasePathToFilePath(toPath, false);
-			new StorageHostFullPathFilesystem().FolderMove(inputFileFullPath,toFileFullPath);
+			new StorageHostFullPathFilesystem(_logger).FolderMove(inputFileFullPath,toFileFullPath);
 		}
 
 		/// <summary>
@@ -87,7 +90,7 @@ namespace starsky.foundation.storage.Storage
 		{
 			var inputFileFullPath = _appSettings.DatabasePathToFilePath(fromPath, false);
 			var toFileFullPath = _appSettings.DatabasePathToFilePath(toPath, false);
-			new StorageHostFullPathFilesystem().FileMove(inputFileFullPath,toFileFullPath);
+			new StorageHostFullPathFilesystem(_logger).FileMove(inputFileFullPath,toFileFullPath);
 		}
 		
 		/// <summary>
@@ -99,7 +102,7 @@ namespace starsky.foundation.storage.Storage
 		{
 			var inputFileFullPath = _appSettings.DatabasePathToFilePath(fromPath, false);
 			var toFileFullPath = _appSettings.DatabasePathToFilePath(toPath, false);
-			new StorageHostFullPathFilesystem().FileCopy(inputFileFullPath,toFileFullPath);
+			new StorageHostFullPathFilesystem(_logger).FileCopy(inputFileFullPath,toFileFullPath);
 		}
 		
 		/// <summary>
@@ -110,7 +113,7 @@ namespace starsky.foundation.storage.Storage
 		public bool FileDelete(string path)
 		{
 			var inputFileFullPath = _appSettings.DatabasePathToFilePath(path, false);
-			return new StorageHostFullPathFilesystem().FileDelete(inputFileFullPath);
+			return new StorageHostFullPathFilesystem(_logger).FileDelete(inputFileFullPath);
 		}
 		
 		/// <summary>
@@ -131,7 +134,7 @@ namespace starsky.foundation.storage.Storage
 		public bool FolderDelete(string path)
 		{
 			var inputFileFullPath = _appSettings.DatabasePathToFilePath(path, false);
-			return new StorageHostFullPathFilesystem().FolderDelete(inputFileFullPath);
+			return new StorageHostFullPathFilesystem(_logger).FolderDelete(inputFileFullPath);
 		}
 		
 		/// <summary>
@@ -148,7 +151,7 @@ namespace starsky.foundation.storage.Storage
 			// null is not found
 			if (fullFilePath == null) return Enumerable.Empty<string>();
 
-			var imageFilesList = new StorageHostFullPathFilesystem().GetAllFilesInDirectory(fullFilePath);
+			var imageFilesList = new StorageHostFullPathFilesystem(_logger).GetAllFilesInDirectory(fullFilePath);
 
 			// to filter use:
 			// ..etAllFilesInDirectory(subPath)
@@ -172,7 +175,7 @@ namespace starsky.foundation.storage.Storage
 			var fullFilePath = _appSettings.DatabasePathToFilePath(path);
 			if (fullFilePath == null) return Enumerable.Empty<string>();
 
-			var imageFilesList = new StorageHostFullPathFilesystem().GetAllFilesInDirectoryRecursive(fullFilePath);
+			var imageFilesList = new StorageHostFullPathFilesystem(_logger).GetAllFilesInDirectoryRecursive(fullFilePath);
 
 			// to filter use:
 			// ..etAllFilesInDirectory(subPath)
@@ -194,7 +197,7 @@ namespace starsky.foundation.storage.Storage
 			var fullFilePath = _appSettings.DatabasePathToFilePath(path);
 			if (fullFilePath == null) return Enumerable.Empty<string>();
 			
-			var folders = new StorageHostFullPathFilesystem().GetDirectories(fullFilePath);
+			var folders = new StorageHostFullPathFilesystem(_logger).GetDirectories(fullFilePath);
 			// Used For subfolders
 			// convert back to subPath style
 			return _appSettings.RenameListItemsToDbStyle(folders.ToList());
@@ -210,7 +213,7 @@ namespace starsky.foundation.storage.Storage
 			var fullFilePath = _appSettings.DatabasePathToFilePath(path);
 			if (fullFilePath == null) return Enumerable.Empty<string>();
 			
-			var folders = new StorageHostFullPathFilesystem().GetDirectoryRecursive(fullFilePath);
+			var folders = new StorageHostFullPathFilesystem(_logger).GetDirectoryRecursive(fullFilePath);
 
 			// Used For subfolders
 			// convert back to subPath style
@@ -265,7 +268,7 @@ namespace starsky.foundation.storage.Storage
 			// should be able to write files that are not exist yet			
 			var fullFilePath = _appSettings.DatabasePathToFilePath(path,false);
 
-			return new StorageHostFullPathFilesystem().WriteStream(stream, fullFilePath);
+			return new StorageHostFullPathFilesystem(_logger).WriteStream(stream, fullFilePath);
 		}
 
 		public bool WriteStreamOpenOrCreate(Stream stream, string path)
@@ -276,7 +279,7 @@ namespace starsky.foundation.storage.Storage
 		public Task<bool> WriteStreamAsync(Stream stream, string path)
 		{
 			var fullFilePath = _appSettings.DatabasePathToFilePath(path,false);
-			return new StorageHostFullPathFilesystem().WriteStreamAsync(stream, fullFilePath);
+			return new StorageHostFullPathFilesystem(_logger).WriteStreamAsync(stream, fullFilePath);
 		}
 	}
 }

--- a/starsky/starsky.foundation.storage/Storage/StorageThumbnailFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageThumbnailFilesystem.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using starsky.foundation.injection;
+using starsky.foundation.platform.Interfaces;
 using starsky.foundation.platform.Models;
 using starsky.foundation.storage.Interfaces;
 using starsky.foundation.storage.Models;
@@ -15,10 +16,12 @@ namespace starsky.foundation.storage.Storage
 	public class StorageThumbnailFilesystem : IStorage
 	{
 		private readonly AppSettings _appSettings;
+		private readonly IWebLogger _logger;
 
-		public StorageThumbnailFilesystem(AppSettings appSettings)
+		public StorageThumbnailFilesystem(AppSettings appSettings, IWebLogger logger)
 		{
 			_appSettings = appSettings;
+			_logger = logger;
 		}
 
 		internal string CombinePath(string fileHash)
@@ -38,13 +41,13 @@ namespace starsky.foundation.storage.Storage
 		/// <returns></returns>
 		public bool ExistFile(string path)
 		{
-			return new StorageHostFullPathFilesystem().ExistFile(CombinePath(path));
+			return new StorageHostFullPathFilesystem(_logger).ExistFile(CombinePath(path));
 		}
 
 		public bool ExistFolder(string path)
 		{
 			// only for the root folder
-			return new StorageHostFullPathFilesystem().ExistFolder(_appSettings.ThumbnailTempFolder);
+			return new StorageHostFullPathFilesystem(_logger).ExistFolder(_appSettings.ThumbnailTempFolder);
 		}
 
 		public FolderOrFileModel.FolderOrFileTypeList IsFolderOrFile(string path)
@@ -62,7 +65,7 @@ namespace starsky.foundation.storage.Storage
 			var oldThumbPath = CombinePath(fromPath);
 			var newThumbPath = CombinePath(toPath);
 
-			var hostFilesystem = new StorageHostFullPathFilesystem();
+			var hostFilesystem = new StorageHostFullPathFilesystem(_logger);
 
 			var existOldFile = hostFilesystem.ExistFile(oldThumbPath);
 			var existNewFile = hostFilesystem.ExistFile(newThumbPath);
@@ -79,7 +82,7 @@ namespace starsky.foundation.storage.Storage
 			var oldThumbPath = CombinePath(fromPath);
 			var newThumbPath = CombinePath(toPath);
 
-			var hostFilesystem = new StorageHostFullPathFilesystem();
+			var hostFilesystem = new StorageHostFullPathFilesystem(_logger);
 
 			var existOldFile = hostFilesystem.ExistFile(oldThumbPath);
 			var existNewFile = hostFilesystem.ExistFile(newThumbPath);
@@ -101,7 +104,7 @@ namespace starsky.foundation.storage.Storage
 			if (string.IsNullOrEmpty(path) || !ExistFile(path) ) return false;
 
 			var thumbPath = CombinePath(path);
-			var hostFilesystem = new StorageHostFullPathFilesystem();
+			var hostFilesystem = new StorageHostFullPathFilesystem(_logger);
 			return hostFilesystem.FileDelete(thumbPath);
 		}
 
@@ -140,7 +143,7 @@ namespace starsky.foundation.storage.Storage
 		public Stream ReadStream(string path, int maxRead = -1)
 		{
 			if ( !ExistFile(path) ) throw new FileNotFoundException(path); 
-			return new StorageHostFullPathFilesystem().ReadStream(CombinePath(path), maxRead);
+			return new StorageHostFullPathFilesystem(_logger).ReadStream(CombinePath(path), maxRead);
 		}
 
 		/// <summary>
@@ -151,7 +154,7 @@ namespace starsky.foundation.storage.Storage
 		/// <returns></returns>
 		public bool WriteStream(Stream stream, string path)
 		{
-			return new StorageHostFullPathFilesystem()
+			return new StorageHostFullPathFilesystem(_logger)
 				.WriteStream(stream, CombinePath(path));
 		}
 
@@ -162,7 +165,7 @@ namespace starsky.foundation.storage.Storage
 
 		public Task<bool> WriteStreamAsync(Stream stream, string path)
 		{
-			return new StorageHostFullPathFilesystem().WriteStreamAsync(stream, CombinePath(path));
+			return new StorageHostFullPathFilesystem(_logger).WriteStreamAsync(stream, CombinePath(path));
 		}
 
 		public StorageInfo Info(string path)

--- a/starsky/starsky.foundation.sync/WatcherHelpers/SyncWatcherConnector.cs
+++ b/starsky/starsky.foundation.sync/WatcherHelpers/SyncWatcherConnector.cs
@@ -6,7 +6,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using starsky.foundation.database.Interfaces;
 using starsky.foundation.database.Models;
 using starsky.foundation.platform.JsonConverter;

--- a/starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs
+++ b/starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs
@@ -102,8 +102,11 @@ namespace starsky.foundation.sync.WatcherServices
 			        $"{DateTime.UtcNow.ToShortDateString()} ~ {DateTime.UtcNow.ToShortTimeString()}");
 			var path = _fileSystemWatcherWrapper.Path;
 
+			_fileSystemWatcherWrapper.Dispose();
 			_fileSystemWatcherWrapper = fileSystemWatcherWrapper;
-			while (!_fileSystemWatcherWrapper.EnableRaisingEvents)
+
+			var i = 0;
+			while (!_fileSystemWatcherWrapper.EnableRaisingEvents && i < 20)
 			{
 				try
 				{
@@ -119,8 +122,10 @@ namespace starsky.foundation.sync.WatcherServices
 					// Sleep for a bit; otherwise, it takes a bit of
 					// processor time
 					System.Threading.Thread.Sleep(5000);
+					i++;
 				}
 			}
+			_webLogger.LogError($"[DiskWatcher] Failed after {i} times - so stop trying");
 			return false;
 		}
 		

--- a/starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs
+++ b/starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs
@@ -118,7 +118,7 @@ namespace starsky.foundation.sync.WatcherServices
 				}
 				catch
 				{
-					_webLogger.LogInformation("[DiskWatcher] next retry - wait for 5000ms");
+					_webLogger.LogInformation($"[DiskWatcher] next retry {i} - wait for 5000ms");
 					// Sleep for a bit; otherwise, it takes a bit of
 					// processor time
 					System.Threading.Thread.Sleep(5000);

--- a/starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs
+++ b/starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs
@@ -113,7 +113,10 @@ namespace starsky.foundation.sync.WatcherServices
 					// This will throw an error at the
 					// watcher.NotifyFilter line if it can't get the path.
 					Watcher(path);
-					_webLogger.LogError("[DiskWatcher] I'm Back!");
+					if ( _fileSystemWatcherWrapper.EnableRaisingEvents )
+					{
+						_webLogger.LogInformation("[DiskWatcher] I'm Back!");
+					}
 					return true;
 				}
 				catch

--- a/starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs
+++ b/starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs
@@ -96,7 +96,7 @@ namespace starsky.foundation.sync.WatcherServices
 		/// <summary>
 		/// @see: https://www.codeguru.com/dotnet/filesystemwatcher%EF%BF%BDwhy-does-it-stop-working/
 		/// </summary>
-		internal bool Retry(IFileSystemWatcherWrapper fileSystemWatcherWrapper)
+		internal bool Retry(IFileSystemWatcherWrapper fileSystemWatcherWrapper, int numberOfTries = 20, int milliSecondsTimeout = 5000)
 		{
 			_webLogger.LogInformation("[DiskWatcher] next retry " +
 			        $"{DateTime.UtcNow.ToShortDateString()} ~ {DateTime.UtcNow.ToShortTimeString()}");
@@ -106,7 +106,7 @@ namespace starsky.foundation.sync.WatcherServices
 			_fileSystemWatcherWrapper = fileSystemWatcherWrapper;
 
 			var i = 0;
-			while (!_fileSystemWatcherWrapper.EnableRaisingEvents && i < 20)
+			while (!_fileSystemWatcherWrapper.EnableRaisingEvents && i < numberOfTries)
 			{
 				try
 				{
@@ -121,10 +121,10 @@ namespace starsky.foundation.sync.WatcherServices
 				}
 				catch
 				{
-					_webLogger.LogInformation($"[DiskWatcher] next retry {i} - wait for 5000ms");
+					_webLogger.LogInformation($"[DiskWatcher] next retry {i} - wait for {milliSecondsTimeout}ms");
 					// Sleep for a bit; otherwise, it takes a bit of
 					// processor time
-					System.Threading.Thread.Sleep(5000);
+					System.Threading.Thread.Sleep(milliSecondsTimeout);
 					i++;
 				}
 			}

--- a/starsky/starsky.foundation.writemeta/Services/ExifToolDownload.cs
+++ b/starsky/starsky.foundation.writemeta/Services/ExifToolDownload.cs
@@ -32,7 +32,7 @@ namespace starsky.foundation.writemeta.Services
 		{
 			_httpClientHelper = httpClientHelper;
 			_appSettings = appSettings;
-			_hostFileSystemStorage = new StorageHostFullPathFilesystem();
+			_hostFileSystemStorage = new StorageHostFullPathFilesystem(logger);
 			_logger = logger;
 		}
 

--- a/starsky/starsky/appsettings.json
+++ b/starsky/starsky/appsettings.json
@@ -12,7 +12,12 @@
         "addMemoryCache": "true",
         "ExifToolImportXmpCreate": "true",
         "CameraTimeZone": "Europe/Berlin",
-        "readOnlyFolders":["/0001"],
+        "readOnlyFolders":[
+            "/0001"
+        ],
+        "importIgnore":[
+            "lost+found"
+        ],
         "metaThumbnailOnImport": "true",
         "isAccountRegisterOpen": "false",
         "accountRegisterDefaultRole": "User",

--- a/starsky/starsky/readme.md
+++ b/starsky/starsky/readme.md
@@ -50,16 +50,16 @@ You could use machine specific configuration files: appsettings.{machinename}.js
 5.  `CameraTimeZone` - The timezone of the Camera, for example `Europe/Amsterdam` (defaults to your local timezone)
 
 ### Optional settings
-1.  `Structure` - The structure that will be used when you import files, has a default fallback.
-2.  `ReadOnlyFolders` - Accepts a list of folders that never may be edited, defaults a empty list
-3.  `AddMemoryCache` - Enable caching _(default true)_
+1. `Structure` - The structure that will be used when you import files, has a default fallback.
+2. `ReadOnlyFolders` - Accepts a list of folders that never may be edited, defaults a empty list
+3. `AddMemoryCache` - Enable caching _(default true)_
      The only 2 build-in exceptions are when there are no accounts or you already logged in _(default false)_
-4.  `AddSwagger` - To show a user interface to show al REST-services _(default false)_
-5.  `ExifToolImportXmpCreate` - is used to create at import time a xmp file based on the raw image _(default false)_
-6.  `AddSwaggerExport` - To Export Swagger definitions on startup _(default false)_
-7.  `AddLegacyOverwrite`- Read Only value for ("Mono.Runtime") _(default false)_
-8.  `Verbose` - show more console logging  _(default false)_
-9.  `WebFtp` - ftp path, this is used by starskyWebFtpCli
+4. `AddSwagger` - To show a user interface to show al REST-services _(default false)_
+5. `ExifToolImportXmpCreate` - is used to create at import time a xmp file based on the raw image _(default false)_
+6. `AddSwaggerExport` - To Export Swagger definitions on startup _(default false)_
+7. `AddLegacyOverwrite`- Read Only value for ("Mono.Runtime") _(default false)_
+8. `Verbose` - show more console logging  _(default false)_
+9. `WebFtp` - ftp path, this is used by starskyWebFtpCli
 10. `PublishProfiles` - settings to configure publish output, used by starskyWebHtmlCli and publish button
 11. `ExifToolPath` - A path to Exiftool.exe _to ignore the included ExifTool_
 12. `isAccountRegisterOpen` - Allow everyone to register an account _(default false)_
@@ -73,6 +73,7 @@ You could use machine specific configuration files: appsettings.{machinename}.js
 19. `UseDiskWatcher` Watch the disk for changes and update the database _default false (but will change)_
 20. `CheckForUpdates` Check if there are updates on github and notify the user _default true_
 21. `SyncIgnore` Ignore pattern to not include disk items while running sync, uses always unix style and startsWith _default list with: /lost+found_
+22. `ImportIgnore` ImportIgnore filter  _default list with: lost+found_
 
 ### Appsettings.json example
 ```json
@@ -85,7 +86,8 @@ You could use machine specific configuration files: appsettings.{machinename}.js
     "Structure": "/yyyy/MM/yyyy_MM_dd/yyyyMMdd_HHmmss_{filenamebase}.ext",
     "ReadOnlyFolders": ["/2015","/2018"],
     "AddMemoryCache": "true",
-    "CameraTimeZone": "America/New_York"
+    "CameraTimeZone": "America/New_York",
+    "ImportIgnore": ["lost+found"]
   }
 }
 ```

--- a/starsky/starsky/readme.md
+++ b/starsky/starsky/readme.md
@@ -271,3 +271,18 @@ There is also a check to make sure the database runs good
 
 #### Application Insights
 Health issues are also reported to Microsoft Application Insights This only is when a valid key is configured.
+
+### Known issues
+
+#### DiskWatcher in combination with child folders that have no access
+When using `useDiskwatcher: true` and there are child folders that are not allowed to read
+For example the `lost+found` folder
+```
+drwx------ 2 root root  16K Apr 16  2018 lost+found
+```
+Then DiskWatcher is stopping and retry 20 times before the state will be disabled
+```
+[DiskWatcher] (catch-ed) Access to the path '/mnt/external_disk/lost+found' is denied
+```
+
+Solution: make sure that all child folder are accessible

--- a/starsky/starskytest/Controllers/CacheIndexControllerTest.cs
+++ b/starsky/starskytest/Controllers/CacheIndexControllerTest.cs
@@ -84,7 +84,7 @@ namespace starskytest.Controllers
 			// get the service
 			_appSettings = serviceProvider.GetRequiredService<AppSettings>();
 	        
-			_iStorage = new StorageSubPathFilesystem(_appSettings);
+			_iStorage = new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger());
 		}
         
 		[TestMethod]

--- a/starsky/starskytest/Controllers/DeleteControllerTest.cs
+++ b/starsky/starskytest/Controllers/DeleteControllerTest.cs
@@ -100,7 +100,7 @@ namespace starskytest.Controllers
 			// get the background helper
 			_bgTaskQueue = serviceProvider.GetRequiredService<IBackgroundTaskQueue>();
 	        
-			_iStorage = new StorageSubPathFilesystem(_appSettings);
+			_iStorage = new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger());
 
 		}
         
@@ -132,7 +132,7 @@ namespace starskytest.Controllers
 			_appSettings.DatabaseType = AppSettings.DatabaseTypeList.InMemoryDatabase;
 			
 			// RealFs Storage
-			var selectorStorage = new FakeSelectorStorage(new StorageSubPathFilesystem(_appSettings));
+			var selectorStorage = new FakeSelectorStorage(new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger()));
 			
 			var deleteItem = new DeleteItem(_query,_appSettings,selectorStorage);
 			var controller = new DeleteController(deleteItem);
@@ -164,7 +164,7 @@ namespace starskytest.Controllers
 			_appSettings.DatabaseType = AppSettings.DatabaseTypeList.InMemoryDatabase;
 	        
 			var selectorStorage =
-				new FakeSelectorStorage(new StorageSubPathFilesystem(_appSettings));
+				new FakeSelectorStorage(new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger()));
 			
 			var deleteItem = new DeleteItem(_query,_appSettings,selectorStorage);
 			var controller = new DeleteController(deleteItem);
@@ -190,7 +190,7 @@ namespace starskytest.Controllers
 				FileHash = "345678765434567"
 			});
             
-			var selectorStorage = new FakeSelectorStorage(new StorageSubPathFilesystem(_appSettings));
+			var selectorStorage = new FakeSelectorStorage(new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger()));
 			var deleteItem = new DeleteItem(_query,_appSettings,selectorStorage);
 			var controller = new DeleteController(deleteItem);
 			var notFoundResult = controller.Delete("/345678765434567.jpg") as NotFoundObjectResult;

--- a/starsky/starskytest/Controllers/ExportControllerTest.cs
+++ b/starsky/starskytest/Controllers/ExportControllerTest.cs
@@ -61,6 +61,7 @@ namespace starskytest.Controllers
 			// Inject Fake Exiftool; dependency injection
 			var services = new ServiceCollection();
 			services.AddSingleton<IExifTool, FakeExifTool>();
+			services.AddSingleton<IWebLogger, FakeIWebLogger>();
 
 			// Fake the readMeta output
 			services.AddSingleton<IReadMeta, FakeReadMeta>();

--- a/starsky/starskytest/Controllers/ExportControllerTest.cs
+++ b/starsky/starskytest/Controllers/ExportControllerTest.cs
@@ -105,7 +105,7 @@ namespace starskytest.Controllers
 		[TestMethod]
 		public void ExportController_CreateZipNotFound()
 		{
-			var iStorage = new StorageSubPathFilesystem(_appSettings);
+			var iStorage = new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger());
 			var storageSelector = new FakeSelectorStorage(iStorage);
 			var export = new ExportService(_query,_appSettings,storageSelector, new FakeIWebLogger());
 			var controller = new ExportController( _bgTaskQueue, storageSelector, export);
@@ -292,7 +292,7 @@ namespace starskytest.Controllers
 		[TestMethod]
 		public void ExportControllerTest__ThumbFalse__FilePathToFileName()
 		{
-			var storage = new StorageSubPathFilesystem(_appSettings);
+			var storage = new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger());
 			var selectorStorage = new FakeSelectorStorage(storage);
 			var export = new ExportService(_query,_appSettings,selectorStorage, new FakeIWebLogger());
 
@@ -307,7 +307,7 @@ namespace starskytest.Controllers
 		[TestMethod]
 		public void ExportControllerTest__ThumbTrue__FilePathToFileName()
 		{
-			var storage = new StorageSubPathFilesystem(_appSettings);
+			var storage = new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger());
 			var selectorStorage = new FakeSelectorStorage(storage);
 			var export = new ExportService(_query,_appSettings,selectorStorage, new FakeIWebLogger());
 			var filePaths = new List<string>
@@ -333,7 +333,7 @@ namespace starskytest.Controllers
 		[TestMethod]
 		public void ExportController_ZipNotFound()
 		{
-			var storage = new StorageSubPathFilesystem(_appSettings);
+			var storage = new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger());
 			var selectorStorage = new FakeSelectorStorage(storage);
 			var export = new ExportService(_query,_appSettings,selectorStorage, new FakeIWebLogger());
 			var controller = new ExportController( _bgTaskQueue, selectorStorage, export);

--- a/starsky/starskytest/Controllers/MetaUpdateControllerTest.cs
+++ b/starsky/starskytest/Controllers/MetaUpdateControllerTest.cs
@@ -94,7 +94,7 @@ namespace starskytest.Controllers
 			// get the background helper
 			_bgTaskQueue = serviceProvider.GetRequiredService<IBackgroundTaskQueue>();
 	        
-			_iStorage = new StorageSubPathFilesystem(_appSettings);
+			_iStorage = new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger());
 
 		}
         
@@ -125,7 +125,7 @@ namespace starskytest.Controllers
 			var createAnImage = new CreateAnImage();
 			InsertSearchData();
             
-			var selectorStorage = new FakeSelectorStorage(new StorageSubPathFilesystem(_appSettings));
+			var selectorStorage = new FakeSelectorStorage(new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger()));
 	        
 			var metaPreflight = new MetaPreflight(_query,_appSettings,
 				selectorStorage,new FakeIWebLogger());
@@ -162,7 +162,7 @@ namespace starskytest.Controllers
 				ParentDirectory = "/",
 				FileHash = "ApiController_Update_SourceImageMissingOnDisk_WithFakeExifTool"
 			});
-			var selectorStorage = new FakeSelectorStorage(new StorageSubPathFilesystem(_appSettings));
+			var selectorStorage = new FakeSelectorStorage(new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger()));
 
 			var metaPreflight = new MetaPreflight(_query,
 				_appSettings,selectorStorage,new FakeIWebLogger());
@@ -195,7 +195,7 @@ namespace starskytest.Controllers
 				ParentDirectory = "/",
 				FileHash = "345678765434567"
 			});
-			var selectorStorage = new FakeSelectorStorage(new StorageSubPathFilesystem(_appSettings));
+			var selectorStorage = new FakeSelectorStorage(new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger()));
 
 			var metaPreflight = new MetaPreflight(_query,
 				_appSettings,selectorStorage,new FakeIWebLogger());

--- a/starsky/starskytest/FakeMocks/FakeIFileSystemWatcherWrapper.cs
+++ b/starsky/starskytest/FakeMocks/FakeIFileSystemWatcherWrapper.cs
@@ -39,8 +39,25 @@ namespace starskytest.FakeMocks
 		{
 			Error?.Invoke(this, args);
 		}
-		
-		public bool EnableRaisingEvents { get; set; }
+
+		public bool CrashOnEnableRaisingEvents { get; set; } = false;
+
+		public bool EnableRaisingEventsPrivate { get; set; }
+
+		public bool EnableRaisingEvents
+		{
+			get => EnableRaisingEventsPrivate;
+			set
+			{
+				if ( CrashOnEnableRaisingEvents && value )
+				{
+					throw new Exception("test");
+				}
+				
+				EnableRaisingEventsPrivate = value;
+			}
+		}
+
 		public bool IncludeSubdirectories { get; set; }
 		public string Path { get; set; }
 		public string Filter { get; set; }

--- a/starsky/starskytest/Services/FileHashTest.cs
+++ b/starsky/starskytest/Services/FileHashTest.cs
@@ -42,7 +42,7 @@ namespace starskytest.Services
 		public void FileHash_CreateAnImage_Test()
 		{
 			var createAnImage = new CreateAnImage();
-			var iStorage = new StorageSubPathFilesystem(new AppSettings{StorageFolder = createAnImage.BasePath});
+			var iStorage = new StorageSubPathFilesystem(new AppSettings{StorageFolder = createAnImage.BasePath}, new FakeIWebLogger());
 			var fileHashCode = new FileHash(iStorage).GetHashCode(createAnImage.DbPath);
 			Assert.IsTrue(fileHashCode.Value);
 			Assert.AreEqual(26,fileHashCode.Key.Length);
@@ -52,7 +52,7 @@ namespace starskytest.Services
 		public void FileHash_StringArray_CreateAnImage_Test()
 		{
 			var createAnImage = new CreateAnImage();
-			var iStorage = new StorageSubPathFilesystem(new AppSettings{StorageFolder = createAnImage.BasePath});
+			var iStorage = new StorageSubPathFilesystem(new AppSettings{StorageFolder = createAnImage.BasePath}, new FakeIWebLogger());
 			var fileHashCode = new FileHash(iStorage).GetHashCode(new []{createAnImage.DbPath});
 			Assert.IsTrue(fileHashCode[0].Value);
 			Assert.AreEqual(26,fileHashCode[0].Key.Length);

--- a/starsky/starskytest/Services/ReadMeta_ReadMetaBoth_Cache_Test.cs
+++ b/starsky/starskytest/Services/ReadMeta_ReadMetaBoth_Cache_Test.cs
@@ -25,7 +25,7 @@ namespace starskytest.Services
 		{
 
 			var appsettings = new AppSettings {StorageFolder = new CreateAnImage().BasePath};
-			var iStorage = new StorageSubPathFilesystem(appsettings);
+			var iStorage = new StorageSubPathFilesystem(appsettings, new FakeIWebLogger());
 
 			var listofFiles = new List<string>{ new CreateAnImage().DbPath};
 			var fakeCache =
@@ -40,7 +40,7 @@ namespace starskytest.Services
 		public void ReadMeta_ReadMetaBothTest_RemoveCache()
 		{
 			var appSettings = new AppSettings {StorageFolder = new CreateAnImage().BasePath};
-			var iStorage = new StorageSubPathFilesystem(appSettings);
+			var iStorage = new StorageSubPathFilesystem(appSettings, new FakeIWebLogger());
 			var fakeCache =
 				new FakeMemoryCache(new Dictionary<string, object>());
 			new ReadMeta(iStorage,appSettings, fakeCache)

--- a/starsky/starskytest/Services/SyncServiceTest.cs
+++ b/starsky/starskytest/Services/SyncServiceTest.cs
@@ -66,10 +66,10 @@ namespace starskytest.Services
 			// Activate Query
 			_query = new Query(context,memoryCache);
             
-			_iStorage = new StorageSubPathFilesystem(_appSettings);
+			_iStorage = new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger());
 			var readmeta = new ReadMeta(_iStorage,_appSettings);
 			// Activate SyncService
-			var iStorage = new StorageSubPathFilesystem(_appSettings);
+			var iStorage = new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger());
 			var storageSelector = new FakeSelectorStorage(iStorage);
 			_syncService = new SyncService(_query,_appSettings,storageSelector);
 		}

--- a/starsky/starskytest/starsky.feature.import/Services/ImportTest.cs
+++ b/starsky/starskytest/starsky.feature.import/Services/ImportTest.cs
@@ -72,6 +72,23 @@ namespace starskytest.starsky.feature.import.Services
 		}
 		
 		[TestMethod]
+		public async Task Preflight_SingleImage_Ignore()
+		{
+			var appSettings = new AppSettings{Verbose = true, ImportIgnore = new List<string>(){"test"}};
+			var importService = new Import(new FakeSelectorStorage(_iStorageFake), appSettings, new FakeIImportQuery(),
+				new FakeExifTool(_iStorageFake, appSettings), null, _console, new FakeIMetaExifThumbnailService());
+
+			var result = await importService.Preflight(
+				new List<string> {"/test.jpg"},
+				new ImportSettingsModel());
+			
+			Assert.IsNotNull(result.FirstOrDefault());
+			Assert.AreEqual(ImportStatus.Ignore, result.FirstOrDefault().Status);
+			
+			Assert.IsNull(result.FirstOrDefault().FileIndexItem);
+		}
+		
+		[TestMethod]
 		public async Task Preflight_SingleImage_Ignore_ColorClassOverwrite()
 		{
 			var appSettings = new AppSettings{Verbose = true};

--- a/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
+++ b/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
@@ -62,11 +62,11 @@ namespace starskytest.starsky.feature.rename.Services
 				});
 			}
 			
-			var iStorage = new StorageSubPathFilesystem(_appSettings);
+			var iStorage = new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger());
 
 			var readMeta = new ReadMeta(iStorage,_appSettings,memoryCache);
 			
-			_iStorageSubPath = new StorageSubPathFilesystem(_appSettings);
+			_iStorageSubPath = new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger());
 			
 			var services = new ServiceCollection();
 			var selectorStorage = new FakeSelectorStorage(iStorage);

--- a/starsky/starskytest/starsky.foundation.storage/Services/StructureServiceTest.cs
+++ b/starsky/starskytest/starsky.foundation.storage/Services/StructureServiceTest.cs
@@ -70,7 +70,7 @@ namespace starskytest.starsky.foundation.storage.Services
 			var storage = new StorageSubPathFilesystem(new AppSettings
 			{
 				StorageFolder = new CreateAnImage().BasePath
-			});
+			}, new FakeIWebLogger());
 			storage.CreateDirectory("test");
 			
 			var result = new StructureService(storage, structure).ParseSubfolders(

--- a/starsky/starskytest/starsky.foundation.storage/Storage/StorageHostFullPathFilesystemTest.cs
+++ b/starsky/starskytest/starsky.foundation.storage/Storage/StorageHostFullPathFilesystemTest.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using starsky.foundation.storage.Models;
 using starsky.foundation.storage.Storage;
 using starskytest.FakeCreateAn;
+using starskytest.FakeMocks;
 
 namespace starskytest.starsky.foundation.storage.Storage
 {
@@ -23,6 +24,17 @@ namespace starskytest.starsky.foundation.storage.Storage
 
 			// Gives a list of the content in the temp folder.
 			Assert.AreEqual(true, content.Any());            
+		}
+		
+		[TestMethod]
+		public void GetAllFilesInDirectoryRecursive_NotFound()
+		{
+			var logger = new FakeIWebLogger();
+			var realStorage = new StorageHostFullPathFilesystem(logger);
+			var directories = realStorage.GetAllFilesInDirectoryRecursive("NOT:\\t");
+			
+			Assert.IsTrue(logger.TrackedInformation.LastOrDefault().Item2.Contains("Could not find a part of the path"));
+			Assert.AreEqual(directories.Count(),0);
 		}
 		
 		[TestMethod]
@@ -47,5 +59,18 @@ namespace starskytest.starsky.foundation.storage.Storage
 			Assert.AreEqual(false,realStorage.ExistFolder(rootDir));
 			Assert.AreEqual(false,realStorage.ExistFolder(childDir));
 		}
+
+		[TestMethod]
+		public void GetFilesAndDirectories_Exception_NotFound()
+		{
+			var logger = new FakeIWebLogger();
+			var realStorage = new StorageHostFullPathFilesystem(logger);
+			var directories = realStorage.GetFilesAndDirectories("NOT:\\t");
+			
+			Assert.IsTrue(logger.TrackedInformation.LastOrDefault().Item2.Contains("Could not find a part of the path"));
+			Assert.AreEqual(directories.Item1.Length,0);
+			Assert.AreEqual(directories.Item2.Length,0);
+		}
+
 	}
 }

--- a/starsky/starskytest/starsky.foundation.storage/Storage/StorageHostFullPathFilesystemTest.cs
+++ b/starsky/starskytest/starsky.foundation.storage/Storage/StorageHostFullPathFilesystemTest.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using starsky.foundation.platform.Models;
 using starsky.foundation.storage.Models;
 using starsky.foundation.storage.Storage;
 using starskytest.FakeCreateAn;
@@ -32,8 +33,16 @@ namespace starskytest.starsky.foundation.storage.Storage
 			var logger = new FakeIWebLogger();
 			var realStorage = new StorageHostFullPathFilesystem(logger);
 			var directories = realStorage.GetAllFilesInDirectoryRecursive("NOT:\\t");
+
+			if ( new AppSettings().IsWindows )
+			{
+				Assert.IsTrue(logger.TrackedInformation.LastOrDefault().Item2.Contains("The filename, directory name, or volume label syntax is incorrect"));
+			}
+			else
+			{
+				Assert.IsTrue(logger.TrackedInformation.LastOrDefault().Item2.Contains("Could not find a part of the path"));
+			}
 			
-			Assert.IsTrue(logger.TrackedInformation.LastOrDefault().Item2.Contains("Could not find a part of the path"));
 			Assert.AreEqual(directories.Count(),0);
 		}
 		
@@ -67,7 +76,15 @@ namespace starskytest.starsky.foundation.storage.Storage
 			var realStorage = new StorageHostFullPathFilesystem(logger);
 			var directories = realStorage.GetFilesAndDirectories("NOT:\\t");
 			
-			Assert.IsTrue(logger.TrackedInformation.LastOrDefault().Item2.Contains("Could not find a part of the path"));
+			if ( new AppSettings().IsWindows )
+			{
+				Assert.IsTrue(logger.TrackedInformation.LastOrDefault().Item2.Contains("The filename, directory name, or volume label syntax is incorrect"));
+			}
+			else
+			{
+				Assert.IsTrue(logger.TrackedInformation.LastOrDefault().Item2.Contains("Could not find a part of the path"));
+			}
+			
 			Assert.AreEqual(directories.Item1.Length,0);
 			Assert.AreEqual(directories.Item2.Length,0);
 		}

--- a/starsky/starskytest/starsky.foundation.storage/Storage/StorageSubPathFilesystemTest.cs
+++ b/starsky/starskytest/starsky.foundation.storage/Storage/StorageSubPathFilesystemTest.cs
@@ -5,6 +5,7 @@ using starsky.foundation.platform.Models;
 using starsky.foundation.storage.Helpers;
 using starsky.foundation.storage.Storage;
 using starskytest.FakeCreateAn;
+using starskytest.FakeMocks;
 
 namespace starskytest.starsky.foundation.storage.Storage
 {
@@ -18,7 +19,7 @@ namespace starskytest.starsky.foundation.storage.Storage
 		{
 			_newImage = new CreateAnImage();
 			var appSettings = new AppSettings {StorageFolder = _newImage.BasePath};
-			_storage = new StorageSubPathFilesystem(appSettings);
+			_storage = new StorageSubPathFilesystem(appSettings, new FakeIWebLogger());
 		}
 		
 		[TestMethod]

--- a/starsky/starskytest/starsky.foundation.storage/Storage/StorageThumbnailFilesystemTest.cs
+++ b/starsky/starskytest/starsky.foundation.storage/Storage/StorageThumbnailFilesystemTest.cs
@@ -6,6 +6,7 @@ using starsky.foundation.platform.Helpers;
 using starsky.foundation.platform.Models;
 using starsky.foundation.storage.Storage;
 using starskytest.FakeCreateAn;
+using starskytest.FakeMocks;
 
 namespace starskytest.starsky.foundation.storage.Storage
 {
@@ -19,7 +20,7 @@ namespace starskytest.starsky.foundation.storage.Storage
 		{
 			var createNewImage = new CreateAnImage();
 			var appSettings = new AppSettings {ThumbnailTempFolder = createNewImage.BasePath};
-			_thumbnailStorage = new StorageThumbnailFilesystem(appSettings);
+			_thumbnailStorage = new StorageThumbnailFilesystem(appSettings, new FakeIWebLogger());
 			_fileNameWithoutExtension = FilenamesHelper.GetFileNameWithoutExtension(createNewImage.FileName);
 
 		}

--- a/starsky/starskytest/starsky.foundation.sync/SyncServices/SingleFileIntegrationTest.cs
+++ b/starsky/starskytest/starsky.foundation.sync/SyncServices/SingleFileIntegrationTest.cs
@@ -51,7 +51,7 @@ namespace starskytest.starsky.foundation.sync.SyncServices
 			
 			var serviceProvider = provider.BuildServiceProvider();
 			
-			_iStorage = new StorageSubPathFilesystem(_appSettings);
+			_iStorage = new StorageSubPathFilesystem(_appSettings, new FakeIWebLogger());
 			_scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
 			_query = serviceProvider.GetRequiredService<IQuery>();
 		}

--- a/starsky/starskytest/starsky.foundation.sync/WatcherServices/DiskWatcherTest.cs
+++ b/starsky/starskytest/starsky.foundation.sync/WatcherServices/DiskWatcherTest.cs
@@ -144,5 +144,22 @@ namespace starskytest.starsky.foundation.sync.WatcherServices
 			
 			Assert.IsTrue(result);	
 		}
+		
+		
+		[TestMethod]
+		[Timeout(500)]
+		public void Watcher_CrashAnd_Retry()
+		{
+			var fakeIFileSystemWatcher = new FakeIFileSystemWatcherWrapper()
+			{
+				CrashOnEnableRaisingEvents = true
+			};
+			
+			fakeIFileSystemWatcher.EnableRaisingEvents = false;
+			
+			var result = new DiskWatcher(fakeIFileSystemWatcher, _scopeFactory).Retry(fakeIFileSystemWatcher,1,0);
+			
+			Assert.IsFalse(result);	
+		}
 	}
 }

--- a/starsky/starskytest/starsky.foundation.thumbnailgeneration/Services/ThumbnailCleanerTest.cs
+++ b/starsky/starskytest/starsky.foundation.thumbnailgeneration/Services/ThumbnailCleanerTest.cs
@@ -74,7 +74,7 @@ namespace starskytest.starsky.foundation.thumbnailgeneration.Services
 				ThumbnailTempFolder = existFullDir,
 				Verbose = true
 			};
-			var thumbnailStorage = new StorageThumbnailFilesystem(appSettings);
+			var thumbnailStorage = new StorageThumbnailFilesystem(appSettings, new FakeIWebLogger());
 			
 			var thumbnailCleaner = new ThumbnailCleaner(thumbnailStorage, _query,appSettings, new FakeIWebLogger());
 			


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

- [x]   (Change) _Back-end_ Max amount of retry for DiskWatcher when folders are not accessible (chown) (PR #490)
- [x]   (Changed) _Back-end_ DiskWatcher in combination with child folders that have no access keeps a known issue 
- [x]   (Fixed) _Back-end_ Skip folders with meta thumbnail tool when folder has no read rights (PR #490) 
- [x]   (Added) _Back-end_  Filter for import (ImportIgnore) (PR #490)

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [x] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
