### PR TITLE
build helpers change - use absolute paths, should be able to run from diff paths

### DIFF
--- a/starsky/build/helpers/ClientHelper.cs
+++ b/starsky/build/helpers/ClientHelper.cs
@@ -31,19 +31,19 @@ namespace helpers
 	
 		public static void ClientCiCommand()
 		{
-			Run(NpmBaseCommand, "ci --legacy-peer-deps --prefer-offline --no-audit --no-fund", ClientAppFolder, 
+			Run(NpmBaseCommand, "ci --legacy-peer-deps --prefer-offline --no-audit --no-fund", GetClientAppFolder(), 
 				false, null, null, false);
 		}
 	
 		public static void ClientBuildCommand()
 		{
-			Run(NpmBaseCommand, "run build", ClientAppFolder, 
+			Run(NpmBaseCommand, "run build", GetClientAppFolder(), 
 				false, null, null, false);
 		}
 	
 		public static void ClientTestCommand()
 		{
-			Run(NpmBaseCommand, "run test:ci", ClientAppFolder, 
+			Run(NpmBaseCommand, "run test:ci", GetClientAppFolder(), 
 				false, null, null, false);
 		}
 	}

--- a/starsky/build/helpers/DotnetGenericHelper.cs
+++ b/starsky/build/helpers/DotnetGenericHelper.cs
@@ -59,12 +59,13 @@ namespace helpers
 			{
 				Environment.SetEnvironmentVariable("app__DependenciesFolder",genericDepsFullPath);
 				Console.WriteLine("Next: DownloadDependencies");
+				Console.WriteLine("Run: " + Path.Combine(WorkingDirectory.GetSolutionParentFolder(),geoCliCsproj));
 
 				DotNetRun(_ =>  _
 					.SetConfiguration(configuration)
 					.EnableNoRestore()
 					.EnableNoBuild()
-					.SetProjectFile(geoCliCsproj));
+					.SetProjectFile(Path.Combine(WorkingDirectory.GetSolutionParentFolder(),geoCliCsproj)));
 			}
 			catch ( Exception exception)
 			{
@@ -93,14 +94,22 @@ namespace helpers
 
 			foreach ( var publishProject in PublishProjectsList )
 			{
+				var publishProjectFullPath = Path.Combine(
+					WorkingDirectory.GetSolutionParentFolder(),
+					publishProject);
+
+				var outputFullPath = Path.Combine(
+					WorkingDirectory.GetSolutionParentFolder(),
+					GenericRuntimeName);
+
 				DotNetPublish(_ => _
 					.SetConfiguration(configuration)
 					.EnableNoRestore()
 					.EnableNoBuild()
 					.EnableNoDependencies()
 					.EnableSelfContained()
-					.SetOutput(GenericRuntimeName)
-					.SetProject(publishProject)
+					.SetOutput(outputFullPath)
+					.SetProject(publishProjectFullPath)
 					.EnableNoLogo());
 			}
 			ProjectAssetsCopier.CopyNewAssetFileByRuntimeId(GenericRuntimeName, solution);

--- a/starsky/build/helpers/MergeCoverageFiles.cs
+++ b/starsky/build/helpers/MergeCoverageFiles.cs
@@ -33,7 +33,7 @@ namespace helpers
 		public static void Merge(bool noUnitTest)
 		{
 			var rootDirectory = Directory.GetParent(AppDomain.CurrentDomain
-				.BaseDirectory).Parent.Parent.Parent.FullName;
+				.BaseDirectory!)!.Parent!.Parent!.Parent!.FullName;
 		
 			if(noUnitTest)
 			{
@@ -41,12 +41,14 @@ namespace helpers
 				return;
 			}
 
-			if (! FileExists(Path.Combine(rootDirectory, $"starsky/clientapp/coverage/cobertura-coverage.xml"))) {
-				throw new FileNotFoundException($"Missing jest coverage file ./starsky/clientapp/coverage/cobertura-coverage.xml");
+			var jestCoverageFile = Path.Combine(rootDirectory, "starsky/clientapp/coverage/cobertura-coverage.xml");
+			if (! FileExists(jestCoverageFile)) {
+				throw new FileNotFoundException($"Missing jest coverage file {jestCoverageFile}");
 			}
 
-			if (! FileExists(Path.Combine(rootDirectory, "starskytest/netcore-coverage.opencover.xml"))) {
-				throw new FileNotFoundException($"Missing .NET Core coverage file ./starskytest/netcore-coverage.opencover.xml");
+			var netCoreCoverageFile = Path.Combine(rootDirectory, "starskytest/netcore-coverage.opencover.xml");
+			if (! FileExists(netCoreCoverageFile)) {
+				throw new FileNotFoundException($"Missing .NET coverage file ${netCoreCoverageFile}");
 			}
 
 			var outputCoverageFile = Path.Combine(rootDirectory,"starskytest/coverage-merge-cobertura.xml");

--- a/starsky/build/helpers/ProjectCheckNetCoreCommandHelper.cs
+++ b/starsky/build/helpers/ProjectCheckNetCoreCommandHelper.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using static SimpleExec.Command;
 using static build.Build;
 
@@ -5,21 +7,33 @@ namespace helpers
 {
 	public static class ProjectCheckNetCoreCommandHelper
 	{
+		static string GetBuildToolsFolder()
+		{
+			var baseDirectory = AppDomain.CurrentDomain?
+				.BaseDirectory;
+			if ( baseDirectory == null )
+				throw new DirectoryNotFoundException("base directory is null, this is wrong");
+			var slnRootDirectory = Directory.GetParent(baseDirectory)?.Parent?.Parent?.Parent?.Parent?.FullName;
+			if ( slnRootDirectory == null )
+				throw new DirectoryNotFoundException("slnRootDirectory is null, this is wrong");
+			return Path.Combine(slnRootDirectory, BuildToolsPath);
+		}
+		
 		public static void ProjectCheckNetCoreCommand()
 		{
 			ClientHelper.NpmPreflight();
 
 			// check branch names on CI
-			Run(NpmBaseCommand, "run release-version-check", BuildToolsPath);
+			Run(NpmBaseCommand, "run release-version-check", GetBuildToolsFolder());
 		
 			/* Checks for valid Project GUIDs in csproj files */
-			Run(NpmBaseCommand, "run project-guid", BuildToolsPath);
+			Run(NpmBaseCommand, "run project-guid", GetBuildToolsFolder());
 		
 			/* List of nuget packages */
-			Run(NpmBaseCommand, "run nuget-package-list", BuildToolsPath);
+			Run(NpmBaseCommand, "run nuget-package-list", GetBuildToolsFolder());
 		}
 
-		const string BuildToolsPath = "../starsky-tools/build-tools/";
+		const string BuildToolsPath = "starsky-tools/build-tools/";
 	}
 }
 

--- a/starsky/build/helpers/SonarQube.cs
+++ b/starsky/build/helpers/SonarQube.cs
@@ -220,6 +220,8 @@ namespace helpers
 				.Append($"/d:sonar.login=\"{login}\" ");
 
 			DotNet(sonarArguments.ToString());
+			
+			Console.Write("- - - - - - - - - -  Sonar done - - - - - - - - - - \n");
 		}
 	}	
 }


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
