### PR TITLE
Swagger autogen is broken after .NET 8 upgrade

### DIFF
--- a/.github/workflows/auto-update-swagger-dotnet.yml
+++ b/.github/workflows/auto-update-swagger-dotnet.yml
@@ -1,4 +1,4 @@
-name: Auto Update Swagger
+name: 'Update Swagger definitions'
 
 on:
   workflow_dispatch:
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Setup .NET Core
+    - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.101

--- a/documentation/static/openapi/openapi.json
+++ b/documentation/static/openapi/openapi.json
@@ -26,7 +26,7 @@
           "parameters": [],
           "responses": {
             "200": {
-              "description": "logged in",
+              "description": "Logged in",
               "headers": {},
               "content": {
                 "application/json": {
@@ -63,7 +63,7 @@
               "unresolvedReference": false
             },
             "401": {
-              "description": "when not logged in",
+              "description": "When not logged in",
               "headers": {},
               "content": {
                 "application/json": {
@@ -123,7 +123,7 @@
               "unresolvedReference": false
             },
             "503": {
-              "description": "database connection error",
+              "description": "Database Connection Error",
               "headers": {},
               "content": {
                 "application/json": {
@@ -153,7 +153,7 @@
               "unresolvedReference": false
             },
             "409": {
-              "description": "Current User does not exist in database",
+              "description": "The Current User does not exist in database",
               "headers": {},
               "content": {},
               "links": {},

--- a/starsky/starsky.foundation.database/Helpers/SetupDatebaseTypes.cs
+++ b/starsky/starsky.foundation.database/Helpers/SetupDatebaseTypes.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using Microsoft.ApplicationInsights;
 using Microsoft.EntityFrameworkCore;
@@ -36,7 +35,7 @@ namespace starsky.foundation.database.Helpers
 			return new ApplicationDbContext(BuilderDbFactorySwitch());
 		}
 
-		internal ServerVersion GetServerVersionMySql()
+		private ServerVersion GetServerVersionMySql()
 		{
 			try
 			{
@@ -50,6 +49,12 @@ namespace starsky.foundation.database.Helpers
 			return new MariaDbServerVersion("10.2");
 		}
 		
+		/// <summary>
+		/// Setup database connection
+		/// </summary>
+		/// <param name="foundationDatabaseName">Assembly name, used for running migrations</param>
+		/// <returns></returns>
+		/// <exception cref="AggregateException">Missing arguments</exception>
 		internal DbContextOptions<ApplicationDbContext> BuilderDbFactorySwitch(string? foundationDatabaseName = "")
 		{
 			switch ( _appSettings.DatabaseType )
@@ -110,6 +115,15 @@ namespace starsky.foundation.database.Helpers
 			return true;
 		}
 
+		/// <summary>
+		/// Setup database connection
+		/// use boot parameters to run with EF Migrations and a direct connection
+		/// ENABLE_DEFAULT_DATABASE: SQLite
+		/// ENABLE_MYSQL_DATABASE: MySql
+		/// In runtime those parameters are not needed and not useful.
+		/// </summary>
+		/// <param name="foundationDatabaseName">Assembly name, used for migrations</param>
+		/// <exception cref="AggregateException">services is null</exception>
 		public void BuilderDb(string? foundationDatabaseName = "")
 		{
 			if ( _services == null ) throw new AggregateException("services is missing");
@@ -145,7 +159,7 @@ namespace starsky.foundation.database.Helpers
 					}));
 #endif
 
-			_services.AddScoped(provider => new ApplicationDbContext(BuilderDbFactorySwitch(foundationDatabaseName)));
+			_services.AddScoped(_ => new ApplicationDbContext(BuilderDbFactorySwitch(foundationDatabaseName)));
 		}
 
 	}

--- a/starsky/starsky.foundation.platform/Helpers/SetupAppSettings.cs
+++ b/starsky/starsky.foundation.platform/Helpers/SetupAppSettings.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/starsky/starsky.foundation.sync/WatcherServices/BufferingFileSystemWatcher.cs
+++ b/starsky/starsky.foundation.sync/WatcherServices/BufferingFileSystemWatcher.cs
@@ -409,6 +409,7 @@ namespace starsky.foundation.sync.WatcherServices
 	        eventHandler(this, e);
 	        return false;
         }
+        
         internal bool? InvokeHandler(ErrorEventHandler? eventHandler, ErrorEventArgs e)
         {
 	        if ( eventHandler == null )
@@ -428,12 +429,26 @@ namespace starsky.foundation.sync.WatcherServices
         }
         // end InvokeHandlers
 
+        /// <summary>
+        /// Status if is Disposed
+        /// </summary>
+        internal bool IsDisposed { get; set; } = false;
+
+        /// <summary>
+        /// Dispose and unsubscribe all events
+        /// </summary>
+        /// <param name="disposing">is disposing</param>
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                _cancellationTokenSource.Cancel();
-                _cancellationTokenSource.Dispose();
+	            IsDisposed = true;
+	            if ( !_cancellationTokenSource.IsCancellationRequested )
+	            {
+		            _cancellationTokenSource.Cancel();
+	            }
+	            
+	            _cancellationTokenSource.Dispose();
                 _containedFsw.Dispose();
             }
             base.Dispose(disposing);

--- a/starsky/starsky.sln.DotSettings
+++ b/starsky/starsky.sln.DotSettings
@@ -3,6 +3,7 @@
 	<s:Boolean x:Key="/Default/CodeEditing/ContextActionTable/DisabledContextActions/=JetBrains_002EReSharper_002EIntentions_002ECSharp_002EContextActions_002EComments_002EDeleteCommentAction/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/ContextActionTable/DisabledContextActions/=JetBrains_002EReSharper_002EIntentions_002ERazor_002EContextActions_002EComments_002EDeleteCommentAction/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=accountmanagement/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=clientapp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=databasetelemetry/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=exiftool/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=filenamebase/@EntryIndexedValue">True</s:Boolean>

--- a/starsky/starsky/Controllers/AccountController.cs
+++ b/starsky/starsky/Controllers/AccountController.cs
@@ -121,11 +121,11 @@ namespace starsky.Controllers
         /// </summary>
         /// <param name="model">Email, password and remember me bool</param>
         /// <returns>Login status</returns>
-        /// <response code="200">successful login</response>
-        /// <response code="401">login failed</response>
-        /// <response code="405">ValidateAntiForgeryToken</response>
-        /// <response code="423">login failed due lock</response>
-        /// <response code="500">login failed due signIn errors</response>
+        /// <response code="200">Successful login</response>
+        /// <response code="401">Login failed</response>
+        /// <response code="405">ValidateAntiForgeryToken error</response>
+        /// <response code="423">Login failed due lock</response>
+        /// <response code="500">Login failed due signIn errors</response>
         [HttpPost("/api/account/login")]
         [ProducesResponseType(typeof(string),200)]
         [ProducesResponseType(typeof(string),401)]
@@ -162,8 +162,8 @@ namespace starsky.Controllers
         /// <summary>
         /// Logout the current HttpContext out
         /// </summary>
-        /// <returns></returns>
-        /// <response code="200">successful logout</response>
+        /// <returns>Login Status</returns>
+        /// <response code="200">Successful logout</response>
         [HttpPost("/api/account/logout")]
         [ProducesResponseType(200)]
         [AllowAnonymous]
@@ -178,7 +178,7 @@ namespace starsky.Controllers
         /// </summary>
         /// <param name="returnUrl">insert url to redirect</param>
         /// <response code="302">redirect to return url</response>
-        /// <returns></returns>
+        /// <returns>Redirect to login page</returns>
         [HttpGet("/account/logout")]
         [ProducesResponseType(200)]
         [AllowAnonymous]
@@ -193,7 +193,7 @@ namespace starsky.Controllers
         /// Update password for current user
         /// </summary>
         /// <param name="model">Password, ChangedPassword and ChangedConfirmPassword</param>
-        /// <returns>Login status</returns>
+        /// <returns>Change secret status</returns>
         /// <response code="200">successful login</response>
         /// <response code="400">Model is not correct</response>
         /// <response code="401"> please login first or your current password is not correct</response>

--- a/starsky/starsky/Controllers/AccountController.cs
+++ b/starsky/starsky/Controllers/AccountController.cs
@@ -34,12 +34,12 @@ namespace starsky.Controllers
 		/// <summary>
 		/// Check the account status of the current logged in user
 		/// </summary>
-		/// <response code="200">logged in</response>
-		/// <response code="401">when not logged in</response>
+		/// <response code="200">Logged in</response>
+		/// <response code="401">When not logged in</response>
 		/// <response code="406">There are no accounts, you must create an account first</response>
-		/// <response code="409">Current User does not exist in database</response>
-		/// <response code="503">database connection error</response>
-		/// <returns>account name, id, and create date</returns>
+		/// <response code="409">The Current User does not exist in database</response>
+		/// <response code="503">Database Connection Error</response>
+		/// <returns>account name, id, and create date as json</returns>
 		[HttpGet("/api/account/status")]
 		[ProducesResponseType(typeof(UserIdentifierStatusModel), 200)]
 		[ProducesResponseType(typeof(string), 401)]

--- a/starsky/starsky/Startup.cs
+++ b/starsky/starsky/Startup.cs
@@ -45,6 +45,9 @@ namespace starsky
         private readonly IConfigurationRoot _configuration;
         private AppSettings? _appSettings;
         
+        /// <summary>
+        /// application/xhtml+xml image/svg+xml
+        /// </summary>
 		private static readonly string[] CompressionMimeTypes =
 		[
 			"application/xhtml+xml",
@@ -273,10 +276,13 @@ namespace starsky
 			}
 			
 	        // Allow Current Directory and wwwroot in Base Directory
-	        app.UseStaticFiles(new StaticFileOptions
+	        if ( _appSettings?.AddSwaggerExportExitAfter != true )
+	        {
+		        app.UseStaticFiles(new StaticFileOptions
 		        {
 			        OnPrepareResponse = PrepareResponse
-	        });
+		        });
+	        }
     
 	        // Use in wwwroot in build directory; the default option assumes Current Directory
 	        if ( _appSettings != null && Directory.Exists(Path.Combine(_appSettings.BaseDirectoryProject, "wwwroot")) )

--- a/starsky/starsky/Startup.cs
+++ b/starsky/starsky/Startup.cs
@@ -343,8 +343,7 @@ namespace starsky
 
 	        // Check if clientapp is build and use the assets folder
 	        if ( !Directory.Exists(Path.Combine(
-		            _appSettings.BaseDirectoryProject, "clientapp", "build",
-		            "assets")) )
+		            _appSettings.BaseDirectoryProject, "clientapp", "build", "assets")) )
 	        {
 		        return result;
 	        }

