### PR TITLE
dependencies upgrade .NET SDK Upgrade to 3.1.415

### DIFF
--- a/starsky/nuget-packages-list.json
+++ b/starsky/nuget-packages-list.json
@@ -46,7 +46,7 @@
   "XmpCore 6.1.10.1",
   "MetadataExtractor 2.7.1",
   "Microsoft.ApplicationInsights.AspNetCore 2.19.0",
-  "Microsoft.Extensions.Logging.Console 3.1.17",
+  "Microsoft.Extensions.Logging.Console 3.1.21",
   "MedallionShell 1.6.2",
   "Microsoft.AspNetCore.Identity.EntityFrameworkCore 3.1.21",
   "Microsoft.Extensions.Hosting 3.1.21",

--- a/starsky/starsky.foundation.webtelemetry/starsky.foundation.webtelemetry.csproj
+++ b/starsky/starsky.foundation.webtelemetry/starsky.foundation.webtelemetry.csproj
@@ -18,7 +18,7 @@
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.19.0" />
       <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
       <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.17" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.21" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(noSonar)' == 'true' ">


### PR DESCRIPTION
## Upgrade of .NET with newer SDK Version
- Install SDK version 3.1.415 on your development machine https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1.21/3.1.21.md
- First test on linux-arm test envs before approve
- update azure runtime on test https://demostarsky.scm.azurewebsites.net/
- update docs with minimal version https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_3.1.415/starsky/readme.md
- update changelog https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_3.1.415/history.md

## When upgrading a major version
- when upgrading to newer major release check docker