### PR TITLE
Feature/202112 indexes

### DIFF
--- a/history.md
+++ b/history.md
@@ -77,7 +77,8 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Changed) _Back-end_ Add dispose on parallel jobs  (PR #552)
 - [x]   (Added) _Back-end_  Add index for IX_ImportIndex_FileHash and IX_Credentials_Id_Identifier (PR #555)
 - [x]   (Added) _Back-end_ Fix for cache ManualSync when item is removed or added its now correct updated (PR #555)
-- [x]   (Added) _Back-end_ Fix for Safari 14.x and newer that after close a modal, the scroll isn't locked anymore (PR #555) 
+- [x]   (Fixed) _Front-end_ Fix for Safari 14.x and newer that after close a modal, the scroll isn't locked anymore (PR #555) 
+- [x]   (Fixed) _Back-end_ Add port to websocket url in connect-src for Safari 14.x using different port numbers  (PR #555)
 
 # version 0.4.12 - 2021-11-04
 - [x]   (Changed) _Back-end_ Your account is locked for an hour when you enter 3 non valid passwords (PR #443 & #445 & #446)

--- a/history.md
+++ b/history.md
@@ -75,6 +75,9 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Fixed) _Back-end_ Extend ServiceCollectionExtensions to load more Assemblies to get auto mapped by the service attribute (PR #550)
 - [x]   (Added) _Back-end_ Add Application Insights logging for CLI Applications (Admin, Geo, Import, Synchronize, Thumbnail) (PR #552)
 - [x]   (Changed) _Back-end_ Add dispose on parallel jobs  (PR #552)
+- [x]   (Added) _Back-end_  Add index for IX_ImportIndex_FileHash and IX_Credentials_Id_Identifier (PR #555)
+- [x]   (Added) _Back-end_ Fix for cache ManualSync when item is removed or added its now correct updated (PR #555)
+- [x]   (Added) _Back-end_ Fix for Safari 14.x and newer that after close a modal, the scroll isn't locked anymore (PR #555) 
 
 # version 0.4.12 - 2021-11-04
 - [x]   (Changed) _Back-end_ Your account is locked for an hour when you enter 3 non valid passwords (PR #443 & #445 & #446)

--- a/starsky/starsky.foundation.database/Data/ApplicationDbContext.cs
+++ b/starsky/starsky.foundation.database/Data/ApplicationDbContext.cs
@@ -29,9 +29,9 @@ namespace starsky.foundation.database.Data
 		protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
 		{
 			// Do nothing because of that in debug mode this only triggered
-			#if (DEBUG) 
-				optionsBuilder.EnableSensitiveDataLogging();
-			#endif
+#if (DEBUG) 
+			optionsBuilder.EnableSensitiveDataLogging();
+#endif
 		}
 			
 		protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -41,7 +41,7 @@ namespace starsky.foundation.database.Data
 			// Add Index to speed performance (on MySQL max key length is 3072 bytes)
 			modelBuilder.Entity<FileIndexItem>()
 				.HasIndex(x => new { x.FileName, x.ParentDirectory });
-	
+			
 			modelBuilder.Entity<User>(etb =>
 				{
 					etb.HasKey(e => e.Id);
@@ -55,10 +55,10 @@ namespace starsky.foundation.database.Data
 					var converter = new ValueConverter<DateTime, string>(
 						v =>
 							v.ToString(@"yyyy\-MM\-dd HH:mm:ss.fff", CultureInfo.InvariantCulture),
-					v => DateTime.TryParseExact(v, @"yyyy\-MM\-dd HH:mm:ss.fff", 
-						CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out parsedDateTime)
-						? parsedDateTime
-						: DateTime.MinValue
+						v => DateTime.TryParseExact(v, @"yyyy\-MM\-dd HH:mm:ss.fff", 
+							CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out parsedDateTime)
+							? parsedDateTime
+							: DateTime.MinValue
 					);
 					
 					etb.Property(e => e.LockoutEnd)
@@ -80,16 +80,18 @@ namespace starsky.foundation.database.Data
 			);
 
 			modelBuilder.Entity<Credential>(etb =>
-				{
-					etb.HasKey(e => e.Id);
-					etb.Property(e => e.Id)
-						.ValueGeneratedOnAdd()
-						.HasAnnotation("MySql:ValueGeneratedOnAdd", true);
-					etb.Property(e => e.Identifier).IsRequired().HasMaxLength(64);
-					etb.Property(e => e.Secret).HasMaxLength(1024);
-					etb.ToTable("Credentials");
-				}
-			);
+			{
+				etb.HasKey(e => e.Id);
+				etb.Property(e => e.Id)
+					.ValueGeneratedOnAdd()
+					.HasAnnotation("MySql:ValueGeneratedOnAdd", true);
+				etb.Property(e => e.Identifier).IsRequired().HasMaxLength(64);
+				etb.Property(e => e.Secret).HasMaxLength(1024);
+				etb.ToTable("Credentials");
+			});
+
+			modelBuilder.Entity<Credential>()
+				.HasIndex(x => new { x.Id, x.Identifier });
 
 			modelBuilder.Entity<Role>(etb =>
 				{
@@ -128,6 +130,10 @@ namespace starsky.foundation.database.Data
 					etb.ToTable("RolePermissions");
 				}
 			);
+			
+			modelBuilder.Entity<ImportIndexItem>()
+				.HasIndex(x => new { x.FileHash });
+			
 		}
 	}
 }

--- a/starsky/starsky.foundation.database/Migrations/20211214155311_IndexOnDatabaseSeed.Designer.cs
+++ b/starsky/starsky.foundation.database/Migrations/20211214155311_IndexOnDatabaseSeed.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using starsky.foundation.database.Data;
 
 namespace starsky.foundation.database.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211214155311_IndexOnDatabaseSeed")]
+    partial class IndexOnDatabaseSeed
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/starsky/starsky.foundation.database/Migrations/20211214155311_IndexOnDatabaseSeed.cs
+++ b/starsky/starsky.foundation.database/Migrations/20211214155311_IndexOnDatabaseSeed.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace starsky.foundation.database.Migrations
+{
+    public partial class IndexOnDatabaseSeed : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportIndex_FileHash",
+                table: "ImportIndex",
+                column: "FileHash");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Credentials_Id_Identifier",
+                table: "Credentials",
+                columns: new[] { "Id", "Identifier" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ImportIndex_FileHash",
+                table: "ImportIndex");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Credentials_Id_Identifier",
+                table: "Credentials");
+        }
+    }
+}

--- a/starsky/starsky.foundation.database/Query/Query.cs
+++ b/starsky/starsky.foundation.database/Query/Query.cs
@@ -215,7 +215,7 @@ namespace starsky.foundation.database.Query
         /// <param name="functionName">how is the function called</param>
         /// <param name="singleItemDbPath">the path</param>
         /// <returns>an unique key</returns>
-        private string CachingDbName(string functionName, string singleItemDbPath)
+        internal string CachingDbName(string functionName, string singleItemDbPath)
         {
 	        // when is nothing assume its the home item
             if ( string.IsNullOrWhiteSpace(singleItemDbPath) ) singleItemDbPath = "/";
@@ -549,7 +549,7 @@ namespace starsky.foundation.database.Query
             // If cache is turned of
             if( _cache == null || _appSettings?.AddMemoryCache == false) return;
 
-            var queryCacheName = CachingDbName(typeof(List<FileIndexItem>).Name, 
+            var queryCacheName = CachingDbName(nameof(FileIndexItem), 
                 updateStatusContent.ParentDirectory);
 
             if (!_cache.TryGetValue(queryCacheName, out var objectFileFolders)) return;
@@ -564,60 +564,60 @@ namespace starsky.foundation.database.Query
             _cache.Set(queryCacheName, displayFileFolders, new TimeSpan(1,0,0));
         }
 
-        /// <summary>
-        /// Cache API within Query to update cached items
-        /// </summary>
-        /// <param name="updateStatusContent">items to update</param>
-        public void CacheUpdateItem(List<FileIndexItem> updateStatusContent)
-        {
-            if( _cache == null || _appSettings?.AddMemoryCache == false) return;
+	    /// <summary>
+	    /// Cache API within Query to update cached items
+	    /// </summary>
+	    /// <param name="updateStatusContent">items to update</param>
+	    public void CacheUpdateItem(List<FileIndexItem> updateStatusContent)
+	    {
+		    if( _cache == null || _appSettings?.AddMemoryCache == false) return;
 
-            var skippedCacheItems = new HashSet<string>();
-			foreach (var item in updateStatusContent.ToList())
-			{
-				// ToList() > Collection was modified; enumeration operation may not execute.
-				var queryCacheName = CachingDbName(typeof(List<FileIndexItem>).Name, 
-					item.ParentDirectory);
+		    var skippedCacheItems = new HashSet<string>();
+		    foreach (var item in updateStatusContent.ToList())
+		    {
+			    // ToList() > Collection was modified; enumeration operation may not execute.
+			    var queryCacheName = CachingDbName(nameof(FileIndexItem), 
+				    item.ParentDirectory);
 
-				if ( !_cache.TryGetValue(queryCacheName,
-					out var objectFileFolders) )
-				{
-					skippedCacheItems.Add(item.ParentDirectory);
-					continue;
-				}
+			    if ( !_cache.TryGetValue(queryCacheName,
+				        out var objectFileFolders) )
+			    {
+				    skippedCacheItems.Add(item.ParentDirectory);
+				    continue;
+			    }
 				
-				var displayFileFolders = (List<FileIndexItem>) objectFileFolders;
+			    var displayFileFolders = (List<FileIndexItem>) objectFileFolders;
 
-				// make it a list to avoid enum errors
-				displayFileFolders = displayFileFolders.ToList();
+			    // make it a list to avoid enum errors
+			    displayFileFolders = displayFileFolders.ToList();
 				
-				var obj = displayFileFolders.FirstOrDefault(p => p.FilePath == item.FilePath);
-				if (obj == null) continue;
-				displayFileFolders.Remove(obj);
+			    var obj = displayFileFolders.FirstOrDefault(p => p.FilePath == item.FilePath);
+			    if (obj == null) continue;
+			    displayFileFolders.Remove(obj);
 
-				if ( item.Status == FileIndexItem.ExifStatus.OkAndSame )
-				{
-					item.Status = FileIndexItem.ExifStatus.Ok;
-				}
+			    if ( item.Status == FileIndexItem.ExifStatus.OkAndSame )
+			    {
+				    item.Status = FileIndexItem.ExifStatus.Ok;
+			    }
 
-				// Add here item to cached index
-				displayFileFolders.Add(item);
+			    // Add here item to cached index
+			    displayFileFolders.Add(item);
 				
-				// make it a list to avoid enum errors
-				displayFileFolders = displayFileFolders.ToList();
-				// Order by filename
-				displayFileFolders = displayFileFolders.OrderBy(p => p.FileName).ToList();
+			    // make it a list to avoid enum errors
+			    displayFileFolders = displayFileFolders.ToList();
+			    // Order by filename
+			    displayFileFolders = displayFileFolders.OrderBy(p => p.FileName).ToList();
 				
-				_cache.Remove(queryCacheName);
-				_cache.Set(queryCacheName, displayFileFolders, new TimeSpan(1,0,0));
-			}
+			    _cache.Remove(queryCacheName);
+			    _cache.Set(queryCacheName, displayFileFolders, new TimeSpan(1,0,0));
+		    }
 
-			if ( skippedCacheItems.Any() )
-			{
-				_logger?.LogInformation($"[CacheUpdateItem] skipped: {string.Join(", ", skippedCacheItems)}");
-			}
+		    if ( skippedCacheItems.Any() )
+		    {
+			    _logger?.LogInformation($"[CacheUpdateItem] skipped: {string.Join(", ", skippedCacheItems)}");
+		    }
 			
-        }
+	    }
 
         /// <summary>
         /// Cache Only! Private api within Query to remove cached items
@@ -645,7 +645,7 @@ namespace starsky.foundation.database.Query
             // Add protection for disabled caching
             if( _cache == null || _appSettings?.AddMemoryCache == false) return;
 
-            var queryCacheName = CachingDbName(typeof(List<FileIndexItem>).Name, 
+            var queryCacheName = CachingDbName(nameof(FileIndexItem), 
                 updateStatusContent.ParentDirectory);
 
             if (!_cache.TryGetValue(queryCacheName, out var objectFileFolders)) return;
@@ -670,7 +670,7 @@ namespace starsky.foundation.database.Query
             // Add protection for disabled caching
             if( _cache == null || _appSettings?.AddMemoryCache == false) return false;
             
-            var queryCacheName = CachingDbName(typeof(List<FileIndexItem>).Name, 
+            var queryCacheName = CachingDbName(nameof(FileIndexItem), 
                 PathHelper.RemoveLatestSlash(directoryName.Clone().ToString()));
             if (!_cache.TryGetValue(queryCacheName, out _)) return false;
             
@@ -688,7 +688,7 @@ namespace starsky.foundation.database.Query
 	        // Add protection for disabled caching
 	        if( _cache == null || _appSettings?.AddMemoryCache == false) return false;
             
-	        var queryCacheName = CachingDbName(typeof(List<FileIndexItem>).Name, 
+	        var queryCacheName = CachingDbName(nameof(FileIndexItem), 
 		        PathHelper.RemoveLatestSlash(directoryName.Clone().ToString()));
             
 	        _cache.Set(queryCacheName, items,  

--- a/starsky/starsky.foundation.database/Query/Query.cs
+++ b/starsky/starsky.foundation.database/Query/Query.cs
@@ -565,7 +565,7 @@ namespace starsky.foundation.database.Query
         }
 
 	    /// <summary>
-	    /// Cache API within Query to update cached items
+	    /// Cache API within Query to update cached items and implicit add items to list
 	    /// </summary>
 	    /// <param name="updateStatusContent">items to update</param>
 	    public void CacheUpdateItem(List<FileIndexItem> updateStatusContent)
@@ -575,6 +575,11 @@ namespace starsky.foundation.database.Query
 		    var skippedCacheItems = new HashSet<string>();
 		    foreach (var item in updateStatusContent.ToList())
 		    {
+			    if ( item.Status == FileIndexItem.ExifStatus.OkAndSame || item.Status == FileIndexItem.ExifStatus.Default )
+			    {
+				    item.Status = FileIndexItem.ExifStatus.Ok;
+			    }
+			    
 			    // ToList() > Collection was modified; enumeration operation may not execute.
 			    var queryCacheName = CachingDbName(nameof(FileIndexItem), 
 				    item.ParentDirectory);
@@ -590,18 +595,21 @@ namespace starsky.foundation.database.Query
 
 			    // make it a list to avoid enum errors
 			    displayFileFolders = displayFileFolders.ToList();
+
+
 				
 			    var obj = displayFileFolders.FirstOrDefault(p => p.FilePath == item.FilePath);
-			    if (obj == null) continue;
-			    displayFileFolders.Remove(obj);
-
-			    if ( item.Status == FileIndexItem.ExifStatus.OkAndSame )
+			    if ( obj != null )
 			    {
-				    item.Status = FileIndexItem.ExifStatus.Ok;
+				    // remove add again
+				    displayFileFolders.Remove(obj);
 			    }
-
-			    // Add here item to cached index
-			    displayFileFolders.Add(item);
+			    
+			    if ( item.Status == FileIndexItem.ExifStatus.Ok) // ExifStatus.default is already changed
+			    {
+				    // Add here item to cached index
+				    displayFileFolders.Add(item);
+			    }
 				
 			    // make it a list to avoid enum errors
 			    displayFileFolders = displayFileFolders.ToList();

--- a/starsky/starsky.foundation.database/Query/QueryFolder.cs
+++ b/starsky/starsky.foundation.database/Query/QueryFolder.cs
@@ -85,7 +85,7 @@ namespace starsky.foundation.database.Query
 		        return fallbackResult;
 	        
 	        // Return values from IMemoryCache
-	        var queryCacheName = CachingDbName(typeof(List<FileIndexItem>).Name, 
+	        var queryCacheName = CachingDbName(nameof(FileIndexItem), 
 		        subPath);
 
 	        // ReSharper disable once ConvertIfStatementToReturnStatement

--- a/starsky/starsky.foundation.database/Query/QueryFolder.cs
+++ b/starsky/starsky.foundation.database/Query/QueryFolder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using starsky.foundation.database.Data;
 using starsky.foundation.database.Models;
@@ -114,7 +115,8 @@ namespace starsky.foundation.database.Query
 	        List<FileIndexItem> QueryItems(ApplicationDbContext context)
 	        {
 		        var queryItems = context.FileIndex
-			        .Where(p => p.ParentDirectory == subPath)
+			        .TagWith("QueryDisplayFileFolders")
+			        .Where(p => p.ParentDirectory == subPath && p.FileName != "/")
 			        .OrderBy(p => p.FileName).AsEnumerable()	
 			        // remove duplicates from list
 			        .GroupBy(t => t.FileName).Select(g => g.First());

--- a/starsky/starsky.foundation.platform/Middleware/ContentSecurityPolicyMiddleware.cs
+++ b/starsky/starsky.foundation.platform/Middleware/ContentSecurityPolicyMiddleware.cs
@@ -34,7 +34,7 @@ namespace starsky.foundation.platform.Middleware
 					.Add("Content-Security-Policy",
 						$"default-src 'self'; img-src 'self' https://*.tile.openstreetmap.org; script-src 'self' " +
 						$"https://az416426.vo.msecnd.net \'nonce-{nonce}\'; " +
-						$"connect-src 'self' {socketUrl} " +
+						$"connect-src 'self' {socketUrl} {socketUrl}:{httpContext.Request.Host.Port} " +
 						$"https://*.in.applicationinsights.azure.com https://dc.services.visualstudio.com/v2/track; " +
 						$"style-src 'self'; " +
 						$"font-src 'self'; frame-ancestors 'none'; base-uri 'none'; " +

--- a/starsky/starsky.foundation.sync/SyncServices/ManualBackgroundSyncService.cs
+++ b/starsky/starsky.foundation.sync/SyncServices/ManualBackgroundSyncService.cs
@@ -93,14 +93,14 @@ namespace starsky.foundation.sync.SyncServices
 			
 			var updatedList = await _synchronize.Sync(subPath, false, PushToSockets);
 			
-			_query.CacheUpdateItem(FilterBefore(updatedList));
+			_query.CacheUpdateItem(updatedList.Where(p => p.ParentDirectory == subPath).ToList());
 			
 			// so you can click on the button again
 			_cache.Remove(ManualSyncCacheName + subPath);
 			_logger.LogInformation($"[ManualBackgroundSyncService] done {subPath} " +
 			                       $"{DateTime.Now.ToShortTimeString()}");
 			_logger.LogInformation($"[ManualBackgroundSyncService] Ok: {updatedList.Count(p => p.Status == FileIndexItem.ExifStatus.Ok)}" +
-			                       $"OkAndSame: {updatedList.Count(p => p.Status == FileIndexItem.ExifStatus.OkAndSame)}");
+			                       $" ~ OkAndSame: {updatedList.Count(p => p.Status == FileIndexItem.ExifStatus.OkAndSame)}");
 			operationHolder.SetData(updatedList);
 		}
 		

--- a/starsky/starsky.foundation.sync/SyncServices/SyncFolder.cs
+++ b/starsky/starsky.foundation.sync/SyncServices/SyncFolder.cs
@@ -95,15 +95,20 @@ namespace starsky.foundation.sync.SyncServices
 					var dbItem = await new SyncSingleFile(_appSettings, query, 
 						_subPathStorage, _logger).SingleFile(subPathInFiles, 
 						fileIndexItems.FirstOrDefault(p => p.FilePath == subPathInFiles), updateDelegate);
-					
-					if ( dbItem.Status == FileIndexItem.ExifStatus.NotFoundSourceMissing )
+
+					if ( dbItem.Status ==
+					     FileIndexItem.ExifStatus.NotFoundSourceMissing )
 					{
-						await new SyncRemove(_appSettings, _setupDatabaseTypes, query)
+						await new SyncRemove(_appSettings, _setupDatabaseTypes,
+								query, _memoryCache, _logger)
 							.Remove(subPathInFiles);
-						_console.Write("≠");
-						return dbItem;
 					}
-					_console.Write("•");
+
+					_console.Write(dbItem.Status == FileIndexItem.ExifStatus
+							.NotFoundSourceMissing
+							? "≠"
+							: "•");
+
 					// only used in Parallelism loop
 					await query.DisposeAsync();
 					return dbItem;

--- a/starsky/starsky.foundation.sync/SyncServices/SyncRemove.cs
+++ b/starsky/starsky.foundation.sync/SyncServices/SyncRemove.cs
@@ -32,11 +32,13 @@ namespace starsky.foundation.sync.SyncServices
 		}
 
 		public SyncRemove(AppSettings appSettings, SetupDatabaseTypes setupDatabaseTypes,
-			IQuery query)
+			IQuery query, IMemoryCache memoryCache, IWebLogger logger)
 		{
 			_appSettings = appSettings;
 			_setupDatabaseTypes = setupDatabaseTypes;
+			_memoryCache = memoryCache;
 			_query = query;
+			_logger = logger;
 		}
 
 		/// <summary>

--- a/starsky/starsky/Controllers/MemoryCacheDebugController.cs
+++ b/starsky/starsky/Controllers/MemoryCacheDebugController.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
@@ -23,7 +25,7 @@ namespace starsky.Controllers
 			foreach ( var key in _memoryCache.GetKeys<string>() )
 			{
 				_memoryCache.TryGetValue(key, out var data);
-				result.Add(key, data);
+				result.Add(key, JsonSerializer.Serialize(data));
 			}
 			return Json(result);
 		}

--- a/starsky/starsky/clientapp/src/hooks/use-capture-position.ts
+++ b/starsky/starsky/clientapp/src/hooks/use-capture-position.ts
@@ -14,7 +14,9 @@ const capturePosition = () => {
       (document.body as any).style.width = "100%";
     },
     unfreeze: () => {
-      document.body.removeAttribute("style");
+      (document.body as any).style.position = "initial";
+      (document.body as any).style.top = "initial";
+      (document.body as any).style.width = "initial";
       window.scrollTo(0, topCachedPosition);
     }
   } as ICaptionPosition;

--- a/starsky/starskytest/starsky.foundation.database/QueryTest/QueryTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/QueryTest/QueryTest.cs
@@ -1017,6 +1017,39 @@ namespace starskytest.starsky.foundation.database.QueryTest
 			var success = _memoryCache.TryGetValue(name, out var objectFileFolders);
 			Assert.IsFalse(success);
 		}
+
+		[TestMethod]
+		public void CacheUpdateItem_ImplicitAdd()
+		{
+
+			_query.AddCacheParentItem("/456789", new List<FileIndexItem>());
+			
+			var item1 = new FileIndexItem {Id = 400, Tags = "hi", ParentDirectory = "/456789", FileName = "cache"};
+			_query.CacheUpdateItem(new List<FileIndexItem>{item1});
+
+			var result = _query.DisplayFileFolders("/456789").ToList();
+
+			Assert.AreEqual(1, result.Count);
+			Assert.AreEqual("hi", result[0].Tags);
+		}
+
+		[TestMethod]
+		public void CacheUpdateItem_UpdateByName()
+		{
+
+			_query.AddCacheParentItem("/3479824783", new List<FileIndexItem>
+			{
+				new FileIndexItem {Id = 401, Tags = "___not___", ParentDirectory = "/3479824783", FileName = "cache"}
+			});
+			
+			var item1 = new FileIndexItem {Id = 400, Tags = "hi", ParentDirectory = "/3479824783", FileName = "cache"};
+			_query.CacheUpdateItem(new List<FileIndexItem>{item1});
+
+			var result = _query.DisplayFileFolders("/3479824783").ToList();
+
+			Assert.AreEqual(1, result.Count);
+			Assert.AreEqual("hi", result[0].Tags);
+		}
 		
 		[TestMethod]
 		public void CacheUpdateItem_ignore_when_parent_does_notExistFakeLogger()

--- a/starsky/starskytest/starsky.foundation.database/QueryTest/QueryTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/QueryTest/QueryTest.cs
@@ -984,8 +984,11 @@ namespace starskytest.starsky.foundation.database.QueryTest
 		[TestMethod]
 		public void QueryFolder_Add_And_UpdateFolderCache_UpdateCacheItemTest()
 		{
+			var name = _query.CachingDbName(nameof(FileIndexItem),
+				"/");
+			
 			// Add folder to cache normally done by: CacheQueryDisplayFileFolders
-			_memoryCache.Set("List`1_/", new List<FileIndexItem>(), 
+			_memoryCache.Set(name, new List<FileIndexItem>(), 
 				new TimeSpan(1,0,0));
 			// "List`1_" is from CachingDbName
             
@@ -994,8 +997,8 @@ namespace starskytest.starsky.foundation.database.QueryTest
             
 			var item1 = new FileIndexItem {Id = 400, Tags = "hi", FileName = "cache"};
 			_query.CacheUpdateItem(new List<FileIndexItem>{item1});
-
-			_memoryCache.TryGetValue("List`1_/", out var objectFileFolders);
+			
+			_memoryCache.TryGetValue(name, out var objectFileFolders);
 			var displayFileFolders = (List<FileIndexItem>) objectFileFolders;
 
 			Assert.AreEqual("hi",displayFileFolders.FirstOrDefault(p => p.FileName == "cache").Tags);
@@ -1009,7 +1012,9 @@ namespace starskytest.starsky.foundation.database.QueryTest
 			var item1 = new FileIndexItem {Id = 400, Tags = "hi", ParentDirectory = "/_fail_test1", FileName = "cache"};
 			_query.CacheUpdateItem(new List<FileIndexItem>{item1});
 
-			var success = _memoryCache.TryGetValue("List`1_/_fail_test1", out var objectFileFolders);
+			var name = _query.CachingDbName(nameof(FileIndexItem),
+				"/_fail_test1");
+			var success = _memoryCache.TryGetValue(name, out var objectFileFolders);
 			Assert.IsFalse(success);
 		}
 		


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

- [x]   (Added) _Back-end_  Add index for IX_ImportIndex_FileHash and IX_Credentials_Id_Identifier (PR #555)
- [x]   (Added) _Back-end_ Fix for cache ManualSync when item is removed or added its now correct updated (PR #555)
- [x]   (Fixed) _Front-end_ Fix for Safari 14.x and newer that after close a modal, the scroll isn't locked anymore (PR #555) 
- [x]   (Fixed) _Back-end_ Add port to websocket url in connect-src for Safari 14.x using different port numbers  (PR #555)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] C# Unit tests 
- [x] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [x] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (update when needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the **./history.md** document