--- a/starsky/starsky/Startup.cs
+++ b/starsky/starsky/Startup.cs
@@ -308,8 +308,9 @@ namespace starsky
         /// Add Static Files to the application
         /// </summary>
         /// <param name="app">Application builder</param>
+        /// <param name="assetsName">assetsName</param>
         /// <returns>1. bool = local dir 2. wwwroot in assembly 3. clientapp</returns>
-        internal (bool,bool,bool) SetupStaticFiles(IApplicationBuilder app)
+        internal (bool,bool,bool) SetupStaticFiles(IApplicationBuilder app, string assetsName = "assets")
         {
 	        var result = ( false, false, false );
 
@@ -343,7 +344,7 @@ namespace starsky
 
 	        // Check if clientapp is build and use the assets folder
 	        if ( !Directory.Exists(Path.Combine(
-		            _appSettings.BaseDirectoryProject, "clientapp", "build", "assets")) )
+		            _appSettings.BaseDirectoryProject, "clientapp", "build", assetsName)) )
 	        {
 		        return result;
 	        }
@@ -352,7 +353,7 @@ namespace starsky
 		        {
 			        OnPrepareResponse = PrepareResponse,
 			        FileProvider = new PhysicalFileProvider(
-				        Path.Combine(_appSettings.BaseDirectoryProject, "clientapp", "build", "assets")),
+				        Path.Combine(_appSettings.BaseDirectoryProject, "clientapp", "build", assetsName)),
 			        RequestPath = $"/assets",
 		        }
 	        );

