### PR TITLE
.NET SDK Upgrade to 6.0.401

### DIFF
--- a/starsky/starsky.foundation.settings/starsky.foundation.settings.csproj
+++ b/starsky/starsky.foundation.settings/starsky.foundation.settings.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>starsky.foundation.settings</RootNamespace>
     <!-- SonarQube needs this -->
     <ProjectGuid>{67e301f1-e700-4ca5-81ae-696abab1bb0f}</ProjectGuid>


### PR DESCRIPTION
## Upgrade of .NET with newer SDK Version
- Install SDK version 6.0.401 on your development machine https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.9/6.0.9.md
- First test on linux-arm test envs before approve
- update azure runtime on test https://demostarsky.scm.azurewebsites.net/
- update docs with minimal version https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_6.0.401/starsky/readme.md
- update changelog https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_6.0.401/history.md

## When upgrading a major version
- when upgrading to newer major release check docker