### PR TITLE
Larger content field for Notifications table

### DIFF
--- a/history.md
+++ b/history.md
@@ -40,6 +40,8 @@ node starsky-tools/build-tools/app-version-update.js
 - [x]   (Changed) _Front-end_ Upgrade React 17.x to React 18.x (PR #724)
 - [x]   (Security) _Frond-end_  Upgrade ClientApp CRA _(Create React App 5.0.1 (2022-04-12))_ (PR #724)
 - [x]   (Added) _Back-end_ Fixed locale issue with Notification API _(CultureInfo.CurrentCulture)_ (PR #730)
+- [x]   (Breaking Change) _Back-end_ Notification Content change from text to mediumtext, **existing data will be lost** (PR #731)
+- [x]   (Breaking Change) _Back-end_ FileIndexItem Size column change from int to bigint, **existing data will be lost, run full sync please** (PR #731)
 
 # version 0.5.0-beta.4 - 2022-04-15
 - [x]   (Changed) _Back-end_ Upgrade to .NET 6 - SDK 6.0.201 (Runtime: 6.0.3) (PR #674)

--- a/starsky/starsky.foundation.database/Data/ApplicationDbContext.cs
+++ b/starsky/starsky.foundation.database/Data/ApplicationDbContext.cs
@@ -160,6 +160,9 @@ namespace starsky.foundation.database.Data
 						.HasAnnotation("Sqlite:Autoincrement", true)
 						.HasAnnotation("MySql:ValueGenerationStrategy",
 							MySqlValueGenerationStrategy.IdentityColumn);
+					
+					etb.Property(p => p.Content).HasColumnType("mediumtext");
+					
 					etb.ToTable("Notifications");
 					etb.HasAnnotation("MySql:CharSet", "utf8mb4");
 				}

--- a/starsky/starsky.foundation.database/Data/ApplicationDbContext.cs
+++ b/starsky/starsky.foundation.database/Data/ApplicationDbContext.cs
@@ -47,9 +47,13 @@ namespace starsky.foundation.database.Data
 
 			// Add Index to speed performance (on MySQL max key length is 3072 bytes)
 			// MySql:CharSet might be working a future release but now it does nothing
-			modelBuilder.Entity<FileIndexItem>()
-				.HasAnnotation("MySql:CharSet", "utf8mb4")
-				.HasIndex(x => new {x.FileName, x.ParentDirectory});
+			modelBuilder.Entity<FileIndexItem>(etb =>
+			{
+				etb.HasAnnotation("MySql:CharSet", "utf8mb4");
+				etb.HasIndex(x => new {x.FileName, x.ParentDirectory});
+				
+				etb.Property(p => p.Size).HasColumnType("bigint");
+			});
 			
 			modelBuilder.Entity<User>(etb =>
 				{

--- a/starsky/starsky.foundation.database/Migrations/20220417170059_ContentSize.Designer.cs
+++ b/starsky/starsky.foundation.database/Migrations/20220417170059_ContentSize.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using starsky.foundation.database.Data;
 
@@ -11,9 +12,10 @@ using starsky.foundation.database.Data;
 namespace starsky.foundation.database.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220417170059_ContentSize")]
+    partial class ContentSize
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/starsky/starsky.foundation.database/Migrations/20220417170059_ContentSize.cs
+++ b/starsky/starsky.foundation.database/Migrations/20220417170059_ContentSize.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace starsky.foundation.database.Migrations
+{
+    public partial class ContentSize : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Content",
+                table: "Notifications",
+                type: "mediumtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Content",
+                table: "Notifications",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "mediumtext",
+                oldNullable: true);
+        }
+    }
+}

--- a/starsky/starsky.foundation.database/Migrations/20220417173513_bigintSize.Designer.cs
+++ b/starsky/starsky.foundation.database/Migrations/20220417173513_bigintSize.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using starsky.foundation.database.Data;
 
@@ -11,9 +12,10 @@ using starsky.foundation.database.Data;
 namespace starsky.foundation.database.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220417173513_bigintSize")]
+    partial class bigintSize
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/starsky/starsky.foundation.database/Migrations/20220417173513_bigintSize.cs
+++ b/starsky/starsky.foundation.database/Migrations/20220417173513_bigintSize.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace starsky.foundation.database.Migrations
+{
+    public partial class bigintSize : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<long>(
+                name: "Size",
+                table: "FileIndex",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "INTEGER");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<long>(
+                name: "Size",
+                table: "FileIndex",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+        }
+    }
+}

--- a/starsky/starsky.foundation.database/Models/FileIndexItem.cs
+++ b/starsky/starsky.foundation.database/Models/FileIndexItem.cs
@@ -926,37 +926,26 @@ namespace starsky.foundation.database.Models
 		/// </summary>
 		public double FocalLength { get; set; }
 
-		
 		/// <summary>
 		/// Private field to store the ByteSize Data
 		/// </summary>
 		private long _size;
 		
 		/// <summary>
-		/// Size of the file in bytes
+		/// Size of the file in bytes (BigInt)
 		/// </summary>
-		public long Size {
+		public long Size
+		{
 			get => _size;
-			set
-			{
-				switch ( value )
+			set {
+				if ( value < 0 )
 				{
-					case >= int.MaxValue:
-						_size = int.MinValue;
-						return;
-					case <= 0:
-						if ( value != int.MinValue)
-						{
-							_size = 0;
-						}
-						return;
-					default:
-						_size = value;
-						break;
+					_size = 0;
+					return;
 				}
+				_size = value;
 			} 
 		}
-
 	    
 		/// <summary>
 		/// To add Make (without comma and TitleCase) and second follow by Model (same as input)

--- a/starsky/starsky.foundation.database/Models/ImportIndexItem.cs
+++ b/starsky/starsky.foundation.database/Models/ImportIndexItem.cs
@@ -107,13 +107,11 @@ namespace starsky.foundation.database.Models
         /// <summary>
         /// Is the Exif DateTime parsed from the fileName
         /// </summary>
-        [NotMapped]
         public bool DateTimeFromFileName { get; set; }
 
         /// <summary>
         /// ColorClass
         /// </summary>
-        [NotMapped]
         public ColorClassParser.Color ColorClass { get; set; }
 
         public DateTime ParseDateTimeFromFileName()

--- a/starsky/starsky.foundation.database/Models/NotificationItem.cs
+++ b/starsky/starsky.foundation.database/Models/NotificationItem.cs
@@ -10,6 +10,9 @@ namespace starsky.foundation.database.Models
 		[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
 		public int Id { get; set; }
 
+		/// <summary>
+		/// Size: MediumText
+		/// </summary>
 		public string Content { get; set; }
 
 		public DateTime DateTime { get; set; }

--- a/starsky/starskytest/starsky.foundation.database/Models/FileIndexItemTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/Models/FileIndexItemTest.cs
@@ -488,16 +488,6 @@ namespace starskytest.starsky.foundation.database.Models
 	    
 		
 		[TestMethod]
-		public void Size_Gt_IntMax()
-		{
-			var value = 99999999999999999;
-			var item = new FileIndexItem(){Size = value};
-		    
-			// should write to large values to min value
-			Assert.AreEqual(int.MinValue, item.Size);
-		}
-		
-		[TestMethod]
 		public void Size_Lt_0()
 		{
 			var value = -1;


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

- [x]   (Breaking Change) _Back-end_ Notification Content change from text to mediumtext, **existing data will be lost** (PR #731)
- [x]   (Breaking Change) _Back-end_ FileIndexItem Size column change from int to bigint, **existing data will be lost, run full sync please** (PR #731)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