--- a/starsky/starsky/Startup.cs
+++ b/starsky/starsky/Startup.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Globalization;
 using System.IO;
@@ -56,7 +55,7 @@ namespace starsky
 		{
 			if ( !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("app__appsettingspath")) )
 			{
-				Console.WriteLine("app__appsettingspath: " + Environment.GetEnvironmentVariable("app__appsettingspath"));
+				Console.WriteLine("app__appSettingsPath: " + Environment.GetEnvironmentVariable("app__appsettingspath"));
 			}
 			_configuration = SetupAppSettings.AppSettingsToBuilder(args).ConfigureAwait(false).GetAwaiter().GetResult();
 		}
@@ -82,7 +81,8 @@ namespace starsky
             // LoggerFactory
             services.AddTelemetryLogging(_appSettings);
             
-            var foundationDatabaseName = typeof(ApplicationDbContext).Assembly.FullName?.Split(",").FirstOrDefault();
+            var foundationDatabaseName = typeof(ApplicationDbContext)
+	            .Assembly.FullName?.Split(",").FirstOrDefault();
             new SetupDatabaseTypes(_appSettings,services).BuilderDb(foundationDatabaseName);
 			new SetupHealthCheck(_appSettings,services).BuilderHealth();
 			EfCoreMigrationsOnProject(services).ConfigureAwait(false);

