### PR TITLE
.NET SDK Upgrade to 8.0.101

### DIFF
--- a/starsky/starsky/starsky.csproj
+++ b/starsky/starsky/starsky.csproj
@@ -58,8 +58,8 @@
         <WarningLevel>0</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
     </ItemGroup>
     <!-- generate xml file for swagger -->


### PR DESCRIPTION
## Upgrade of .NET with newer SDK Version
- Install SDK version 8.0.101 on your development machine https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.1/8.0.1.md
- First test on linux-arm test envs before approve
- update azure runtime on test https://demostarsky.scm.azurewebsites.net/
- update docs with minimal version https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.101/starsky/readme.md
- update changelog https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.101/history.md

## When upgrading a major version
- when upgrading to newer major release check docker