--- a/starsky/starsky/Startup.cs
+++ b/starsky/starsky/Startup.cs
@@ -361,7 +361,7 @@ namespace starsky
 	        return result;
         }
         
-        void PrepareResponse(StaticFileResponseContext ctx)
+        internal static void PrepareResponse(StaticFileResponseContext ctx)
         {
 	        // Cache static files for 356 days
 	        ctx.Context.Response.Headers.Append("Expires", DateTime.UtcNow.AddDays(365)

--- a/starsky/starskytest/root/StartupTest.cs
+++ b/starsky/starskytest/root/StartupTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -71,7 +72,8 @@ namespace starskytest.root
 			Assert.IsNotNull(env);
 		}
 
-		private static IEnumerable<object?>? GetMiddlewareInstance(IApplicationBuilder app)
+		[SuppressMessage("ReSharper", "ReturnTypeCanBeEnumerable.Local")]
+		private static List<object?>? GetMiddlewareInstance(IApplicationBuilder app)
 		{
 			const string middlewareTypeName = "Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware";
 			var appBuilderType = typeof(ApplicationBuilder);
@@ -134,7 +136,7 @@ namespace starskytest.root
 		{
 			var storage = new StorageHostFullPathFilesystem();
 			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "wwwroot"));
-			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "clientapp", "build"));
+			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "clientapp", "build", "assets"));
 			
 			var startup = new Startup();
 			var serviceCollection = new ServiceCollection();
@@ -176,7 +178,7 @@ namespace starskytest.root
 			
 			var storage = new StorageHostFullPathFilesystem();
 			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "wwwroot"));
-			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "clientapp", "build"));
+			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "clientapp", "build", "assets"));
 
 			var result = startup.SetupStaticFiles(applicationBuilder);
 			Assert.IsNotNull(result);

--- a/starsky/starskytest/root/StartupTest.cs
+++ b/starsky/starskytest/root/StartupTest.cs
@@ -196,5 +196,31 @@ namespace starskytest.root
 			Assert.IsTrue(value?.Value.RequestPath.HasValue);
 			Assert.AreEqual("/assets", value?.Value.RequestPath.Value);
 		}
+		
+		[TestMethod]
+		public void BasicFlow_Assets_NotFound()
+		{
+			var startup = new Startup();
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddSingleton<AppSettings, AppSettings>();
+			var serviceProvider = serviceCollection.BuildServiceProvider();
+			var serviceProviderInterface = serviceProvider.GetRequiredService<IServiceProvider>();
+			
+			var applicationBuilder = new ApplicationBuilder(serviceProviderInterface);
+			startup.ConfigureServices(serviceCollection);
+			
+			var storage = new StorageHostFullPathFilesystem();
+			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "wwwroot"));
+
+			var result = startup.SetupStaticFiles(applicationBuilder,"not-found-folder-name");
+			Assert.IsNotNull(result);
+			
+			Console.WriteLine("result:");
+			Console.WriteLine("1: " +result.Item1 + " 2: " + result.Item2 + " 3: " + result.Item3);
+			
+			Assert.IsTrue(result.Item1);
+			Assert.IsTrue(result.Item2);
+			Assert.IsFalse(result.Item3);
+		}
 	}
 }

--- a/starsky/starskytest/root/StartupTest.cs
+++ b/starsky/starskytest/root/StartupTest.cs
@@ -1,15 +1,21 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using starsky;
 using starsky.foundation.platform.Models;
 using starsky.foundation.realtime.Interfaces;
+using starsky.foundation.storage.Storage;
 using starskytest.FakeMocks;
 
 namespace starskytest.root
@@ -63,6 +69,124 @@ namespace starskytest.root
 			
 			Assert.IsNotNull(applicationBuilder);
 			Assert.IsNotNull(env);
+		}
+
+		private static IEnumerable<object?>? GetMiddlewareInstance(IApplicationBuilder app)
+		{
+			const string middlewareTypeName = "Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware";
+			var appBuilderType = typeof(ApplicationBuilder);
+			var middlewareField = appBuilderType.GetField("_components", BindingFlags.Instance | BindingFlags.NonPublic);
+			var components = middlewareField?.GetValue(app);
+
+			if (components != null)
+			{
+				var element = components as List<Func<RequestDelegate, RequestDelegate>>;
+
+				var middlewares = element?.Where(p =>
+					p.Target?.ToString() == middlewareTypeName);
+				if ( middlewares == null )
+				{
+					return null;
+				}
+
+				var status = new List<object?>();
+				foreach ( var middleware in middlewares )
+				{
+
+					var type = middleware.Target?.GetType();
+					var privatePropertyInfo = type?.GetField("_args", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+					var privateFieldValue =
+						privatePropertyInfo?.GetValue(middleware.Target) as object[];
+					
+					status.Add(privateFieldValue);
+				}
+				return status;
+			}
+
+			return null;
+		}
+		
+		[TestMethod]
+		public void BasicFlow_Default()
+		{
+			var startup = new Startup();
+			var serviceCollection = new ServiceCollection();
+			var serviceProvider = serviceCollection.BuildServiceProvider();
+			var serviceProviderInterface = serviceProvider.GetRequiredService<IServiceProvider>();
+			
+			var applicationBuilder = new ApplicationBuilder(serviceProviderInterface);
+			var result = startup.SetupStaticFiles(applicationBuilder);
+			
+			Assert.IsNotNull(result);
+			Assert.IsTrue(result.Item1);
+			Assert.IsFalse(result.Item2);
+			Assert.IsFalse(result.Item3);
+			
+			var middlewareInstance = GetMiddlewareInstance(applicationBuilder)?.FirstOrDefault() as object?[];
+			var value = middlewareInstance?.FirstOrDefault() as OptionsWrapper<StaticFileOptions>;
+			
+			Assert.IsFalse(value?.Value.RequestPath.HasValue);
+			Assert.AreEqual(string.Empty, value?.Value.RequestPath.Value);
+		}
+		
+		[TestMethod]
+		public void BasicFlow_Assets()
+		{
+			var startup = new Startup();
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddSingleton<AppSettings, AppSettings>();
+			var serviceProvider = serviceCollection.BuildServiceProvider();
+			var serviceProviderInterface = serviceProvider.GetRequiredService<IServiceProvider>();
+			
+			var storage = new StorageHostFullPathFilesystem();
+			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "wwwroot"));
+			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "clientapp", "build"));
+
+			var applicationBuilder = new ApplicationBuilder(serviceProviderInterface);
+			startup.ConfigureServices(serviceCollection);
+			var result = startup.SetupStaticFiles(applicationBuilder);
+
+			Assert.IsNotNull(result);
+			
+			Assert.IsTrue(result.Item1);
+			Assert.IsTrue(result.Item2);
+			Assert.IsTrue(result.Item3);
+
+			var middlewareInstance = GetMiddlewareInstance(applicationBuilder)?.ToList()[1] as object?[];
+			var value = middlewareInstance?.FirstOrDefault() as OptionsWrapper<StaticFileOptions>;
+			
+			Assert.IsFalse(value?.Value.RequestPath.HasValue);
+			Assert.AreEqual(string.Empty, value?.Value.RequestPath.Value);
+		}
+		
+		[TestMethod]
+		public void BasicFlow_Assets2()
+		{
+			var startup = new Startup();
+			var serviceCollection = new ServiceCollection();
+			serviceCollection.AddSingleton<AppSettings, AppSettings>();
+			var serviceProvider = serviceCollection.BuildServiceProvider();
+			var serviceProviderInterface = serviceProvider.GetRequiredService<IServiceProvider>();
+			
+			var applicationBuilder = new ApplicationBuilder(serviceProviderInterface);
+			startup.ConfigureServices(serviceCollection);
+			
+			var storage = new StorageHostFullPathFilesystem();
+			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "wwwroot"));
+			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "clientapp", "build"));
+
+			var result = startup.SetupStaticFiles(applicationBuilder);
+			Assert.IsNotNull(result);
+			
+			Assert.IsTrue(result.Item1);
+			Assert.IsTrue(result.Item2);
+			Assert.IsTrue(result.Item3);
+
+			var middlewareInstance = GetMiddlewareInstance(applicationBuilder)?.ToList()[2] as object?[];
+			var value = middlewareInstance?.FirstOrDefault() as OptionsWrapper<StaticFileOptions>;
+			
+			Assert.IsTrue(value?.Value.RequestPath.HasValue);
+			Assert.AreEqual("/assets", value?.Value.RequestPath.Value);
 		}
 	}
 }

--- a/starsky/starskytest/root/StartupTest.cs
+++ b/starsky/starskytest/root/StartupTest.cs
@@ -132,21 +132,24 @@ namespace starskytest.root
 		[TestMethod]
 		public void BasicFlow_Assets()
 		{
+			var storage = new StorageHostFullPathFilesystem();
+			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "wwwroot"));
+			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "clientapp", "build"));
+			
 			var startup = new Startup();
 			var serviceCollection = new ServiceCollection();
 			serviceCollection.AddSingleton<AppSettings, AppSettings>();
 			var serviceProvider = serviceCollection.BuildServiceProvider();
 			var serviceProviderInterface = serviceProvider.GetRequiredService<IServiceProvider>();
-			
-			var storage = new StorageHostFullPathFilesystem();
-			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "wwwroot"));
-			storage.CreateDirectory(Path.Combine(new AppSettings().BaseDirectoryProject, "clientapp", "build"));
 
 			var applicationBuilder = new ApplicationBuilder(serviceProviderInterface);
 			startup.ConfigureServices(serviceCollection);
 			var result = startup.SetupStaticFiles(applicationBuilder);
 
 			Assert.IsNotNull(result);
+
+			Console.WriteLine("result:");
+			Console.WriteLine("1: " +result.Item1 + " 2: " + result.Item2 + " 3: " + result.Item3);
 			
 			Assert.IsTrue(result.Item1);
 			Assert.IsTrue(result.Item2);
@@ -177,6 +180,9 @@ namespace starskytest.root
 
 			var result = startup.SetupStaticFiles(applicationBuilder);
 			Assert.IsNotNull(result);
+			
+			Console.WriteLine("result:");
+			Console.WriteLine("1: " +result.Item1 + " 2: " + result.Item2 + " 3: " + result.Item3);
 			
 			Assert.IsTrue(result.Item1);
 			Assert.IsTrue(result.Item2);

--- a/starsky/starskytest/starsky.foundation.sync/WatcherServices/BufferingFileSystemWatcherTest.cs
+++ b/starsky/starskytest/starsky.foundation.sync/WatcherServices/BufferingFileSystemWatcherTest.cs
@@ -674,5 +674,20 @@ namespace starskytest.starsky.foundation.sync.WatcherServices
 			wrapper.Dispose();
 			watcher.Dispose();
 		}
+
+		[TestMethod]
+		[SuppressMessage("Usage", "S3966:Objects should not be disposed more than once")]
+		public void DisposeDouble()
+		{
+			var watcher = new FileSystemWatcher(_tempFolder);
+			var wrapper = new BufferingFileSystemWatcher(watcher);
+			
+			wrapper.Dispose();
+			Assert.IsTrue(wrapper.IsDisposed);
+
+			wrapper.Dispose();
+			
+			Assert.IsTrue(wrapper.IsDisposed);
+		}
 	}
 }


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
