### PR TITLE
Feature/202402 import refactor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -72,3 +72,6 @@ dotnet_diagnostic.IDE0005.severity = warning
 # CS4014: Because this call is not awaited, execution of the current method continues before the call is completed.
 # Consider applying the 'await' operator to the result of the call.
 dotnet_diagnostic.CS4014.severity = error
+
+
+dotnet_diagnostic.IDE0028.severity = silent #  IDE0028 = Simplify collection initialization

--- a/.editorconfig
+++ b/.editorconfig
@@ -75,3 +75,4 @@ dotnet_diagnostic.CS4014.severity = error
 
 
 dotnet_diagnostic.IDE0028.severity = silent #  IDE0028 = Simplify collection initialization
+dotnet_diagnostic.IDE0051.severity = silent # Private member is unused

--- a/history.md
+++ b/history.md
@@ -44,8 +44,8 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 ## version 0.6.0-beta.1 -  _(Unreleased)_ - 2024-02-? {#v0.6.0-beta.1}
 
 - [x] (Changed) _Back-end_ Upgrade to .NET 8 - SDK 8.0.200 (Runtime: 8.0.2) (PR #1382)
-- [x] (Fixed) _Back-end_ Docker update base package and no recommonds install (PR #1393) 
-
+- [x] (Fixed) _Back-end_ Docker update base package and no recommendations install (PR #1393)
+- [x] (Fixed) _Back-end_ Corrupt images where generated due import (Issue started with .NET 8)  (PR #1392)
 
 ## version 0.6.0-beta.0 - 2024-02-11 {#v0.6.0-beta.0}
 

--- a/starsky/starsky.feature.import/Helpers/UpdateImportTransformations.cs
+++ b/starsky/starsky.feature.import/Helpers/UpdateImportTransformations.cs
@@ -56,7 +56,9 @@ namespace starsky.feature.import.Helpers
 			bool indexMode)
 		{
 			if ( !ExtensionRolesHelper.IsExtensionExifToolSupported(fileIndexItem.FileName) )
+			{
 				return fileIndexItem;
+			}
 
 			var comparedNamesList = new List<string>();
 			if ( dateTimeParsedFromFileName )

--- a/starsky/starsky.feature.import/Helpers/UpdateImportTransformations.cs
+++ b/starsky/starsky.feature.import/Helpers/UpdateImportTransformations.cs
@@ -63,15 +63,15 @@ namespace starsky.feature.import.Helpers
 			var comparedNamesList = new List<string>();
 			if ( dateTimeParsedFromFileName )
 			{
-				_logger.LogInformation(
-					$"[Import] DateTimeParsedFromFileName ExifTool Sync {fileIndexItem.FilePath}");
+				_logger.LogInformation($"[Import] DateTimeParsedFromFileName " +
+				                       $"ExifTool Sync {fileIndexItem.FilePath}");
 				comparedNamesList = DateTimeParsedComparedNamesList();
 			}
 
 			if ( colorClassTransformation >= 0 )
 			{
-				_logger.LogInformation(
-					$"[Import] ColorClassComparedNamesList ExifTool Sync {fileIndexItem.FilePath}");
+				_logger.LogInformation($"[Import] ColorClassComparedNamesList " +
+				                       $"ExifTool Sync {fileIndexItem.FilePath}");
 				comparedNamesList = ColorClassComparedNamesList(comparedNamesList);
 			}
 
@@ -80,6 +80,7 @@ namespace starsky.feature.import.Helpers
 				return fileIndexItem;
 			}
 
+			// Update ColorClass and DateTime if reqeusted
 			var exifToolCmdHelper = new ExifToolCmdHelper(_exifTool,
 				_subPathStorage, _thumbnailStorage,
 				new ReadMeta(_subPathStorage, _appSettings, null!, _logger),

--- a/starsky/starsky.feature.import/Services/Import.cs
+++ b/starsky/starsky.feature.import/Services/Import.cs
@@ -34,820 +34,883 @@ using starsky.foundation.writemeta.Services;
 
 [assembly: InternalsVisibleTo("starskytest")]
 
-namespace starsky.feature.import.Services
+namespace starsky.feature.import.Services;
+
+/// <summary>
+/// Also known as ImportService - Import.cs
+/// </summary>
+[Service(typeof(IImport), InjectionLifetime = InjectionLifetime.Scoped)]
+public class Import : IImport
 {
+	private readonly IImportQuery? _importQuery;
+
+	// storage providers
+	private readonly IStorage _filesystemStorage;
+	private readonly IStorage _subPathStorage;
+	private readonly IStorage _thumbnailStorage;
+
+	private readonly AppSettings _appSettings;
+
+	private readonly ReadMeta _readMetaHost;
+	private readonly IExifTool _exifTool;
+	private readonly IQuery _query;
+
+	private readonly IConsole _console;
+	private readonly IMetaExifThumbnailService _metaExifThumbnailService;
+
+	private readonly IMemoryCache? _memoryCache;
+	private readonly IServiceScopeFactory? _serviceScopeFactory;
+	private readonly IWebLogger _logger;
+	private readonly UpdateImportTransformations _updateImportTransformations;
+	private readonly IThumbnailQuery _thumbnailQuery;
+
 	/// <summary>
-	/// Also known as ImportService - Import.cs
+	/// Used when File has no exif date in description
 	/// </summary>
-	[Service(typeof(IImport), InjectionLifetime = InjectionLifetime.Scoped)]
-	public class Import : IImport
+	internal const string MessageDateTimeBasedOnFilename = "Date and Time based on filename";
+
+	[SuppressMessage("Usage",
+		"S107: Constructor has 8 parameters, which is greater than the 7 authorized")]
+	public Import(
+		ISelectorStorage selectorStorage,
+		AppSettings appSettings,
+		IImportQuery importQuery,
+		IExifTool exifTool,
+		IQuery query,
+		IConsole console,
+		IMetaExifThumbnailService metaExifThumbnailService,
+		IWebLogger logger,
+		IThumbnailQuery thumbnailQuery,
+		IMemoryCache? memoryCache = null,
+		IServiceScopeFactory? serviceScopeFactory = null)
 	{
-		private readonly IImportQuery? _importQuery;
+		_importQuery = importQuery;
 
-		// storage providers
-		private readonly IStorage _filesystemStorage;
-		private readonly IStorage _subPathStorage;
-		private readonly IStorage _thumbnailStorage;
+		_filesystemStorage =
+			selectorStorage.Get(SelectorStorage.StorageServices.HostFilesystem);
+		_subPathStorage = selectorStorage.Get(SelectorStorage.StorageServices.SubPath);
+		_thumbnailStorage = selectorStorage.Get(SelectorStorage.StorageServices.Thumbnail);
 
-		private readonly AppSettings _appSettings;
+		_appSettings = appSettings;
+		_readMetaHost = new ReadMeta(_filesystemStorage, appSettings, null!, logger);
+		_exifTool = exifTool;
+		_query = query;
+		_console = console;
+		_metaExifThumbnailService = metaExifThumbnailService;
+		_memoryCache = memoryCache;
+		_serviceScopeFactory = serviceScopeFactory;
+		_logger = logger;
+		_updateImportTransformations = new UpdateImportTransformations(logger, _exifTool,
+			selectorStorage, appSettings, thumbnailQuery);
+		_thumbnailQuery = thumbnailQuery;
+	}
 
-		private readonly ReadMeta _readMetaHost;
-		private readonly IExifTool _exifTool;
-		private readonly IQuery _query;
+	/// <summary>
+	/// Check if the item can be add to the database
+	/// Run `importer` to perform the action
+	/// </summary>
+	/// <param name="fullFilePathsList">paths</param>
+	/// <param name="importSettings">settings</param>
+	/// <returns></returns>
+	public async Task<List<ImportIndexItem>> Preflight(List<string> fullFilePathsList,
+		ImportSettingsModel importSettings)
+	{
+		var includedDirectoryFilePaths = AppendDirectoryFilePaths(
+			fullFilePathsList,
+			importSettings).ToList();
 
-		private readonly IConsole _console;
-		private readonly IMetaExifThumbnailService _metaExifThumbnailService;
-
-		private readonly IMemoryCache? _memoryCache;
-		private readonly IServiceScopeFactory? _serviceScopeFactory;
-		private readonly IWebLogger _logger;
-		private readonly UpdateImportTransformations _updateImportTransformations;
-		private readonly IThumbnailQuery _thumbnailQuery;
-
-		/// <summary>
-		/// Used when File has no exif date in description
-		/// </summary>
-		internal const string MessageDateTimeBasedOnFilename = "Date and Time based on filename";
-
-		[SuppressMessage("Usage",
-			"S107: Constructor has 8 parameters, which is greater than the 7 authorized")]
-		public Import(
-			ISelectorStorage selectorStorage,
-			AppSettings appSettings,
-			IImportQuery importQuery,
-			IExifTool exifTool,
-			IQuery query,
-			IConsole console,
-			IMetaExifThumbnailService metaExifThumbnailService,
-			IWebLogger logger,
-			IThumbnailQuery thumbnailQuery,
-			IMemoryCache? memoryCache = null,
-			IServiceScopeFactory? serviceScopeFactory = null)
+		// When Directory is Empty
+		if ( includedDirectoryFilePaths.Count == 0 )
 		{
-			_importQuery = importQuery;
-
-			_filesystemStorage =
-				selectorStorage.Get(SelectorStorage.StorageServices.HostFilesystem);
-			_subPathStorage = selectorStorage.Get(SelectorStorage.StorageServices.SubPath);
-			_thumbnailStorage = selectorStorage.Get(SelectorStorage.StorageServices.Thumbnail);
-
-			_appSettings = appSettings;
-			_readMetaHost = new ReadMeta(_filesystemStorage, appSettings, null!, logger);
-			_exifTool = exifTool;
-			_query = query;
-			_console = console;
-			_metaExifThumbnailService = metaExifThumbnailService;
-			_memoryCache = memoryCache;
-			_serviceScopeFactory = serviceScopeFactory;
-			_logger = logger;
-			_updateImportTransformations = new UpdateImportTransformations(logger, _exifTool,
-				selectorStorage, appSettings, thumbnailQuery);
-			_thumbnailQuery = thumbnailQuery;
+			return new List<ImportIndexItem>();
 		}
 
-		/// <summary>
-		/// Check if the item can be add to the database
-		/// Run `importer` to perform the action
-		/// </summary>
-		/// <param name="fullFilePathsList">paths</param>
-		/// <param name="importSettings">settings</param>
-		/// <returns></returns>
-		public async Task<List<ImportIndexItem>> Preflight(List<string> fullFilePathsList,
-			ImportSettingsModel importSettings)
+		var importIndexItemsList = ( await includedDirectoryFilePaths
+			.ForEachAsync(
+				async (includedFilePath)
+					=> await PreflightPerFile(includedFilePath, importSettings),
+				_appSettings.MaxDegreesOfParallelism) )!.ToList();
+
+		var directoriesContent = ParentFoldersDictionary(importIndexItemsList);
+
+		importIndexItemsList =
+			CheckForDuplicateNaming(importIndexItemsList.ToList(), directoriesContent);
+		CheckForReadOnlyFileSystems(importIndexItemsList, importSettings.DeleteAfter);
+
+		return importIndexItemsList;
+	}
+
+	internal List<Tuple<string?, List<string>>> CheckForReadOnlyFileSystems(
+		List<ImportIndexItem> importIndexItemsList, bool deleteAfter = true)
+	{
+		if ( !deleteAfter )
 		{
-			var includedDirectoryFilePaths = AppendDirectoryFilePaths(
-				fullFilePathsList,
-				importSettings).ToList();
-
-			// When Directory is Empty
-			if ( includedDirectoryFilePaths.Count == 0 )
-			{
-				return new List<ImportIndexItem>();
-			}
-
-			var importIndexItemsList = ( await includedDirectoryFilePaths
-				.ForEachAsync(
-					async (includedFilePath)
-						=> await PreflightPerFile(includedFilePath, importSettings),
-					_appSettings.MaxDegreesOfParallelism) )!.ToList();
-
-			var directoriesContent = ParentFoldersDictionary(importIndexItemsList);
-
-			importIndexItemsList =
-				CheckForDuplicateNaming(importIndexItemsList.ToList(), directoriesContent);
-			CheckForReadOnlyFileSystems(importIndexItemsList, importSettings.DeleteAfter);
-
-			return importIndexItemsList;
+			return new List<Tuple<string?, List<string>>>();
 		}
 
-		internal List<Tuple<string?, List<string>>> CheckForReadOnlyFileSystems(
-			List<ImportIndexItem> importIndexItemsList, bool deleteAfter = true)
+		var parentFolders = new List<Tuple<string?, List<string>>>();
+		foreach ( var itemSourceFullFilePath in importIndexItemsList.Select(item =>
+			         item.SourceFullFilePath) )
 		{
-			if ( !deleteAfter )
+			var parentFolder = Directory.GetParent(itemSourceFullFilePath)
+				?.FullName;
+
+			if ( parentFolders.TrueForAll(p => p.Item1 != parentFolder) )
 			{
-				return new List<Tuple<string?, List<string>>>();
+				parentFolders.Add(new Tuple<string?, List<string>>(parentFolder,
+					new List<string> { itemSourceFullFilePath }));
+				continue;
 			}
 
-			var parentFolders = new List<Tuple<string?, List<string>>>();
-			foreach ( var itemSourceFullFilePath in importIndexItemsList.Select(item =>
-						 item.SourceFullFilePath) )
-			{
-				var parentFolder = Directory.GetParent(itemSourceFullFilePath)
-					?.FullName;
+			var item2 = parentFolders.First(p => p.Item1 == parentFolder);
+			parentFolders[parentFolders.IndexOf(item2)].Item2.Add(itemSourceFullFilePath);
+		}
 
-				if ( parentFolders.TrueForAll(p => p.Item1 != parentFolder) )
+		foreach ( var parentFolder in parentFolders.Where(p => p.Item1 != null) )
+		{
+			var fileStorageInfo = _filesystemStorage.Info(parentFolder.Item1!);
+			if ( fileStorageInfo.IsFolderOrFile !=
+			     FolderOrFileModel.FolderOrFileTypeList.Folder ||
+			     fileStorageInfo.IsFileSystemReadOnly != true )
+			{
+				continue;
+			}
+
+			var items = parentFolder.Item2.Select(parentItem =>
+				Array.Find(importIndexItemsList.ToArray(),
+					p => p.SourceFullFilePath == parentItem)).Cast<ImportIndexItem>();
+
+			foreach ( var item in items )
+			{
+				importIndexItemsList[importIndexItemsList.IndexOf(item)]
+					.Status = ImportStatus.ReadOnlyFileSystem;
+
+				if ( _appSettings.IsVerbose() )
 				{
-					parentFolders.Add(new Tuple<string?, List<string>>(parentFolder,
-						new List<string> { itemSourceFullFilePath }));
+					_console.WriteLine(
+						$"🤷🗜️ Ignored, source file system is readonly try without move to copy {item.SourceFullFilePath}");
+				}
+			}
+		}
+
+		return parentFolders;
+	}
+
+	/// <summary>
+	/// Get a Dictionary with all the content of the parent folders
+	/// Used to scan for duplicate names
+	/// </summary>
+	/// <param name="importIndexItemsList">files to import, use FileIndexItem.ParentDirectory and status Ok</param>
+	/// <returns>All parent folders with content</returns>
+	internal Dictionary<string, List<string>> ParentFoldersDictionary(
+		List<ImportIndexItem> importIndexItemsList)
+	{
+		var directoriesContent = new Dictionary<string, List<string>>();
+		foreach ( var importIndexItemFileIndexItemParentDirectory in importIndexItemsList.Where(
+				         p =>
+					         p.Status == ImportStatus.Ok)
+			         .Select(p => p.FileIndexItem?.ParentDirectory) )
+		{
+			if ( importIndexItemFileIndexItemParentDirectory == null ||
+			     directoriesContent.ContainsKey(importIndexItemFileIndexItemParentDirectory) )
+				continue;
+
+			var parentDirectoryList =
+				_subPathStorage
+					.GetAllFilesInDirectory(importIndexItemFileIndexItemParentDirectory)
+					.ToList();
+			directoriesContent.Add(importIndexItemFileIndexItemParentDirectory,
+				parentDirectoryList);
+		}
+
+		return directoriesContent;
+	}
+
+	/// <summary>
+	/// Preflight for duplicate fileNames
+	/// </summary>
+	/// <param name="importIndexItemsList">list of files to be imported</param>
+	/// <param name="directoriesContent">Dictionary of all parent folders</param>
+	/// <returns>updated ImportIndexItem list</returns>
+	/// <exception cref="ApplicationException">when there are to many files with the same name</exception>
+	internal List<ImportIndexItem> CheckForDuplicateNaming(
+		List<ImportIndexItem> importIndexItemsList,
+		Dictionary<string, List<string>> directoriesContent)
+	{
+		foreach ( var importIndexItem in importIndexItemsList.Where(p =>
+			         p.Status == ImportStatus.Ok) )
+		{
+			if ( importIndexItem.FileIndexItem == null )
+			{
+				_logger.LogInformation("[CheckForDuplicateNaming] FileIndexItem is missing");
+				continue;
+			}
+
+			// Try again until the max
+			var updatedFilePath = "";
+			var indexer = 0;
+			for ( var i = 0; i < MaxTryGetDestinationPath; i++ )
+			{
+				updatedFilePath = AppendIndexerToFilePath(
+					importIndexItem.FileIndexItem!.ParentDirectory!,
+					importIndexItem.FileIndexItem!.FileName!, indexer);
+
+				var currentDirectoryContent =
+					directoriesContent[importIndexItem.FileIndexItem.ParentDirectory!];
+
+				if ( currentDirectoryContent.Contains(updatedFilePath) )
+				{
+					indexer++;
 					continue;
 				}
 
-				var item2 = parentFolders.First(p => p.Item1 == parentFolder);
-				parentFolders[parentFolders.IndexOf(item2)].Item2.Add(itemSourceFullFilePath);
+				currentDirectoryContent.Add(updatedFilePath);
+				break;
 			}
 
-			foreach ( var parentFolder in parentFolders.Where(p => p.Item1 != null) )
+			if ( indexer >= MaxTryGetDestinationPath || string.IsNullOrEmpty(updatedFilePath) )
 			{
-				var fileStorageInfo = _filesystemStorage.Info(parentFolder.Item1!);
-				if ( fileStorageInfo.IsFolderOrFile !=
-					 FolderOrFileModel.FolderOrFileTypeList.Folder ||
-					 fileStorageInfo.IsFileSystemReadOnly != true )
-				{
-					continue;
-				}
-
-				var items = parentFolder.Item2.Select(parentItem =>
-					Array.Find(importIndexItemsList.ToArray(),
-						p => p.SourceFullFilePath == parentItem)).Cast<ImportIndexItem>();
-
-				foreach ( var item in items )
-				{
-					importIndexItemsList[importIndexItemsList.IndexOf(item)]
-						.Status = ImportStatus.ReadOnlyFileSystem;
-
-					if ( _appSettings.IsVerbose() )
-					{
-						_console.WriteLine(
-							$"🤷🗜️ Ignored, source file system is readonly try without move to copy {item.SourceFullFilePath}");
-					}
-				}
+				throw new AggregateException($"tried after {MaxTryGetDestinationPath} times");
 			}
 
-			return parentFolders;
+			importIndexItem.FileIndexItem!.FilePath = updatedFilePath;
+			importIndexItem.FileIndexItem.FileName = PathHelper.GetFileName(updatedFilePath);
+			importIndexItem.FilePath = updatedFilePath;
 		}
 
-		/// <summary>
-		/// Get a Dictionary with all the content of the parent folders
-		/// Used to scan for duplicate names
-		/// </summary>
-		/// <param name="importIndexItemsList">files to import, use FileIndexItem.ParentDirectory and status Ok</param>
-		/// <returns>All parent folders with content</returns>
-		internal Dictionary<string, List<string>> ParentFoldersDictionary(
-			List<ImportIndexItem> importIndexItemsList)
-		{
-			var directoriesContent = new Dictionary<string, List<string>>();
-			foreach ( var importIndexItemFileIndexItemParentDirectory in importIndexItemsList.Where(
-							 p =>
-								 p.Status == ImportStatus.Ok)
-						 .Select(p => p.FileIndexItem?.ParentDirectory) )
-			{
-				if ( importIndexItemFileIndexItemParentDirectory == null ||
-					 directoriesContent.ContainsKey(importIndexItemFileIndexItemParentDirectory) )
-					continue;
+		return importIndexItemsList;
+	}
 
-				var parentDirectoryList =
-					_subPathStorage
-						.GetAllFilesInDirectory(importIndexItemFileIndexItemParentDirectory)
-						.ToList();
-				directoriesContent.Add(importIndexItemFileIndexItemParentDirectory,
-					parentDirectoryList);
+
+	/// <summary>
+	/// To Add files form directory to list
+	/// </summary>
+	/// <param name="fullFilePathsList">full file Path</param>
+	/// <param name="importSettings">settings to add recursive</param>
+	private List<KeyValuePair<string, bool>> AppendDirectoryFilePaths(
+		List<string> fullFilePathsList,
+		ImportSettingsModel importSettings)
+	{
+		var includedDirectoryFilePaths = new List<KeyValuePair<string, bool>>();
+		foreach ( var fullFilePath in fullFilePathsList )
+		{
+			if ( _filesystemStorage.ExistFolder(fullFilePath) &&
+			     importSettings.RecursiveDirectory )
+			{
+				// recursive
+				includedDirectoryFilePaths.AddRange(_filesystemStorage
+					.GetAllFilesInDirectoryRecursive(fullFilePath)
+					.Where(ExtensionRolesHelper.IsExtensionSyncSupported)
+					.Select(syncedFiles => new KeyValuePair<string, bool>(syncedFiles, true)));
+				continue;
 			}
 
-			return directoriesContent;
+			if ( _filesystemStorage.ExistFolder(fullFilePath) &&
+			     !importSettings.RecursiveDirectory )
+			{
+				// non-recursive
+				includedDirectoryFilePaths.AddRange(_filesystemStorage
+					.GetAllFilesInDirectory(fullFilePath)
+					.Where(ExtensionRolesHelper.IsExtensionSyncSupported)
+					.Select(syncedFiles => new KeyValuePair<string, bool>(syncedFiles, true)));
+				continue;
+			}
+
+			includedDirectoryFilePaths.Add(
+				new KeyValuePair<string, bool>(fullFilePath,
+					_filesystemStorage.ExistFile(fullFilePath))
+			);
 		}
 
-		/// <summary>
-		/// Preflight for duplicate fileNames
-		/// </summary>
-		/// <param name="importIndexItemsList">list of files to be imported</param>
-		/// <param name="directoriesContent">Dictionary of all parent folders</param>
-		/// <returns>updated ImportIndexItem list</returns>
-		/// <exception cref="ApplicationException">when there are to many files with the same name</exception>
-		internal List<ImportIndexItem> CheckForDuplicateNaming(
-			List<ImportIndexItem> importIndexItemsList,
-			Dictionary<string, List<string>> directoriesContent)
+		return includedDirectoryFilePaths;
+	}
+
+	internal async Task<ImportIndexItem> PreflightPerFile(
+		KeyValuePair<string, bool> inputFileFullPath,
+		ImportSettingsModel importSettings)
+	{
+		if ( _appSettings.ImportIgnore.Exists(p => inputFileFullPath.Key.Contains(p)) )
 		{
-			foreach ( var importIndexItem in importIndexItemsList.Where(p =>
-						 p.Status == ImportStatus.Ok) )
+			ConsoleIfVerbose($"❌ skip due rules: {inputFileFullPath.Key} ");
+			return new ImportIndexItem
 			{
-				if ( importIndexItem.FileIndexItem == null )
-				{
-					_logger.LogInformation("[CheckForDuplicateNaming] FileIndexItem is missing");
-					continue;
-				}
-
-				// Try again until the max
-				var updatedFilePath = "";
-				var indexer = 0;
-				for ( var i = 0; i < MaxTryGetDestinationPath; i++ )
-				{
-					updatedFilePath = AppendIndexerToFilePath(
-						importIndexItem.FileIndexItem!.ParentDirectory!,
-						importIndexItem.FileIndexItem!.FileName!, indexer);
-
-					var currentDirectoryContent =
-						directoriesContent[importIndexItem.FileIndexItem.ParentDirectory!];
-
-					if ( currentDirectoryContent.Contains(updatedFilePath) )
-					{
-						indexer++;
-						continue;
-					}
-
-					currentDirectoryContent.Add(updatedFilePath);
-					break;
-				}
-
-				if ( indexer >= MaxTryGetDestinationPath || string.IsNullOrEmpty(updatedFilePath) )
-				{
-					throw new AggregateException($"tried after {MaxTryGetDestinationPath} times");
-				}
-
-				importIndexItem.FileIndexItem!.FilePath = updatedFilePath;
-				importIndexItem.FileIndexItem.FileName = PathHelper.GetFileName(updatedFilePath);
-				importIndexItem.FilePath = updatedFilePath;
-			}
-
-			return importIndexItemsList;
-		}
-
-
-		/// <summary>
-		/// To Add files form directory to list
-		/// </summary>
-		/// <param name="fullFilePathsList">full file Path</param>
-		/// <param name="importSettings">settings to add recursive</param>
-		private List<KeyValuePair<string, bool>> AppendDirectoryFilePaths(
-			List<string> fullFilePathsList,
-			ImportSettingsModel importSettings)
-		{
-			var includedDirectoryFilePaths = new List<KeyValuePair<string, bool>>();
-			foreach ( var fullFilePath in fullFilePathsList )
-			{
-				if ( _filesystemStorage.ExistFolder(fullFilePath) &&
-					 importSettings.RecursiveDirectory )
-				{
-					// recursive
-					includedDirectoryFilePaths.AddRange(_filesystemStorage
-						.GetAllFilesInDirectoryRecursive(fullFilePath)
-						.Where(ExtensionRolesHelper.IsExtensionSyncSupported)
-						.Select(syncedFiles => new KeyValuePair<string, bool>(syncedFiles, true)));
-					continue;
-				}
-
-				if ( _filesystemStorage.ExistFolder(fullFilePath) &&
-					 !importSettings.RecursiveDirectory )
-				{
-					// non-recursive
-					includedDirectoryFilePaths.AddRange(_filesystemStorage
-						.GetAllFilesInDirectory(fullFilePath)
-						.Where(ExtensionRolesHelper.IsExtensionSyncSupported)
-						.Select(syncedFiles => new KeyValuePair<string, bool>(syncedFiles, true)));
-					continue;
-				}
-
-				includedDirectoryFilePaths.Add(
-					new KeyValuePair<string, bool>(fullFilePath,
-						_filesystemStorage.ExistFile(fullFilePath))
-				);
-			}
-
-			return includedDirectoryFilePaths;
-		}
-
-		internal async Task<ImportIndexItem> PreflightPerFile(
-			KeyValuePair<string, bool> inputFileFullPath,
-			ImportSettingsModel importSettings)
-		{
-			if ( _appSettings.ImportIgnore.Exists(p => inputFileFullPath.Key.Contains(p)) )
-			{
-				ConsoleIfVerbose($"❌ skip due rules: {inputFileFullPath.Key} ");
-				return new ImportIndexItem
-				{
-					Status = ImportStatus.Ignore,
-					FilePath = inputFileFullPath.Key,
-					SourceFullFilePath = inputFileFullPath.Key,
-					AddToDatabase = DateTime.UtcNow
-				};
-			}
-
-			if ( !inputFileFullPath.Value || !_filesystemStorage.ExistFile(inputFileFullPath.Key) )
-			{
-				ConsoleIfVerbose($"❌ not found: {inputFileFullPath.Key}");
-				return new ImportIndexItem
-				{
-					Status = ImportStatus.NotFound,
-					FilePath = inputFileFullPath.Key,
-					SourceFullFilePath = inputFileFullPath.Key,
-					AddToDatabase = DateTime.UtcNow
-				};
-			}
-
-			var imageFormat = ExtensionRolesHelper.GetImageFormat(
-				_filesystemStorage.ReadStream(inputFileFullPath.Key,
-					160));
-
-			// Check if extension is correct && Check if the file is correct
-			if ( !ExtensionRolesHelper.IsExtensionSyncSupported(inputFileFullPath.Key) ||
-				 !ExtensionRolesHelper.IsExtensionSyncSupported($".{imageFormat}") )
-			{
-				ConsoleIfVerbose($"❌ extension not supported: {inputFileFullPath.Key}");
-				return new ImportIndexItem
-				{
-					Status = ImportStatus.FileError,
-					FilePath = inputFileFullPath.Key,
-					SourceFullFilePath = inputFileFullPath.Key
-				};
-			}
-
-			var hashList = await
-				new FileHash(_filesystemStorage).GetHashCodeAsync(inputFileFullPath.Key);
-			if ( !hashList.Value )
-			{
-				ConsoleIfVerbose($"❌ FileHash error {inputFileFullPath.Key}");
-				return new ImportIndexItem
-				{
-					Status = ImportStatus.FileError,
-					FilePath = inputFileFullPath.Key,
-					SourceFullFilePath = inputFileFullPath.Key
-				};
-			}
-
-			if ( importSettings.IndexMode &&
-				 await _importQuery!.IsHashInImportDbAsync(hashList.Key) )
-			{
-				ConsoleIfVerbose($"🤷 Ignored, exist already {inputFileFullPath.Key}");
-				return new ImportIndexItem
-				{
-					Status = ImportStatus.IgnoredAlreadyImported,
-					FilePath = inputFileFullPath.Key,
-					FileHash = hashList.Key,
-					AddToDatabase = DateTime.UtcNow,
-					SourceFullFilePath = inputFileFullPath.Key
-				};
-			}
-
-			// Only accept files with correct meta data
-			// Check if there is a xmp file that contains data
-			var fileIndexItem =
-				await _readMetaHost.ReadExifAndXmpFromFileAsync(inputFileFullPath.Key);
-
-			// Parse the filename and create a new importIndexItem object
-			var importIndexItem = ObjectCreateIndexItem(inputFileFullPath.Key, imageFormat,
-				hashList.Key, fileIndexItem!, importSettings.ColorClass,
-				_filesystemStorage.Info(inputFileFullPath.Key).Size);
-
-			// Update the parent and filenames
-			importIndexItem = ApplyStructure(importIndexItem, importSettings.Structure);
-
-			return importIndexItem;
-		}
-
-		private void ConsoleIfVerbose(string message)
-		{
-			if ( _appSettings.IsVerbose() )
-			{
-				_console.WriteLine(message);
-			}
-		}
-
-
-		/// <summary>
-		/// Create a new import object
-		/// </summary>
-		/// <param name="inputFileFullPath">full file path</param>
-		/// <param name="imageFormat">is it jpeg or png or something different</param>
-		/// <param name="fileHashCode">file hash base32</param>
-		/// <param name="fileIndexItem">database item</param>
-		/// <param name="colorClassTransformation">Force to update colorclass</param>
-		/// <param name="size">Add filesize in bytes</param>
-		/// <returns></returns>
-		private ImportIndexItem ObjectCreateIndexItem(
-			string inputFileFullPath,
-			ExtensionRolesHelper.ImageFormat imageFormat,
-			string fileHashCode,
-			FileIndexItem fileIndexItem,
-			int colorClassTransformation,
-			long size)
-		{
-			var importIndexItem = new ImportIndexItem(_appSettings)
-			{
-				SourceFullFilePath = inputFileFullPath,
-				DateTime = fileIndexItem.DateTime,
-				FileHash = fileHashCode,
-				FileIndexItem = fileIndexItem,
-				Status = ImportStatus.Ok,
-				FilePath = fileIndexItem.FilePath,
-				ColorClass = fileIndexItem.ColorClass
+				Status = ImportStatus.Ignore,
+				FilePath = inputFileFullPath.Key,
+				SourceFullFilePath = inputFileFullPath.Key,
+				AddToDatabase = DateTime.UtcNow
 			};
+		}
 
-			// used for files without a Exif Date for example WhatsApp images
-			if ( fileIndexItem.DateTime.Year == 1 )
+		if ( !inputFileFullPath.Value || !_filesystemStorage.ExistFile(inputFileFullPath.Key) )
+		{
+			ConsoleIfVerbose($"❌ not found: {inputFileFullPath.Key}");
+			return new ImportIndexItem
 			{
-				importIndexItem.FileIndexItem.DateTime =
-					importIndexItem.ParseDateTimeFromFileName();
-				// used to sync exifTool and to let the user know that the transformation has been applied
-				importIndexItem.FileIndexItem.Description = MessageDateTimeBasedOnFilename;
-				// only set when date is parsed if not ignore update
-				if ( importIndexItem.FileIndexItem.DateTime.Year != 1 )
-				{
-					importIndexItem.DateTimeFromFileName = true;
-				}
+				Status = ImportStatus.NotFound,
+				FilePath = inputFileFullPath.Key,
+				SourceFullFilePath = inputFileFullPath.Key,
+				AddToDatabase = DateTime.UtcNow
+			};
+		}
+
+		var imageFormat = ExtensionRolesHelper.GetImageFormat(
+			_filesystemStorage.ReadStream(inputFileFullPath.Key,
+				160));
+
+		// Check if extension is correct && Check if the file is correct
+		if ( !ExtensionRolesHelper.IsExtensionSyncSupported(inputFileFullPath.Key) ||
+		     !ExtensionRolesHelper.IsExtensionSyncSupported($".{imageFormat}") )
+		{
+			ConsoleIfVerbose($"❌ extension not supported: {inputFileFullPath.Key}");
+			return new ImportIndexItem
+			{
+				Status = ImportStatus.FileError,
+				FilePath = inputFileFullPath.Key,
+				SourceFullFilePath = inputFileFullPath.Key
+			};
+		}
+
+		var hashList = await
+			new FileHash(_filesystemStorage).GetHashCodeAsync(inputFileFullPath.Key);
+		if ( !hashList.Value )
+		{
+			ConsoleIfVerbose($"❌ FileHash error {inputFileFullPath.Key}");
+			return new ImportIndexItem
+			{
+				Status = ImportStatus.FileError,
+				FilePath = inputFileFullPath.Key,
+				SourceFullFilePath = inputFileFullPath.Key
+			};
+		}
+
+		if ( importSettings.IndexMode &&
+		     await _importQuery!.IsHashInImportDbAsync(hashList.Key) )
+		{
+			ConsoleIfVerbose($"🤷 Ignored, exist already {inputFileFullPath.Key}");
+			return new ImportIndexItem
+			{
+				Status = ImportStatus.IgnoredAlreadyImported,
+				FilePath = inputFileFullPath.Key,
+				FileHash = hashList.Key,
+				AddToDatabase = DateTime.UtcNow,
+				SourceFullFilePath = inputFileFullPath.Key
+			};
+		}
+
+		// Only accept files with correct meta data
+		// Check if there is a xmp file that contains data
+		var fileIndexItem =
+			await _readMetaHost.ReadExifAndXmpFromFileAsync(inputFileFullPath.Key);
+
+		// Parse the filename and create a new importIndexItem object
+		var importIndexItem = ObjectCreateIndexItem(inputFileFullPath.Key, imageFormat,
+			hashList.Key, fileIndexItem!, importSettings.ColorClass,
+			_filesystemStorage.Info(inputFileFullPath.Key).Size);
+
+		// Update the parent and filenames
+		importIndexItem = ApplyStructure(importIndexItem, importSettings.Structure);
+
+		return importIndexItem;
+	}
+
+	private void ConsoleIfVerbose(string message)
+	{
+		if ( _appSettings.IsVerbose() )
+		{
+			_console.WriteLine(message);
+		}
+	}
+
+
+	/// <summary>
+	/// Create a new import object
+	/// </summary>
+	/// <param name="inputFileFullPath">full file path</param>
+	/// <param name="imageFormat">is it jpeg or png or something different</param>
+	/// <param name="fileHashCode">file hash base32</param>
+	/// <param name="fileIndexItem">database item</param>
+	/// <param name="colorClassTransformation">Force to update colorclass</param>
+	/// <param name="size">Add filesize in bytes</param>
+	/// <returns></returns>
+	private ImportIndexItem ObjectCreateIndexItem(
+		string inputFileFullPath,
+		ExtensionRolesHelper.ImageFormat imageFormat,
+		string fileHashCode,
+		FileIndexItem fileIndexItem,
+		int colorClassTransformation,
+		long size)
+	{
+		var importIndexItem = new ImportIndexItem(_appSettings)
+		{
+			SourceFullFilePath = inputFileFullPath,
+			DateTime = fileIndexItem.DateTime,
+			FileHash = fileHashCode,
+			FileIndexItem = fileIndexItem,
+			Status = ImportStatus.Ok,
+			FilePath = fileIndexItem.FilePath,
+			ColorClass = fileIndexItem.ColorClass
+		};
+
+		// used for files without a Exif Date for example WhatsApp images
+		if ( fileIndexItem.DateTime.Year == 1 )
+		{
+			importIndexItem.FileIndexItem.DateTime =
+				importIndexItem.ParseDateTimeFromFileName();
+			// used to sync exifTool and to let the user know that the transformation has been applied
+			importIndexItem.FileIndexItem.Description = MessageDateTimeBasedOnFilename;
+			// only set when date is parsed if not ignore update
+			if ( importIndexItem.FileIndexItem.DateTime.Year != 1 )
+			{
+				importIndexItem.DateTimeFromFileName = true;
 			}
+		}
 
-			// Also add Camera brand to list
-			importIndexItem.MakeModel = importIndexItem.FileIndexItem.MakeModel;
+		// Also add Camera brand to list
+		importIndexItem.MakeModel = importIndexItem.FileIndexItem.MakeModel;
 
-			// AddToDatabase is Used by the importer History agent
-			importIndexItem.FileIndexItem.AddToDatabase = DateTime.UtcNow;
-			importIndexItem.AddToDatabase = DateTime.UtcNow;
+		// AddToDatabase is Used by the importer History agent
+		importIndexItem.FileIndexItem.AddToDatabase = DateTime.UtcNow;
+		importIndexItem.AddToDatabase = DateTime.UtcNow;
 
-			importIndexItem.FileIndexItem.Size = size;
-			importIndexItem.FileIndexItem.FileHash = fileHashCode;
-			importIndexItem.FileIndexItem.ImageFormat = imageFormat;
-			importIndexItem.FileIndexItem.Status = FileIndexItem.ExifStatus.Ok;
-			if ( colorClassTransformation < 0 ) return importIndexItem;
+		importIndexItem.FileIndexItem.Size = size;
+		importIndexItem.FileIndexItem.FileHash = fileHashCode;
+		importIndexItem.FileIndexItem.ImageFormat = imageFormat;
+		importIndexItem.FileIndexItem.Status = FileIndexItem.ExifStatus.Ok;
+		if ( colorClassTransformation < 0 ) return importIndexItem;
 
-			// only when set in ImportSettingsModel
-			var colorClass = ( ColorClassParser.Color )colorClassTransformation;
-			importIndexItem.FileIndexItem.ColorClass = colorClass;
-			importIndexItem.ColorClass = colorClass;
+		// only when set in ImportSettingsModel
+		var colorClass = ( ColorClassParser.Color )colorClassTransformation;
+		importIndexItem.FileIndexItem.ColorClass = colorClass;
+		importIndexItem.ColorClass = colorClass;
+		return importIndexItem;
+	}
+
+	/// <summary>
+	/// Overwrite structures when importing using a header
+	/// </summary>
+	/// <param name="importIndexItem"></param>
+	/// <param name="overwriteStructure">to overwrite, keep empty to ignore</param>
+	/// <returns>Names applied to FileIndexItem</returns>
+	private ImportIndexItem ApplyStructure(ImportIndexItem importIndexItem,
+		string overwriteStructure)
+	{
+		importIndexItem.Structure = _appSettings.Structure;
+
+		// Feature to overwrite structures when importing using a header
+		// Overwrite the structure in the ImportIndexItem
+		if ( !string.IsNullOrWhiteSpace(overwriteStructure) )
+		{
+			importIndexItem.Structure = overwriteStructure;
+		}
+
+		var structureService = new StructureService(_subPathStorage, importIndexItem.Structure);
+
+		importIndexItem.FileIndexItem!.ParentDirectory = structureService.ParseSubfolders(
+			importIndexItem.FileIndexItem.DateTime,
+			importIndexItem.FileIndexItem.FileCollectionName!,
+			FilenamesHelper.GetFileExtensionWithoutDot(importIndexItem.FileIndexItem
+				.FileName!));
+
+		importIndexItem.FileIndexItem.FileName = structureService.ParseFileName(
+			importIndexItem.FileIndexItem.DateTime,
+			importIndexItem.FileIndexItem.FileCollectionName!,
+			FilenamesHelper.GetFileExtensionWithoutDot(importIndexItem.FileIndexItem
+				.FileName!));
+		importIndexItem.FilePath = importIndexItem.FileIndexItem.FilePath;
+
+		return importIndexItem;
+	}
+
+	/// <summary>
+	/// Run import on list of files and folders (full path style)
+	/// </summary>
+	/// <param name="inputFullPathList">list of files and folders (full path style)</param>
+	/// <param name="importSettings">settings</param>
+	/// <returns>status object</returns>
+	public async Task<List<ImportIndexItem>> Importer(IEnumerable<string> inputFullPathList,
+		ImportSettingsModel importSettings)
+	{
+		var preflightItemList = await Preflight(inputFullPathList.ToList(), importSettings);
+
+		// When directory is empty 
+		if ( preflightItemList.Count == 0 )
+		{
+			return new List<ImportIndexItem>();
+		}
+
+		var directoriesContent = ParentFoldersDictionary(preflightItemList);
+		if ( importSettings.IndexMode ) await CreateParentFolders(directoriesContent);
+
+		var importIndexItemsList = ( await preflightItemList.AsEnumerable()
+			.ForEachAsync(
+				async (preflightItem)
+					=> await Importer(preflightItem, importSettings),
+				_appSettings.MaxDegreesOfParallelism) )!.ToList();
+
+		return importIndexItemsList;
+	}
+
+	/// <summary>
+	/// fail/pass, right type, string=subPath, string?2= error reason
+	/// </summary>
+	/// <param name="importIndexItemsList"></param>
+	/// <param name="importSettings"></param>
+	/// <returns></returns>
+	internal async Task<IEnumerable<(bool, bool, string, string?)>> CreateMataThumbnail(
+		IEnumerable<ImportIndexItem>
+			importIndexItemsList, ImportSettingsModel importSettings)
+	{
+		if ( _appSettings.MetaThumbnailOnImport == false ||
+		     !importSettings.IndexMode )
+		{
+			return new List<(bool, bool, string, string?)>();
+		}
+
+		var items = importIndexItemsList
+			.Where(p => p.Status == ImportStatus.Ok)
+			.Select(p => ( p.FilePath, p.FileIndexItem!.FileHash )).Cast<(string, string)>()
+			.ToList();
+
+		if ( items.Count == 0 )
+		{
+			return new List<(bool, bool, string, string?)>();
+		}
+
+		return await _metaExifThumbnailService.AddMetaThumbnail(items);
+	}
+
+	/// <summary>
+	/// Run the import on the config file
+	/// Does NOT add anything to the database
+	/// </summary>
+	/// <param name="importIndexItem">config file</param>
+	/// <param name="importSettings">optional settings</param>
+	/// <returns>status</returns>
+	internal async Task<ImportIndexItem> Importer(ImportIndexItem? importIndexItem,
+		ImportSettingsModel importSettings)
+	{
+		if ( importIndexItem is not { Status: ImportStatus.Ok } ) return importIndexItem!;
+
+		// True when exist and file type is raw
+		var xmpExistForThisFileType = ExistXmpSidecarForThisFileType(importIndexItem);
+
+		if ( xmpExistForThisFileType || ( _appSettings.ExifToolImportXmpCreate
+		                                  && ExtensionRolesHelper.IsExtensionForceXmp(
+			                                  importIndexItem.FilePath) ) )
+		{
+			// When a xmp file already exist (only for raws)
+			// AND when this created afterwards with the ExifToolImportXmpCreate setting  (only for raws)
+			importIndexItem.FileIndexItem!.AddSidecarExtension("xmp");
+		}
+
+		// Add item to database
+		await AddToQueryAndImportDatabaseAsync(importIndexItem, importSettings);
+
+		if ( ! await CopyStream(importIndexItem, importSettings) )
+		{
 			return importIndexItem;
 		}
 
-		/// <summary>
-		/// Overwrite structures when importing using a header
-		/// </summary>
-		/// <param name="importIndexItem"></param>
-		/// <param name="overwriteStructure">to overwrite, keep empty to ignore</param>
-		/// <returns>Names applied to FileIndexItem</returns>
-		private ImportIndexItem ApplyStructure(ImportIndexItem importIndexItem,
-			string overwriteStructure)
+		// Copy the sidecar file
+		if ( xmpExistForThisFileType )
 		{
-			importIndexItem.Structure = _appSettings.Structure;
-
-			// Feature to overwrite structures when importing using a header
-			// Overwrite the structure in the ImportIndexItem
-			if ( !string.IsNullOrWhiteSpace(overwriteStructure) )
-			{
-				importIndexItem.Structure = overwriteStructure;
-			}
-
-			var structureService = new StructureService(_subPathStorage, importIndexItem.Structure);
-
-			importIndexItem.FileIndexItem!.ParentDirectory = structureService.ParseSubfolders(
-				importIndexItem.FileIndexItem.DateTime,
-				importIndexItem.FileIndexItem.FileCollectionName!,
-				FilenamesHelper.GetFileExtensionWithoutDot(importIndexItem.FileIndexItem
-					.FileName!));
-
-			importIndexItem.FileIndexItem.FileName = structureService.ParseFileName(
-				importIndexItem.FileIndexItem.DateTime,
-				importIndexItem.FileIndexItem.FileCollectionName!,
-				FilenamesHelper.GetFileExtensionWithoutDot(importIndexItem.FileIndexItem
-					.FileName!));
-			importIndexItem.FilePath = importIndexItem.FileIndexItem.FilePath;
-
-			return importIndexItem;
-		}
-
-		/// <summary>
-		/// Run import on list of files and folders (full path style)
-		/// </summary>
-		/// <param name="inputFullPathList">list of files and folders (full path style)</param>
-		/// <param name="importSettings">settings</param>
-		/// <returns>status object</returns>
-		public async Task<List<ImportIndexItem>> Importer(IEnumerable<string> inputFullPathList,
-			ImportSettingsModel importSettings)
-		{
-			var preflightItemList = await Preflight(inputFullPathList.ToList(), importSettings);
-
-			// When directory is empty 
-			if ( preflightItemList.Count == 0 )
-			{
-				return new List<ImportIndexItem>();
-			}
-
-			var directoriesContent = ParentFoldersDictionary(preflightItemList);
-			if ( importSettings.IndexMode ) await CreateParentFolders(directoriesContent);
-
-			var importIndexItemsList = ( await preflightItemList.AsEnumerable()
-				.ForEachAsync(
-					async (preflightItem)
-						=> await Importer(preflightItem, importSettings),
-					_appSettings.MaxDegreesOfParallelism) )!.ToList();
-
-			return importIndexItemsList;
-		}
-
-		/// <summary>
-		/// fail/pass, right type, string=subPath, string?2= error reason
-		/// </summary>
-		/// <param name="importIndexItemsList"></param>
-		/// <param name="importSettings"></param>
-		/// <returns></returns>
-		internal async Task<IEnumerable<(bool, bool, string, string?)>> CreateMataThumbnail(
-			IEnumerable<ImportIndexItem>
-				importIndexItemsList, ImportSettingsModel importSettings)
-		{
-			if ( _appSettings.MetaThumbnailOnImport == false ||
-				 !importSettings.IndexMode )
-			{
-				return new List<(bool, bool, string, string?)>();
-			}
-
-			var items = importIndexItemsList
-				.Where(p => p.Status == ImportStatus.Ok)
-				.Select(p => (p.FilePath, p.FileIndexItem!.FileHash)).Cast<(string, string)>()
-				.ToList();
-
-			if ( items.Count == 0 )
-			{
-				return new List<(bool, bool, string, string?)>();
-			}
-
-			return await _metaExifThumbnailService.AddMetaThumbnail(items);
-		}
-
-		/// <summary>
-		/// Run the import on the config file
-		/// Does NOT add anything to the database
-		/// </summary>
-		/// <param name="importIndexItem">config file</param>
-		/// <param name="importSettings">optional settings</param>
-		/// <returns>status</returns>
-		internal async Task<ImportIndexItem> Importer(ImportIndexItem? importIndexItem,
-			ImportSettingsModel importSettings)
-		{
-			if ( importIndexItem is not { Status: ImportStatus.Ok } ) return importIndexItem!;
-
-			// True when exist and file type is raw
-			var xmpExistForThisFileType = ExistXmpSidecarForThisFileType(importIndexItem);
-
-			if ( xmpExistForThisFileType || ( _appSettings.ExifToolImportXmpCreate
-											  && ExtensionRolesHelper.IsExtensionForceXmp(
-												  importIndexItem.FilePath) ) )
-			{
-				// When a xmp file already exist (only for raws)
-				// AND when this created afterwards with the ExifToolImportXmpCreate setting  (only for raws)
-				importIndexItem.FileIndexItem!.AddSidecarExtension("xmp");
-			}
-
-			// Add item to database
-			await AddToQueryAndImportDatabaseAsync(importIndexItem, importSettings);
-
-			// Copy
-			if ( _appSettings.IsVerbose() )
-				_logger.LogInformation("[Import] Next Action = Copy" +
-									   $" {importIndexItem.SourceFullFilePath} {importIndexItem.FilePath}");
-			using ( var sourceStream =
-				   _filesystemStorage.ReadStream(importIndexItem.SourceFullFilePath) )
-				await _subPathStorage.WriteStreamAsync(sourceStream, importIndexItem.FilePath!);
-
-			// Copy the sidecar file
-			if ( xmpExistForThisFileType )
-			{
-				var xmpSourceFullFilePath =
-					ExtensionRolesHelper.ReplaceExtensionWithXmp(importIndexItem
-						.SourceFullFilePath);
-				var destinationXmpFullPath =
-					ExtensionRolesHelper.ReplaceExtensionWithXmp(importIndexItem.FilePath);
-				_filesystemStorage.FileCopy(xmpSourceFullFilePath, destinationXmpFullPath);
-			}
-
-			await CreateSideCarFile(importIndexItem, xmpExistForThisFileType);
-
-			// Run Exiftool to Update for example colorClass
-			UpdateImportTransformations.QueryUpdateDelegate? updateItemAsync = null;
-			UpdateImportTransformations.QueryThumbnailUpdateDelegate? queryThumbnailUpdateDelegate =
-				null;
-
-			if ( importSettings.IndexMode )
-			{
-				var queryFactory = new QueryFactory(
-					new SetupDatabaseTypes(_appSettings), _query,
-					_memoryCache, _appSettings, _serviceScopeFactory, _logger);
-				updateItemAsync = queryFactory.Query()!.UpdateItemAsync;
-				queryThumbnailUpdateDelegate = (thumbnailItems) => new ThumbnailQueryFactory(
-						new SetupDatabaseTypes(_appSettings), _serviceScopeFactory,
-						_thumbnailQuery, _logger).ThumbnailQuery()!
-					.AddThumbnailRangeAsync(thumbnailItems);
-			}
-
-			await CreateMataThumbnail(new List<ImportIndexItem> { importIndexItem },
-				importSettings);
-
-			// next: and save the database item
-			importIndexItem.FileIndexItem = await _updateImportTransformations
-				.UpdateTransformations(updateItemAsync, importIndexItem.FileIndexItem!,
-					importSettings.ColorClass, importIndexItem.DateTimeFromFileName,
-					importSettings.IndexMode);
-
-			await UpdateCreateMetaThumbnail(queryThumbnailUpdateDelegate,
-				importIndexItem.FileIndexItem?.FileHash, importSettings.IndexMode);
-
-			DeleteFileAfter(importSettings, importIndexItem);
-
-			if ( _appSettings.IsVerbose() ) _console.Write("+");
-			return importIndexItem;
-		}
-
-		private async Task UpdateCreateMetaThumbnail(
-			UpdateImportTransformations.QueryThumbnailUpdateDelegate? queryThumbnailUpdateDelegate,
-			string? fileHash, bool indexMode)
-		{
-			if ( fileHash == null || _appSettings.MetaThumbnailOnImport == false || !indexMode ||
-				 queryThumbnailUpdateDelegate == null ) return;
-			// Check if fastest version is available to show 
-			var setStatus = _thumbnailStorage.ExistFile(
-				ThumbnailNameHelper.Combine(fileHash, ThumbnailSize.TinyMeta));
-			await queryThumbnailUpdateDelegate(new List<ThumbnailResultDataTransferModel>
-			{
-				new ThumbnailResultDataTransferModel(fileHash, setStatus)
-			});
-		}
-
-		/// <summary>
-		/// To Move Files after import
-		/// </summary>
-		/// <param name="importSettings">to enable the 'Delete After' flag</param>
-		/// <param name="importIndexItem">item</param>
-		private void DeleteFileAfter(ImportSettingsModel importSettings,
-			ImportIndexItem importIndexItem)
-		{
-			// to move files
-			if ( !importSettings.DeleteAfter ) return;
-			if ( _appSettings.IsVerbose() )
-			{
-				_console.WriteLine($"🚮 Delete file: {importIndexItem.SourceFullFilePath}");
-			}
-
-			_filesystemStorage.FileDelete(importIndexItem.SourceFullFilePath);
-		}
-
-		/// <summary>
-		///	From here on the item is exit in the storage folder
-		/// Creation of a sidecar xmp file
-		/// </summary>
-		/// <param name="importIndexItem"></param>
-		/// <param name="xmpExistForThisFileType"></param>
-		private async Task CreateSideCarFile(ImportIndexItem importIndexItem,
-			bool xmpExistForThisFileType)
-		{
-			if ( _appSettings.ExifToolImportXmpCreate && !xmpExistForThisFileType )
-			{
-				var exifCopy = new ExifCopy(_subPathStorage,
-					_thumbnailStorage, _exifTool, new ReadMeta(_subPathStorage,
-						_appSettings, null!, _logger), _thumbnailQuery);
-				await exifCopy.XmpSync(importIndexItem.FileIndexItem!.FilePath!);
-			}
-		}
-
-		/// <summary>
-		/// Support for include sidecar files - True when exist and current filetype is raw
-		/// </summary>
-		/// <param name="importIndexItem">to get the SourceFullFilePath</param>
-		/// <returns>True when exist and current filetype is raw</returns>
-		internal bool ExistXmpSidecarForThisFileType(ImportIndexItem importIndexItem)
-		{
-			if ( string.IsNullOrEmpty(importIndexItem.SourceFullFilePath) )
-			{
-				return false;
-			}
-
-			// Support for include sidecar files
 			var xmpSourceFullFilePath =
 				ExtensionRolesHelper.ReplaceExtensionWithXmp(importIndexItem
 					.SourceFullFilePath);
-			return ExtensionRolesHelper.IsExtensionForceXmp(importIndexItem
-					   .SourceFullFilePath) &&
-				   _filesystemStorage.ExistFile(xmpSourceFullFilePath);
+			var destinationXmpFullPath =
+				ExtensionRolesHelper.ReplaceExtensionWithXmp(importIndexItem.FilePath);
+			_filesystemStorage.FileCopy(xmpSourceFullFilePath, destinationXmpFullPath);
 		}
 
-		/// <summary>
-		/// Add item to database
-		/// </summary>
-		internal async Task AddToQueryAndImportDatabaseAsync(
-			ImportIndexItem importIndexItem,
-			ImportSettingsModel importSettings)
-		{
-			if ( !importSettings.IndexMode || _importQuery?.TestConnection() != true )
-			{
-				if ( _appSettings.IsVerbose() )
-					_logger.LogInformation(" AddToQueryAndImportDatabaseAsync Ignored - " +
-										   $"IndexMode {importSettings.IndexMode} " +
-										   $"TestConnection {_importQuery?.TestConnection()}");
-				return;
-			}
+		await CreateSideCarFile(importIndexItem, xmpExistForThisFileType);
 
-			// Add to Normal File Index database
+		// Run Exiftool to Update for example colorClass
+		UpdateImportTransformations.QueryUpdateDelegate? updateItemAsync = null;
+		UpdateImportTransformations.QueryThumbnailUpdateDelegate? queryThumbnailUpdateDelegate =
+			null;
+
+		if ( importSettings.IndexMode )
+		{
 			var queryFactory = new QueryFactory(
 				new SetupDatabaseTypes(_appSettings), _query,
 				_memoryCache, _appSettings, _serviceScopeFactory, _logger);
-			var query = queryFactory.Query();
-			await query!.AddItemAsync(importIndexItem.FileIndexItem!);
-
-			// Add to check db, to avoid duplicate input
-			var importQuery = new ImportQueryFactory(new SetupDatabaseTypes(_appSettings),
-				_importQuery, _console, _logger).ImportQuery();
-			await importQuery!.AddAsync(importIndexItem,
-				importSettings.IsConsoleOutputModeDefault());
-
-			await query.DisposeAsync();
+			updateItemAsync = queryFactory.Query()!.UpdateItemAsync;
+			queryThumbnailUpdateDelegate = (thumbnailItems) => new ThumbnailQueryFactory(
+					new SetupDatabaseTypes(_appSettings), _serviceScopeFactory,
+					_thumbnailQuery, _logger).ThumbnailQuery()!
+				.AddThumbnailRangeAsync(thumbnailItems);
 		}
 
-		/// <summary>
-		/// Number of checks for files with the same filePath.
-		/// Change only to get Exceptions earlier
-		/// </summary>
-		internal int MaxTryGetDestinationPath { get; set; } = 100;
+		await CreateMataThumbnail(new List<ImportIndexItem> { importIndexItem },
+			importSettings);
 
-		/// <summary>
-		/// Append test_1.jpg to filepath (subPath style)
-		/// </summary>
-		/// <param name="fileName">the fileName</param>
-		/// <param name="index">number</param>
-		/// <param name="parentDirectory">subPath style</param>
-		/// <returns>test_1.jpg with complete filePath</returns>
-		internal static string AppendIndexerToFilePath(string parentDirectory, string fileName,
-			int index)
+		// next: and save the database item
+		importIndexItem.FileIndexItem = await _updateImportTransformations
+			.UpdateTransformations(updateItemAsync, importIndexItem.FileIndexItem!,
+				importSettings.ColorClass, importIndexItem.DateTimeFromFileName,
+				importSettings.IndexMode);
+
+		await UpdateCreateMetaThumbnail(queryThumbnailUpdateDelegate,
+			importIndexItem.FileIndexItem?.FileHash, importSettings.IndexMode);
+
+		DeleteFileAfter(importSettings, importIndexItem);
+
+		if ( _appSettings.IsVerbose() ) _console.Write("+");
+		return importIndexItem;
+	}
+
+	private async Task<bool> CopyStream(ImportIndexItem importIndexItem,
+		ImportSettingsModel importSettings)
+	{
+		if ( _appSettings.IsVerbose() )
 		{
-			if ( index >= 1 )
-			{
-				fileName = string.Concat(
-					FilenamesHelper.GetFileNameWithoutExtension(fileName),
-					$"_{index}.",
-					FilenamesHelper.GetFileExtensionWithoutDot(fileName)
-				);
-			}
-
-			return PathHelper.AddSlash(parentDirectory) + PathHelper.RemovePrefixDbSlash(fileName);
+			_logger.LogInformation("[Import] Next Action = Copy" +
+			                       $" {importIndexItem.SourceFullFilePath} {importIndexItem.FilePath}");
 		}
 
-		/// <summary>
-		/// Create parent folders if the folder does not exist on disk
-		/// </summary>
-		/// <param name="directoriesContent">List of all ParentFolders</param>
-		private async Task CreateParentFolders(Dictionary<string, List<string>> directoriesContent)
+		var hostStorageFileSize = _filesystemStorage.Info(importIndexItem.SourceFullFilePath).Size;
+		var sourceStream =
+			_filesystemStorage.ReadStream(importIndexItem.SourceFullFilePath);
+
+		try
 		{
-			foreach ( var parentDirectoryPath in directoriesContent )
+			await _subPathStorage.WriteStreamAsync(sourceStream, importIndexItem.FilePath!);
+		}
+		catch ( AggregateException exception )
+		{
+			//  System.IO.IOException: No space left on device 
+			_logger.LogError($"CopyStream  {importIndexItem.FilePath} - retry helper failed {exception.Message}", exception);
+		}
+		finally
+		{
+			await sourceStream.DisposeAsync();
+		}
+
+		var subStorageFileSize = _subPathStorage.Info(importIndexItem.FilePath!).Size;
+		if ( hostStorageFileSize == subStorageFileSize ) return true;
+		_logger.LogError($"Host size does not match   {hostStorageFileSize} - {subStorageFileSize} " +
+		                 $"{importIndexItem.SourceFullFilePath} - {importIndexItem.FilePath}");
+
+		_subPathStorage.FileDelete(importIndexItem.FilePath!);
+		await RemoveFromQueryAndImportDatabaseAsync(importIndexItem, importSettings);
+		importIndexItem.Status = ImportStatus.FileError;
+		return false;
+	}
+
+	private async Task UpdateCreateMetaThumbnail(
+		UpdateImportTransformations.QueryThumbnailUpdateDelegate? queryThumbnailUpdateDelegate,
+		string? fileHash, bool indexMode)
+	{
+		if ( fileHash == null || _appSettings.MetaThumbnailOnImport == false || !indexMode ||
+		     queryThumbnailUpdateDelegate == null ) return;
+		// Check if fastest version is available to show 
+		var setStatus = _thumbnailStorage.ExistFile(
+			ThumbnailNameHelper.Combine(fileHash, ThumbnailSize.TinyMeta));
+		await queryThumbnailUpdateDelegate(new List<ThumbnailResultDataTransferModel>
+		{
+			new ThumbnailResultDataTransferModel(fileHash, setStatus)
+		});
+	}
+
+	/// <summary>
+	/// To Move Files after import
+	/// </summary>
+	/// <param name="importSettings">to enable the 'Delete After' flag</param>
+	/// <param name="importIndexItem">item</param>
+	private void DeleteFileAfter(ImportSettingsModel importSettings,
+		ImportIndexItem importIndexItem)
+	{
+		// to move files
+		if ( !importSettings.DeleteAfter ) return;
+		if ( _appSettings.IsVerbose() )
+		{
+			_console.WriteLine($"🚮 Delete file: {importIndexItem.SourceFullFilePath}");
+		}
+
+		_filesystemStorage.FileDelete(importIndexItem.SourceFullFilePath);
+	}
+
+	/// <summary>
+	///	From here on the item is exit in the storage folder
+	/// Creation of a sidecar xmp file
+	/// </summary>
+	/// <param name="importIndexItem"></param>
+	/// <param name="xmpExistForThisFileType"></param>
+	private async Task CreateSideCarFile(ImportIndexItem importIndexItem,
+		bool xmpExistForThisFileType)
+	{
+		if ( _appSettings.ExifToolImportXmpCreate && !xmpExistForThisFileType )
+		{
+			var exifCopy = new ExifCopy(_subPathStorage,
+				_thumbnailStorage, _exifTool, new ReadMeta(_subPathStorage,
+					_appSettings, null!, _logger), _thumbnailQuery);
+			await exifCopy.XmpSync(importIndexItem.FileIndexItem!.FilePath!);
+		}
+	}
+
+	/// <summary>
+	/// Support for include sidecar files - True when exist and current filetype is raw
+	/// </summary>
+	/// <param name="importIndexItem">to get the SourceFullFilePath</param>
+	/// <returns>True when exist and current filetype is raw</returns>
+	internal bool ExistXmpSidecarForThisFileType(ImportIndexItem importIndexItem)
+	{
+		if ( string.IsNullOrEmpty(importIndexItem.SourceFullFilePath) )
+		{
+			return false;
+		}
+
+		// Support for include sidecar files
+		var xmpSourceFullFilePath =
+			ExtensionRolesHelper.ReplaceExtensionWithXmp(importIndexItem
+				.SourceFullFilePath);
+		return ExtensionRolesHelper.IsExtensionForceXmp(importIndexItem
+			       .SourceFullFilePath) &&
+		       _filesystemStorage.ExistFile(xmpSourceFullFilePath);
+	}
+
+	/// <summary>
+	/// Add item to database
+	/// </summary>
+	internal async Task AddToQueryAndImportDatabaseAsync(
+		ImportIndexItem importIndexItem,
+		ImportSettingsModel importSettings)
+	{
+		if ( !importSettings.IndexMode || _importQuery?.TestConnection() != true )
+		{
+			if ( _appSettings.IsVerbose() )
+				_logger.LogInformation(" AddToQueryAndImportDatabaseAsync Ignored - " +
+				                       $"IndexMode {importSettings.IndexMode} " +
+				                       $"TestConnection {_importQuery?.TestConnection()}");
+			return;
+		}
+
+		// Add to Normal File Index database
+		var queryFactory = new QueryFactory(
+			new SetupDatabaseTypes(_appSettings), _query,
+			_memoryCache, _appSettings, _serviceScopeFactory, _logger);
+		var query = queryFactory.Query();
+		await query!.AddItemAsync(importIndexItem.FileIndexItem!);
+		await query.DisposeAsync();
+
+		// Add to import db, to avoid duplicate input
+		var importQuery = new ImportQueryFactory(new SetupDatabaseTypes(_appSettings),
+			_importQuery, _console, _logger).ImportQuery();
+		await importQuery!.AddAsync(importIndexItem,
+			importSettings.IsConsoleOutputModeDefault());
+	}
+
+	/// <summary>
+	/// Remove from database
+	/// </summary>
+	internal async Task RemoveFromQueryAndImportDatabaseAsync(
+		ImportIndexItem importIndexItem,
+		ImportSettingsModel importSettings)
+	{
+		if ( !importSettings.IndexMode || _importQuery?.TestConnection() != true )
+		{
+			if ( _appSettings.IsVerbose() )
+				_logger.LogInformation(" RemoveToQueryAndImportDatabaseAsync Ignored - " +
+				                       $"IndexMode {importSettings.IndexMode} " +
+				                       $"TestConnection {_importQuery?.TestConnection()}");
+			return;
+		}
+
+		// Remove from Normal File Index database
+		var queryFactory = new QueryFactory(
+			new SetupDatabaseTypes(_appSettings), _query,
+			_memoryCache, _appSettings, _serviceScopeFactory, _logger);
+		var query = queryFactory.Query();
+		await query!.RemoveItemAsync(importIndexItem.FileIndexItem!);
+		await query.DisposeAsync();
+
+		// Remove from import db
+		var importQuery = new ImportQueryFactory(new SetupDatabaseTypes(_appSettings),
+			_importQuery, _console, _logger).ImportQuery();
+		await importQuery!.RemoveItemAsync(importIndexItem);
+	}
+
+	/// <summary>
+	/// Number of checks for files with the same filePath.
+	/// Change only to get Exceptions earlier
+	/// </summary>
+	internal int MaxTryGetDestinationPath { get; set; } = 100;
+
+	/// <summary>
+	/// Append test_1.jpg to filepath (subPath style)
+	/// </summary>
+	/// <param name="fileName">the fileName</param>
+	/// <param name="index">number</param>
+	/// <param name="parentDirectory">subPath style</param>
+	/// <returns>test_1.jpg with complete filePath</returns>
+	internal static string AppendIndexerToFilePath(string parentDirectory, string fileName,
+		int index)
+	{
+		if ( index >= 1 )
+		{
+			fileName = string.Concat(
+				FilenamesHelper.GetFileNameWithoutExtension(fileName),
+				$"_{index}.",
+				FilenamesHelper.GetFileExtensionWithoutDot(fileName)
+			);
+		}
+
+		return PathHelper.AddSlash(parentDirectory) + PathHelper.RemovePrefixDbSlash(fileName);
+	}
+
+	/// <summary>
+	/// Create parent folders if the folder does not exist on disk
+	/// </summary>
+	/// <param name="directoriesContent">List of all ParentFolders</param>
+	private async Task CreateParentFolders(Dictionary<string, List<string>> directoriesContent)
+	{
+		foreach ( var parentDirectoryPath in directoriesContent )
+		{
+			var parentDirectoriesList = parentDirectoryPath.Key.Split('/');
+
+			var parentPath = new StringBuilder();
+			await CreateNewDatabaseDirectory("/");
+
+			foreach ( var folderName in parentDirectoriesList )
 			{
-				var parentDirectoriesList = parentDirectoryPath.Key.Split('/');
+				if ( string.IsNullOrEmpty(folderName) ) continue;
+				parentPath.Append($"/{folderName}");
 
-				var parentPath = new StringBuilder();
-				await CreateNewDatabaseDirectory("/");
+				await CreateNewDatabaseDirectory(parentPath.ToString());
 
-				foreach ( var folderName in parentDirectoriesList )
+				if ( _subPathStorage.ExistFolder(parentPath.ToString()) )
 				{
-					if ( string.IsNullOrEmpty(folderName) ) continue;
-					parentPath.Append($"/{folderName}");
-
-					await CreateNewDatabaseDirectory(parentPath.ToString());
-
-					if ( _subPathStorage.ExistFolder(parentPath.ToString()) )
-					{
-						continue;
-					}
-
-					_subPathStorage.CreateDirectory(parentPath.ToString());
+					continue;
 				}
+
+				_subPathStorage.CreateDirectory(parentPath.ToString());
 			}
 		}
+	}
 
-		/// <summary>
-		/// Temp place to store parent Directories to avoid lots of Database requests
-		/// </summary>
-		private List<string> AddedParentDirectories { get; set; } = new List<string>();
+	/// <summary>
+	/// Temp place to store parent Directories to avoid lots of Database requests
+	/// </summary>
+	private List<string> AddedParentDirectories { get; set; } = new List<string>();
 
-		/// <summary>
-		/// Create a directory in the database
-		/// </summary>
-		/// <param name="parentPath">path to create</param>
-		/// <returns>async task</returns>
-		private async Task CreateNewDatabaseDirectory(string parentPath)
+	/// <summary>
+	/// Create a directory in the database
+	/// </summary>
+	/// <param name="parentPath">path to create</param>
+	/// <returns>async task</returns>
+	private async Task CreateNewDatabaseDirectory(string parentPath)
+	{
+		if ( AddedParentDirectories.Contains(parentPath) ||
+		     _query.SingleItem(parentPath) != null ) return;
+
+		var item = new FileIndexItem(PathHelper.RemoveLatestSlash(parentPath))
 		{
-			if ( AddedParentDirectories.Contains(parentPath) ||
-				 _query.SingleItem(parentPath) != null ) return;
+			AddToDatabase = DateTime.UtcNow,
+			IsDirectory = true,
+			ColorClass = ColorClassParser.Color.None
+		};
 
-			var item = new FileIndexItem(PathHelper.RemoveLatestSlash(parentPath))
-			{
-				AddToDatabase = DateTime.UtcNow,
-				IsDirectory = true,
-				ColorClass = ColorClassParser.Color.None
-			};
-
-			await _query.AddItemAsync(item);
-			AddedParentDirectories.Add(parentPath);
-		}
+		await _query.AddItemAsync(item);
+		AddedParentDirectories.Add(parentPath);
 	}
 }

--- a/starsky/starsky.feature.import/Services/Import.cs
+++ b/starsky/starsky.feature.import/Services/Import.cs
@@ -622,6 +622,7 @@ public class Import : IImport
 			_filesystemStorage.FileCopy(xmpSourceFullFilePath, destinationXmpFullPath);
 		}
 
+		// ExifCopy / XMPSync
 		await CreateSideCarFile(importIndexItem, xmpExistForThisFileType);
 
 		// Run Exiftool to Update for example colorClass

--- a/starsky/starsky.feature.import/Services/ImportCli.cs
+++ b/starsky/starsky.feature.import/Services/ImportCli.cs
@@ -36,7 +36,7 @@ namespace starsky.feature.import.Services
 		/// </summary>
 		/// <param name="args">arguments provided by command line app</param>
 		/// <returns>Void Task</returns>
-		public async Task Importer(string[] args)
+		public async Task<bool> Importer(string[] args)
 		{
 			_logger.LogInformation("run importer");
 
@@ -49,7 +49,7 @@ namespace starsky.feature.import.Services
 				    .GetPathFormArgs(args, false).Length <= 1 )
 			{
 				new ArgsHelper(_appSettings, _console).NeedHelpShowDialog();
-				return;
+				return true;
 			}
 
 			var inputPathListFormArgs = new ArgsHelper(_appSettings).GetPathListFormArgs(args);
@@ -86,6 +86,9 @@ namespace starsky.feature.import.Services
 			WriteOutputStatus(importSettings, result, stopWatch);
 
 			_logger.LogInformation("done import");
+
+			return result.TrueForAll(p =>
+				p.Status is ImportStatus.Ok or ImportStatus.IgnoredAlreadyImported);
 		}
 
 		private void WriteOutputStatus(ImportSettingsModel importSettings,

--- a/starsky/starsky.feature.import/Services/ImportCli.cs
+++ b/starsky/starsky.feature.import/Services/ImportCli.cs
@@ -97,14 +97,21 @@ namespace starsky.feature.import.Services
 			if ( importSettings.IsConsoleOutputModeDefault() )
 			{
 				var okCount = result.Count(p => p.Status == ImportStatus.Ok);
-				_console.WriteLine($"\nDone Importing {okCount}");
+				_logger.LogInformation($"\nDone Importing {okCount}");
+
 				if ( okCount != 0 )
 				{
-					_console.WriteLine($"Time: {Math.Round(stopWatch.Elapsed.TotalSeconds, 1)} " +
-					                   $"sec. or {Math.Round(stopWatch.Elapsed.TotalMinutes, 1)} min.");
+					_logger.LogInformation(
+						$"Time: {Math.Round(stopWatch.Elapsed.TotalSeconds, 1)} " +
+						$"sec. or {Math.Round(stopWatch.Elapsed.TotalMinutes, 1)} min.");
 				}
 
-				_console.WriteLine($"Failed: {result.Count(p => p.Status != ImportStatus.Ok)}");
+				var failedCount = result.Count(p =>
+					p.Status != ImportStatus.Ok && p.Status != ImportStatus.IgnoredAlreadyImported);
+				_logger.LogInformation($"Failed: {failedCount}");
+				var ignoredCount =
+					result.Count(p => p.Status == ImportStatus.IgnoredAlreadyImported);
+				_logger.LogInformation($"Skip due already imported: {ignoredCount}");
 			}
 
 			if ( importSettings.ConsoleOutputMode != ConsoleOutputMode.Csv )

--- a/starsky/starsky.feature.thumbnail/Services/PeriodicThumbnailScanHostedService.cs
+++ b/starsky/starsky.feature.thumbnail/Services/PeriodicThumbnailScanHostedService.cs
@@ -10,6 +10,7 @@ using starsky.foundation.platform.Interfaces;
 using starsky.foundation.platform.Models;
 
 [assembly: InternalsVisibleTo("starskytest")]
+
 namespace starsky.feature.thumbnail.Services;
 
 /// <summary>
@@ -54,7 +55,8 @@ public class PeriodicThumbnailScanHostedService : BackgroundService
 		await StartBackgroundAsync(IsEnabled, stoppingToken);
 	}
 
-	internal async Task<bool?> StartBackgroundAsync(bool startDirect, CancellationToken cancellationToken)
+	internal async Task<bool?> StartBackgroundAsync(bool startDirect,
+		CancellationToken cancellationToken)
 	{
 		if ( startDirect )
 		{
@@ -78,7 +80,8 @@ public class PeriodicThumbnailScanHostedService : BackgroundService
 		}
 		catch ( OperationCanceledException exception )
 		{
-			_logger.LogError("[StartBackgroundAsync] catch-ed OperationCanceledException", exception);
+			_logger.LogError("[StartBackgroundAsync] catch-ed OperationCanceledException",
+				exception);
 		}
 
 		return null;
@@ -98,7 +101,8 @@ public class PeriodicThumbnailScanHostedService : BackgroundService
 		try
 		{
 			await using var asyncScope = _factory.CreateAsyncScope();
-			var service = asyncScope.ServiceProvider.GetRequiredService<IDatabaseThumbnailGenerationService>();
+			var service = asyncScope.ServiceProvider
+				.GetRequiredService<IDatabaseThumbnailGenerationService>();
 			await service.StartBackgroundQueue(DateTime.UtcNow.Add(Period));
 			_executionCount++;
 			// Executed PeriodicThumbnailScanHostedService
@@ -107,12 +111,13 @@ public class PeriodicThumbnailScanHostedService : BackgroundService
 				$" Count: {_executionCount} ({DateTime.UtcNow:HH:mm:ss})");
 			return true;
 		}
-		catch ( Exception ex )
+		catch ( Exception exception )
 		{
-			_logger.LogInformation(
+			_logger.LogError(
 				$"Failed to execute {nameof(PeriodicThumbnailScanHostedService)} " +
-				$"with exception message {ex.Message}. Good luck next round!");
+				$"with exception message {exception.Message}. Good luck next round!", exception);
 		}
+
 		return null;
 	}
 }

--- a/starsky/starsky.foundation.database/Import/ImportQuery.cs
+++ b/starsky/starsky.foundation.database/Import/ImportQuery.cs
@@ -159,9 +159,9 @@ namespace starsky.foundation.database.Import
 			{
 				await LocalRemoveDefaultQuery();
 			}
-			catch ( DbUpdateConcurrencyException e )
+			catch ( DbUpdateConcurrencyException exception )
 			{
-				_logger.LogInformation(e, "[RemoveItemAsync] catch-ed " +
+				_logger.LogInformation(exception, "[RemoveItemAsync] catch-ed " +
 				                          "DbUpdateConcurrencyException (do nothing)");
 			}
 

--- a/starsky/starsky.foundation.database/Import/ImportQuery.cs
+++ b/starsky/starsky.foundation.database/Import/ImportQuery.cs
@@ -10,6 +10,7 @@ using starsky.foundation.database.Interfaces;
 using starsky.foundation.database.Models;
 using starsky.foundation.database.Query;
 using starsky.foundation.injection;
+using starsky.foundation.platform.Helpers;
 using starsky.foundation.platform.Interfaces;
 
 namespace starsky.foundation.database.Import
@@ -32,7 +33,8 @@ namespace starsky.foundation.database.Import
 		/// <param name="console">console output</param>
 		/// <param name="logger"></param>
 		/// <param name="dbContext"></param>
-		public ImportQuery(IServiceScopeFactory? scopeFactory, IConsole console, IWebLogger logger, ApplicationDbContext? dbContext = null)
+		public ImportQuery(IServiceScopeFactory? scopeFactory, IConsole console, IWebLogger logger,
+			ApplicationDbContext? dbContext = null)
 		{
 			_scopeFactory = scopeFactory;
 
@@ -48,7 +50,9 @@ namespace starsky.foundation.database.Import
 		/// <returns>database context</returns>
 		private ApplicationDbContext GetDbContext()
 		{
-			return ( _scopeFactory != null ? new InjectServiceScope(_scopeFactory).Context() : _dbContext )!;
+			return ( _scopeFactory != null
+				? new InjectServiceScope(_scopeFactory).Context()
+				: _dbContext )!;
 		}
 
 		/// <summary>
@@ -65,7 +69,7 @@ namespace starsky.foundation.database.Import
 			if ( _isConnection )
 			{
 				var value = await GetDbContext().ImportIndex.CountAsync(p =>
-					p.FileHash == fileHashCode) != 0;           // there is no any in ef core
+					p.FileHash == fileHashCode) != 0; // there is no any in ef core
 				return value;
 			}
 
@@ -80,7 +84,8 @@ namespace starsky.foundation.database.Import
 		/// <param name="updateStatusContent">import database item</param>
 		/// <param name="writeConsole">add icon to console</param>
 		/// <returns>fail or success</returns>
-		public async Task<bool> AddAsync(ImportIndexItem updateStatusContent, bool writeConsole = true)
+		public async Task<bool> AddAsync(ImportIndexItem updateStatusContent,
+			bool writeConsole = true)
 		{
 			var dbContext = GetDbContext();
 			updateStatusContent.AddToDatabase = DateTime.UtcNow;
@@ -97,11 +102,13 @@ namespace starsky.foundation.database.Import
 		/// <returns>List of items</returns>
 		public List<ImportIndexItem> History()
 		{
-			return GetDbContext().ImportIndex.Where(p => p.AddToDatabase >= DateTime.UtcNow.AddDays(-1)).ToList();
+			return GetDbContext().ImportIndex
+				.Where(p => p.AddToDatabase >= DateTime.UtcNow.AddDays(-1)).ToList();
 			// for debug: p.AddToDatabase >= DateTime.UtcNow.AddDays(-2) && p.Id % 6 == 1
 		}
 
-		public async Task<List<ImportIndexItem>> AddRangeAsync(List<ImportIndexItem> importIndexItemList)
+		public async Task<List<ImportIndexItem>> AddRangeAsync(
+			List<ImportIndexItem> importIndexItemList)
 		{
 			var dbContext = GetDbContext();
 			await dbContext.ImportIndex.AddRangeAsync(importIndexItemList);
@@ -109,6 +116,58 @@ namespace starsky.foundation.database.Import
 			_console.Write($"⬆️ {importIndexItemList.Count} "); // arrowUp
 			return importIndexItemList;
 		}
+
+		public async Task<ImportIndexItem> RemoveItemAsync(ImportIndexItem importIndexItem)
+		{
+			async Task<bool> LocalRemoveDefaultQuery()
+			{
+				await LocalRemoveQuery(new InjectServiceScope(_scopeFactory).Context());
+				return true;
+			}
+
+			async Task LocalRemoveQuery(ApplicationDbContext context)
+			{
+				// Detach first https://stackoverflow.com/a/42475617
+				var local = context.Set<FileIndexItem>()
+					.Local
+					.FirstOrDefault(entry => entry.Id.Equals(importIndexItem.Id));
+				if ( local != null )
+				{
+					context.Entry(local).State = EntityState.Detached;
+				}
+
+				// keep conditional marker for test
+				context.ImportIndex?.Remove(importIndexItem);
+				await context.SaveChangesAsync();
+			}
+
+			try
+			{
+				await LocalRemoveQuery(_dbContext!);
+			}
+			catch ( Microsoft.Data.Sqlite.SqliteException )
+			{
+				// Files that are locked
+				await RetryHelper.DoAsync(LocalRemoveDefaultQuery,
+					TimeSpan.FromSeconds(2), 4);
+			}
+			catch ( ObjectDisposedException )
+			{
+				await LocalRemoveDefaultQuery();
+			}
+			catch ( InvalidOperationException )
+			{
+				await LocalRemoveDefaultQuery();
+			}
+			catch ( DbUpdateConcurrencyException e )
+			{
+				_logger.LogInformation(e, "[RemoveItemAsync] catch-ed " +
+				                          "DbUpdateConcurrencyException (do nothing)");
+			}
+
+			return importIndexItem;
+		}
+
 
 		public List<ImportIndexItem> AddRange(List<ImportIndexItem> importIndexItemList)
 		{

--- a/starsky/starsky.foundation.database/Interfaces/IImportQuery.cs
+++ b/starsky/starsky.foundation.database/Interfaces/IImportQuery.cs
@@ -11,5 +11,6 @@ namespace starsky.foundation.database.Interfaces
 		Task<bool> AddAsync(ImportIndexItem updateStatusContent, bool writeConsole = true);
 		List<ImportIndexItem> History();
 		Task<List<ImportIndexItem>> AddRangeAsync(List<ImportIndexItem> importIndexItemList);
+		Task<ImportIndexItem> RemoveItemAsync(ImportIndexItem importIndexItem);
 	}
 }

--- a/starsky/starsky.foundation.platform/Exceptions/WebApplicationException.cs
+++ b/starsky/starsky.foundation.platform/Exceptions/WebApplicationException.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Runtime.Serialization;
+
+#pragma warning disable SYSLIB0051
+
+namespace starsky.foundation.platform.Exceptions;
+
+[Serializable]
+public class WebApplicationException : Exception
+{
+	public WebApplicationException()
+	{
+	}
+
+	public WebApplicationException(string message)
+		: base(message)
+	{
+	}
+
+	public WebApplicationException(string message, System.Exception inner)
+		: base(message, inner)
+	{
+	}
+
+	// Serialization constructor
+	protected WebApplicationException(SerializationInfo info, StreamingContext context)
+		: base(info, context)
+	{
+		// nothing here
+	}
+}

--- a/starsky/starsky.foundation.platform/Helpers/ExtensionRolesHelper.cs
+++ b/starsky/starsky.foundation.platform/Helpers/ExtensionRolesHelper.cs
@@ -8,7 +8,6 @@ using System.Text.RegularExpressions;
 
 namespace starsky.foundation.platform.Helpers
 {
-
 	public static class ExtensionRolesHelper
 	{
 		/// <summary>
@@ -19,7 +18,8 @@ namespace starsky.foundation.platform.Helpers
 		/// <summary>
 		/// Meta.json sidecar files
 		/// </summary>
-		private static readonly List<string> ExtensionJsonSidecar = new List<string> { "meta.json" };
+		private static readonly List<string>
+			ExtensionJsonSidecar = new List<string> { "meta.json" };
 
 
 		/// <summary>
@@ -32,8 +32,18 @@ namespace starsky.foundation.platform.Helpers
 		/// tiff, arw:sony, dng:adobe, nef:nikon, raf:fuji, cr2:canon,  orf:olympus, rw2:panasonic, pef:pentax,
 		/// Not supported due Image Processing Error x3f:sigma, crw:canon
 		/// </summary>
-		private static readonly List<string> ExtensionTiff = new List<string> {"tiff", "arw", "dng", "nef",
-			"raf", "cr2", "orf", "rw2", "pef"};
+		private static readonly List<string> ExtensionTiff = new List<string>
+		{
+			"tiff",
+			"arw",
+			"dng",
+			"nef",
+			"raf",
+			"cr2",
+			"orf",
+			"rw2",
+			"pef"
+		};
 
 		/// <summary>
 		/// Bitmaps
@@ -60,34 +70,19 @@ namespace starsky.foundation.platform.Helpers
 		/// </summary>
 		private static readonly List<string> ExtensionMp4 = new List<string> { "mp4", "mov" };
 
-		private static readonly Dictionary<ImageFormat, List<string>> MapFileTypesToExtensionDictionary =
-			new Dictionary<ImageFormat, List<string>>
-			{
+		private static readonly Dictionary<ImageFormat, List<string>>
+			MapFileTypesToExtensionDictionary =
+				new Dictionary<ImageFormat, List<string>>
 				{
-					ImageFormat.jpg, ExtensionJpg
-				},
-				{
-					ImageFormat.tiff, ExtensionTiff
-				},
-				{
-					ImageFormat.bmp, ExtensionBmp
-				},
-				{
-					ImageFormat.gif, ExtensionGif
-				},
-				{
-					ImageFormat.png, ExtensionPng
-				},
-				{
-					ImageFormat.gpx, ExtensionGpx
-				},
-				{
-					ImageFormat.mp4, ExtensionMp4
-				},
-				{
-					ImageFormat.xmp, ExtensionXmp
-				},
-			};
+					{ ImageFormat.jpg, ExtensionJpg },
+					{ ImageFormat.tiff, ExtensionTiff },
+					{ ImageFormat.bmp, ExtensionBmp },
+					{ ImageFormat.gif, ExtensionGif },
+					{ ImageFormat.png, ExtensionPng },
+					{ ImageFormat.gpx, ExtensionGpx },
+					{ ImageFormat.mp4, ExtensionMp4 },
+					{ ImageFormat.xmp, ExtensionXmp },
+				};
 
 
 		public static ImageFormat MapFileTypesToExtension(string filename)
@@ -117,6 +112,7 @@ namespace starsky.foundation.platform.Helpers
 					imageFormat = extImageFormat;
 				}
 			}
+
 			return imageFormat;
 		}
 
@@ -299,7 +295,8 @@ namespace starsky.foundation.platform.Helpers
 			}
 
 			// ReSharper disable once ConvertIfStatementToReturnStatement
-			if ( filename.ToLowerInvariant().EndsWith(".meta.json") && checkThisList.Contains("meta.json") )
+			if ( filename.ToLowerInvariant().EndsWith(".meta.json") &&
+			     checkThisList.Contains("meta.json") )
 			{
 				return true;
 			}
@@ -339,6 +336,7 @@ namespace starsky.foundation.platform.Helpers
 					return new string(matchValue);
 				}
 			}
+
 			return string.Empty;
 		}
 
@@ -386,12 +384,14 @@ namespace starsky.foundation.platform.Helpers
 			{
 				stream.Read(buffer, 0, buffer.Length);
 				stream.Close();
-				stream.Dispose();
+				stream.Flush();
+				stream.Dispose(); // also flush
 			}
 			catch ( UnauthorizedAccessException ex )
 			{
 				Console.WriteLine(ex.Message);
 			}
+
 			return buffer;
 		}
 
@@ -454,23 +454,22 @@ namespace starsky.foundation.platform.Helpers
 
 		private static ImageFormat? GetImageFormatMetaJson(byte[] bytes)
 		{
-			var metaJsonUnix = new byte[] {
-				123, 10, 32, 32, 34, 36, 105, 100, 34, 58, 32, 34, 104, 116, 116,
-				112, 115, 58, 47, 47, 100, 111, 99, 115, 46, 113, 100, 114, 97,
-				119, 46, 110, 108, 47, 115, 99, 104, 101, 109, 97, 47, 109, 101,
-				116, 97, 45, 100, 97, 116, 97, 45, 99, 111, 110, 116, 97, 105, 110,
-				101, 114, 46, 106, 115, 111, 110, 34, 44
+			var metaJsonUnix = new byte[]
+			{
+				123, 10, 32, 32, 34, 36, 105, 100, 34, 58, 32, 34, 104, 116, 116, 112, 115, 58,
+				47, 47, 100, 111, 99, 115, 46, 113, 100, 114, 97, 119, 46, 110, 108, 47, 115,
+				99, 104, 101, 109, 97, 47, 109, 101, 116, 97, 45, 100, 97, 116, 97, 45, 99, 111,
+				110, 116, 97, 105, 110, 101, 114, 46, 106, 115, 111, 110, 34, 44
 			};
 			// or : { \n "$id": "https://docs.qdraw.nl/schema/meta-data-container.json",
 
 			var metaJsonWindows = new byte[]
 			{
 				// 13 is CR
-				123, 13, 10, 32, 32, 34, 36, 105, 100, 34, 58, 32, 34, 104, 116,
-				116, 112, 115, 58, 47, 47, 100, 111, 99, 115, 46, 113, 100, 114,
-				97, 119, 46, 110, 108, 47, 115, 99, 104, 101, 109, 97, 47, 109, 101,
-				116, 97, 45, 100, 97, 116, 97, 45, 99, 111, 110, 116, 97, 105, 110,
-				101, 114, 46, 106, 115, 111, 110, 34
+				123, 13, 10, 32, 32, 34, 36, 105, 100, 34, 58, 32, 34, 104, 116, 116, 112, 115, 58,
+				47, 47, 100, 111, 99, 115, 46, 113, 100, 114, 97, 119, 46, 110, 108, 47, 115, 99,
+				104, 101, 109, 97, 47, 109, 101, 116, 97, 45, 100, 97, 116, 97, 45, 99, 111, 110,
+				116, 97, 105, 110, 101, 114, 46, 106, 115, 111, 110, 34
 			};
 
 			if ( metaJsonUnix.SequenceEqual(bytes.Take(metaJsonUnix.Length)) )
@@ -515,7 +514,7 @@ namespace starsky.foundation.platform.Helpers
 		private static ImageFormat? GetImageFormatMpeg4(byte[] bytes)
 		{
 			var fTypMp4 = new byte[] { 102, 116, 121, 112 }; //  00  00  00  [skip this byte]
-															 // 66  74  79  70 QuickTime Container 3GG, 3GP, 3G2 	FLV
+			// 66  74  79  70 QuickTime Container 3GG, 3GP, 3G2 	FLV
 
 			if ( fTypMp4.SequenceEqual(bytes.Skip(4).Take(fTypMp4.Length)) )
 				return ImageFormat.mp4;
@@ -532,16 +531,17 @@ namespace starsky.foundation.platform.Helpers
 			var gpx = new byte[] { 60, 103, 112 }; // <gpx
 
 			if ( gpx.SequenceEqual(bytes.Take(gpx.Length)) ||
-				 gpx.SequenceEqual(bytes.Skip(21).Take(gpx.Length)) ||
-				 gpx.SequenceEqual(bytes.Skip(39).Take(gpx.Length)) ||
-				 gpx.SequenceEqual(bytes.Skip(1).Take(gpx.Length)) ||
-				 gpx.SequenceEqual(bytes.Skip(56).Take(gpx.Length)) ||
-				 gpx.SequenceEqual(bytes.Skip(57).Take(gpx.Length)) ||
-				 gpx.SequenceEqual(bytes.Skip(60).Take(gpx.Length)) ||
-				 gpx.SequenceEqual(bytes.Skip(55).Take(gpx.Length)) )
+			     gpx.SequenceEqual(bytes.Skip(21).Take(gpx.Length)) ||
+			     gpx.SequenceEqual(bytes.Skip(39).Take(gpx.Length)) ||
+			     gpx.SequenceEqual(bytes.Skip(1).Take(gpx.Length)) ||
+			     gpx.SequenceEqual(bytes.Skip(56).Take(gpx.Length)) ||
+			     gpx.SequenceEqual(bytes.Skip(57).Take(gpx.Length)) ||
+			     gpx.SequenceEqual(bytes.Skip(60).Take(gpx.Length)) ||
+			     gpx.SequenceEqual(bytes.Skip(55).Take(gpx.Length)) )
 			{
 				return ImageFormat.gpx;
 			}
+
 			return null;
 		}
 

--- a/starsky/starsky.foundation.realtime/Middleware/DisabledWebSocketsMiddleware.cs
+++ b/starsky/starsky.foundation.realtime/Middleware/DisabledWebSocketsMiddleware.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.Http;
 namespace starsky.foundation.realtime.Middleware
 {
 	[SuppressMessage("Performance", "CA1822:Mark members as static")]
+	[SuppressMessage("ReSharper", "UnusedParameter.Local")]
+	[SuppressMessage("Performance", "IDE0060:UnusedParameter.Local")]
 	public sealed class DisabledWebSocketsMiddleware
 	{
 		public DisabledWebSocketsMiddleware(RequestDelegate next)

--- a/starsky/starsky.foundation.storage/ArchiveFormats/Zipper.cs
+++ b/starsky/starsky.foundation.storage/ArchiveFormats/Zipper.cs
@@ -91,7 +91,7 @@ namespace starsky.foundation.storage.ArchiveFormats
 					zip.CreateEntryFromFile(filePaths[i], fileName);
 				}
 			}
-			zip.Dispose();
+			zip.Dispose(); // no flush
 			return tempFileFullPath;
 		}
 	}

--- a/starsky/starsky.foundation.storage/Helpers/StreamGetFirstBytes.cs
+++ b/starsky/starsky.foundation.storage/Helpers/StreamGetFirstBytes.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace starsky.foundation.storage.Helpers;
+
+public static class StreamGetFirstBytes
+{
+	public static async Task<MemoryStream> GetFirstBytesAsync(Stream originalStream, int count,
+		CancellationToken cancellationToken = default)
+	{
+		// Create a new MemoryStream to store the first 'count' bytes
+		var resultStream = new MemoryStream();
+
+		// Save the current position of the originalStream
+		var originalPosition = originalStream.Position;
+
+		// Set the position of the originalStream to the beginning
+		originalStream.Seek(0, SeekOrigin.Begin);
+
+		// Copy 'count' bytes from the originalStream to the resultStream asynchronously
+		var buffer = new byte[count];
+		var memory = new Memory<byte>(buffer);
+		var bytesRead = await originalStream.ReadAsync(memory, cancellationToken);
+		var readOnlyMemory = new ReadOnlyMemory<byte>(buffer, 0, bytesRead);
+		await resultStream.WriteAsync(readOnlyMemory, CancellationToken.None);
+
+		// Reset the position of the originalStream to its original position
+		originalStream.Seek(originalPosition, SeekOrigin.Begin);
+
+		// Set the position of the resultStream to the beginning
+		resultStream.Seek(0, SeekOrigin.Begin);
+
+		return resultStream;
+	}
+}

--- a/starsky/starsky.foundation.storage/Helpers/StreamToStringHelper.cs
+++ b/starsky/starsky.foundation.storage/Helpers/StreamToStringHelper.cs
@@ -19,10 +19,10 @@ public static class StreamToStringHelper
 	{
 		var reader = new StreamReader(stream, Encoding.UTF8);
 		var result = await reader.ReadToEndAsync();
-		await stream.FlushAsync();
 
 		if ( dispose )
 		{
+			await stream.FlushAsync();
 			await stream.DisposeAsync(); // also flush
 		}
 

--- a/starsky/starsky.foundation.storage/Helpers/StreamToStringHelper.cs
+++ b/starsky/starsky.foundation.storage/Helpers/StreamToStringHelper.cs
@@ -9,7 +9,6 @@ namespace starsky.foundation.storage.Helpers;
 /// </summary>
 public static class StreamToStringHelper
 {
-
 	/// <summary>
 	/// Stream to string (UTF8) But Async - check dispose flag
 	/// </summary>
@@ -20,11 +19,13 @@ public static class StreamToStringHelper
 	{
 		var reader = new StreamReader(stream, Encoding.UTF8);
 		var result = await reader.ReadToEndAsync();
+		await stream.FlushAsync();
+
 		if ( dispose )
 		{
-			await stream.DisposeAsync();
+			await stream.DisposeAsync(); // also flush
 		}
+
 		return result;
 	}
-
 }

--- a/starsky/starsky.foundation.storage/Helpers/StreamToStringHelper.cs
+++ b/starsky/starsky.foundation.storage/Helpers/StreamToStringHelper.cs
@@ -20,11 +20,10 @@ public static class StreamToStringHelper
 		var reader = new StreamReader(stream, Encoding.UTF8);
 		var result = await reader.ReadToEndAsync();
 
-		if ( dispose )
-		{
-			await stream.FlushAsync();
-			await stream.DisposeAsync(); // also flush
-		}
+		if ( !dispose ) return result;
+
+		await stream.FlushAsync();
+		await stream.DisposeAsync(); // also flush
 
 		return result;
 	}

--- a/starsky/starsky.foundation.storage/Interfaces/IStorage.cs
+++ b/starsky/starsky.foundation.storage/Interfaces/IStorage.cs
@@ -74,6 +74,4 @@ public interface IStorage
 	Task<bool> WriteStreamAsync(Stream stream, string path);
 
 	StorageInfo Info(string path);
-
-	DateTime SetLastWriteTime(string path, DateTime? dateTime = null);
 }

--- a/starsky/starsky.foundation.storage/Services/FileHash.cs
+++ b/starsky/starsky.foundation.storage/Services/FileHash.cs
@@ -200,10 +200,9 @@ public sealed class FileHash
 
 				md5.TransformFinalBlock(block, 0, 0);
 
-				await stream.FlushAsync(cancellationToken);
-
 				if ( dispose )
 				{
+					await stream.FlushAsync(cancellationToken);
 					stream.Close();
 					await stream.DisposeAsync(); // also flush
 				}

--- a/starsky/starsky.foundation.storage/Services/FileHash.cs
+++ b/starsky/starsky.foundation.storage/Services/FileHash.cs
@@ -192,18 +192,20 @@ public sealed class FileHash
 			{
 				int length;
 				while ( ( length = await stream
-						   .ReadAsync(block, cancellationToken)
-						   .ConfigureAwait(false) ) > 0 )
+					       .ReadAsync(block, cancellationToken)
+					       .ConfigureAwait(false) ) > 0 )
 				{
 					md5.TransformBlock(block, 0, length, null, 0);
 				}
 
 				md5.TransformFinalBlock(block, 0, 0);
 
+				await stream.FlushAsync(cancellationToken);
+
 				if ( dispose )
 				{
 					stream.Close();
-					await stream.DisposeAsync();
+					await stream.DisposeAsync(); // also flush
 				}
 
 				var hash = md5.Hash;

--- a/starsky/starsky.foundation.storage/Storage/SelectorStorage.cs
+++ b/starsky/starsky.foundation.storage/Storage/SelectorStorage.cs
@@ -18,8 +18,16 @@ namespace starsky.foundation.storage.Storage
 
 		public enum StorageServices
 		{
+			/// <summary>
+			/// Storage location
+			/// </summary>
 			SubPath,
+
+			/// <summary>
+			/// Location for thumbnails
+			/// </summary>
 			Thumbnail,
+
 			/// <summary>
 			/// Use only to import from
 			/// </summary>

--- a/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
@@ -235,6 +235,7 @@ namespace starsky.foundation.storage.Storage
 					return fileStream;
 				}
 
+				// to reuse stream please check StreamGetFirstBytes.GetFirstBytesAsync
 				// Only for when selecting the first part of the file
 				var buffer = new byte[maxRead];
 				// ReSharper disable once MustUseReturnValue

--- a/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
@@ -410,6 +410,7 @@ namespace starsky.foundation.storage.Storage
 					       FileOptions.Asynchronous | FileOptions.SequentialScan) )
 				{
 					await stream.CopyToAsync(fileStream);
+					await fileStream.FlushAsync();
 				}
 
 				await stream.FlushAsync();
@@ -450,8 +451,8 @@ namespace starsky.foundation.storage.Storage
 			}
 			catch ( Exception exception )
 			{
-				_logger?.LogInformation(
-					$"[StorageHostFullPathFilesystem] catch-ed ex: {exception.Message} -  {path}");
+				_logger?.LogInformation($"[StorageHostFullPathFilesystem] " +
+				                        $"catch-ed ex: {exception.Message} -  {path}");
 				return new Tuple<string[], string[]>(
 					new List<string>().ToArray(),
 					new List<string>().ToArray()

--- a/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
@@ -411,7 +411,15 @@ namespace starsky.foundation.storage.Storage
 					       FileOptions.Asynchronous | FileOptions.SequentialScan) )
 				{
 					await stream.CopyToAsync(fileStream);
-					await fileStream.FlushAsync();
+
+					try
+					{
+						await fileStream.FlushAsync();
+					}
+					catch ( NotSupportedException )
+					{
+						// HttpConnection does not support this - Specified method is not supported.
+					}
 				}
 
 				await stream.FlushAsync();

--- a/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
@@ -411,18 +411,19 @@ namespace starsky.foundation.storage.Storage
 					       FileOptions.Asynchronous | FileOptions.SequentialScan) )
 				{
 					await stream.CopyToAsync(fileStream);
+					await fileStream.FlushAsync();
 
-					try
-					{
-						await fileStream.FlushAsync();
-					}
-					catch ( NotSupportedException )
-					{
-						// HttpConnection does not support this - Specified method is not supported.
-					}
+
 				}
-
-				await stream.FlushAsync();
+				
+				try
+				{
+					await stream.FlushAsync();
+				}
+				catch ( NotSupportedException )
+				{
+					// HttpConnection does not support this - Specified method is not supported.
+				}
 				await stream.DisposeAsync(); // also flush
 
 				return true;

--- a/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
@@ -412,8 +412,6 @@ namespace starsky.foundation.storage.Storage
 				{
 					await stream.CopyToAsync(fileStream);
 					await fileStream.FlushAsync();
-
-
 				}
 				
 				try

--- a/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageHostFullPathFilesystem.cs
@@ -71,8 +71,9 @@ namespace starsky.foundation.storage.Storage
 				var testFilePath = Path.Combine(folderPath, ".test");
 				var myFileStream = File.Open(testFilePath, FileMode.OpenOrCreate,
 					FileAccess.ReadWrite, FileShare.ReadWrite);
+				myFileStream.Flush();
 				myFileStream.Close();
-				myFileStream.Dispose();
+				myFileStream.Dispose(); // also flush
 				File.Delete(testFilePath);
 			}
 			catch ( IOException )
@@ -357,7 +358,8 @@ namespace starsky.foundation.storage.Storage
 					// fileStream is disposed due using
 				}
 
-				stream.Dispose();
+				stream.Flush();
+				stream.Dispose(); // also flush
 				return true;
 			}
 
@@ -410,7 +412,8 @@ namespace starsky.foundation.storage.Storage
 					await stream.CopyToAsync(fileStream);
 				}
 
-				await stream.DisposeAsync();
+				await stream.FlushAsync();
+				await stream.DisposeAsync(); // also flush
 
 				return true;
 			}

--- a/starsky/starsky.foundation.storage/Storage/StorageSubPathFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageSubPathFilesystem.cs
@@ -279,8 +279,9 @@ namespace starsky.foundation.storage.Storage
 				// read only the first number of bytes
 				var buffer = new byte[maxRead];
 				fileStream.Read(buffer, 0, maxRead);
+				fileStream.Flush();
 				fileStream.Close();
-				fileStream.Dispose();
+				fileStream.Dispose(); // also flush
 				return new MemoryStream(buffer);
 			}
 
@@ -311,8 +312,8 @@ namespace starsky.foundation.storage.Storage
 		public Task<bool> WriteStreamAsync(Stream stream, string path)
 		{
 			var fullFilePath = _appSettings.DatabasePathToFilePath(path);
-			return new StorageHostFullPathFilesystem(_logger)
-				.WriteStreamAsync(stream, fullFilePath);
+			var service = new StorageHostFullPathFilesystem(_logger);
+			return service.WriteStreamAsync(stream, fullFilePath);
 		}
 	}
 }

--- a/starsky/starsky.foundation.storage/Storage/StorageThumbnailFilesystem.cs
+++ b/starsky/starsky.foundation.storage/Storage/StorageThumbnailFilesystem.cs
@@ -187,10 +187,5 @@ namespace starsky.foundation.storage.Storage
 		{
 			throw new System.NotImplementedException();
 		}
-
-		public DateTime SetLastWriteTime(string path, DateTime? dateTime = null)
-		{
-			return dateTime ?? DateTime.Now;
-		}
 	}
 }

--- a/starsky/starsky.foundation.thumbnailmeta/Services/WriteMetaThumbnailService.cs
+++ b/starsky/starsky.foundation.thumbnailmeta/Services/WriteMetaThumbnailService.cs
@@ -40,7 +40,7 @@ public sealed class WriteMetaThumbnailService : IWriteMetaThumbnailService
 		try
 		{
 			using ( var thumbnailStream =
-				   new MemoryStream(offsetData.Data, offsetData.Index, offsetData.Count) )
+			       new MemoryStream(offsetData.Data, offsetData.Index, offsetData.Count) )
 			using ( var smallImage = await Image.LoadAsync(thumbnailStream) )
 			using ( var outputStream = new MemoryStream() )
 			{
@@ -77,12 +77,14 @@ public sealed class WriteMetaThumbnailService : IWriteMetaThumbnailService
 
 			return true;
 		}
-		catch ( Exception ex )
+		catch ( Exception exception )
 		{
-			var message = ex.Message;
+			var message = exception.Message;
 			if ( message.StartsWith("Image cannot be loaded") )
 				message = "Image cannot be loaded";
-			_logger.LogError($"[WriteFile@meta] Exception {reference} {message}", ex);
+			_logger.LogError(
+				$"[WriteFile@meta] Meta data read - Exception {reference} {message} - can continue without",
+				exception);
 			return false;
 		}
 	}

--- a/starsky/starsky.foundation.worker/Helpers/ProcessTaskQueue.cs
+++ b/starsky/starsky.foundation.worker/Helpers/ProcessTaskQueue.cs
@@ -53,9 +53,11 @@ namespace starsky.foundation.worker.Helpers
 
 					for ( var i = 0; i < taskQueueCount; i++ )
 					{
-						var (workItem, metaData, parentTraceId) = await taskQueue.DequeueAsync(cancellationToken);
+						var (workItem, metaData, parentTraceId) =
+							await taskQueue.DequeueAsync(cancellationToken);
 						toDoItems.Add(
-							new Tuple<Func<CancellationToken, ValueTask>, string?, string?>(workItem,
+							new Tuple<Func<CancellationToken, ValueTask>, string?, string?>(
+								workItem,
 								metaData, parentTraceId));
 					}
 
@@ -63,9 +65,9 @@ namespace starsky.foundation.worker.Helpers
 
 					foreach ( var (task, meta, _) in afterDistinct )
 					{
-						logger.LogInformation(
-							$"[{taskQueue.GetType().ToString().Split(".").LastOrDefault()}] next task: " +
-							meta);
+						var name = taskQueue.GetType().ToString().Split(".").LastOrDefault();
+						logger.LogInformation($"[] {name} next task: {meta}");
+
 						await ExecuteTask(task, logger, null, cancellationToken);
 					}
 
@@ -95,7 +97,7 @@ namespace starsky.foundation.worker.Helpers
 					// Dequeue here
 					( workItem, metaData, parentTraceId ) =
 						await taskQueue.DequeueAsync(cancellationToken);
-					
+
 					// set as parent for activity
 					activity = CreateActivity(parentTraceId, metaData);
 				}
@@ -124,6 +126,7 @@ namespace starsky.foundation.worker.Helpers
 			{
 				return activity;
 			}
+
 			activity.SetParentId(parentTraceId);
 			return activity;
 		}

--- a/starsky/starsky.foundation.writemeta/Helpers/ExifTool.cs
+++ b/starsky/starsky.foundation.writemeta/Helpers/ExifTool.cs
@@ -78,14 +78,13 @@ public sealed class ExifTool : IExifTool
 			return new KeyValuePair<bool, string>(false, beforeFileHash);
 		}
 
-		stream.Seek(0, SeekOrigin.Begin);
-		var streamResult = await _iStorage.WriteStreamAsync(stream, subPath);
-		var statusResult = new KeyValuePair<bool, string>(streamResult, newHashCode);
-
 		// Need to Dispose for Windows
 		await sourceStream.DisposeAsync();
 
-		return statusResult;
+		stream.Seek(0, SeekOrigin.Begin);
+		var streamResult = await _iStorage.WriteStreamAsync(stream, subPath);
+
+		return new KeyValuePair<bool, string>(streamResult, newHashCode);
 	}
 
 

--- a/starsky/starsky/Controllers/ImportController.cs
+++ b/starsky/starsky/Controllers/ImportController.cs
@@ -126,10 +126,10 @@ namespace starsky.Controllers
 				var thumbnailQuery = scope.ServiceProvider.GetRequiredService<IThumbnailQuery>();
 
 				// use of IImport direct does not work
-				importedFiles = await new Import(selectorStorage, _appSettings,
-						importQuery, exifTool, query, console,
-						metaExifThumbnailService, _logger, thumbnailQuery, memoryCache)
-					.Importer(tempImportPaths, importSettings);
+				var service = new Import(selectorStorage, _appSettings,
+					importQuery, exifTool, query, console,
+					metaExifThumbnailService, _logger, thumbnailQuery, memoryCache);
+				importedFiles = await service.Importer(tempImportPaths, importSettings);
 			}
 
 			if ( isVerbose )

--- a/starsky/starsky/Controllers/PublishController.cs
+++ b/starsky/starsky/Controllers/PublishController.cs
@@ -85,15 +85,15 @@ namespace starsky.Controllers
 			var inputFilePaths = PathHelper.SplitInputFilePaths(f).ToList();
 			var info = await _metaInfo.GetInfoAsync(inputFilePaths, false);
 			if ( info.TrueForAll(p =>
-					p.Status != FileIndexItem.ExifStatus.Ok &&
-					p.Status != FileIndexItem.ExifStatus.ReadOnly) )
+				    p.Status != FileIndexItem.ExifStatus.Ok &&
+				    p.Status != FileIndexItem.ExifStatus.ReadOnly) )
 			{
 				return NotFound(info);
 			}
 
 			var slugItemName = GenerateSlugHelper.GenerateSlug(itemName, true);
-			_webLogger.LogInformation(
-				$"[/api/publish/create] Press publish: {slugItemName} {f} {DateTime.UtcNow}");
+			_webLogger.LogInformation($"[/api/publish/create] Press publish: " +
+			                          $"{slugItemName} {f} {DateTime.UtcNow}");
 
 			var location = Path.Combine(_appSettings.TempFolder, slugItemName);
 
@@ -110,8 +110,8 @@ namespace starsky.Controllers
 					publishProfileName, itemName, location);
 				await _publishService.GenerateZip(_appSettings.TempFolder, itemName,
 					renderCopyResult, true);
-				_webLogger.LogInformation(
-					$"[/api/publish/create] done: {itemName} {DateTime.UtcNow}");
+				_webLogger.LogInformation($"[/api/publish/create] done: " +
+				                          $"{itemName} {DateTime.UtcNow}");
 			}, publishProfileName + "_" + itemName);
 
 			// Get the zip 	by	[HttpGet("/export/zip/{f}.zip")]

--- a/starsky/starsky/Controllers/UploadController.cs
+++ b/starsky/starsky/Controllers/UploadController.cs
@@ -29,7 +29,7 @@ namespace starsky.Controllers
 {
 	[Authorize] // <- should be logged in!
 	[SuppressMessage("Usage", "S5693:Make sure the content " +
-							  "length limit is safe here", Justification = "Is checked")]
+	                          "length limit is safe here", Justification = "Is checked")]
 	public sealed class UploadController : Controller
 	{
 		private readonly AppSettings _appSettings;
@@ -131,7 +131,8 @@ namespace starsky.Controllers
 
 				var writeStatus =
 					await _iStorage.WriteStreamAsync(tempFileStream, subPath + ".tmp");
-				await tempFileStream.DisposeAsync();
+				await tempFileStream.FlushAsync();
+				await tempFileStream.DisposeAsync(); // also flush
 
 				// to avoid partly written stream to be read by an other application
 				_iStorage.FileDelete(subPath);
@@ -171,7 +172,7 @@ namespace starsky.Controllers
 			if ( fileIndexResultsList.TrueForAll(p => p.Status == ImportStatus.FileError) )
 			{
 				_logger.LogInformation($"Wrong input extension is not allowed" +
-									   $" {string.Join(",", fileIndexResultsList.Select(p => p.FilePath))}");
+				                       $" {string.Join(",", fileIndexResultsList.Select(p => p.FilePath))}");
 				Response.StatusCode = 415;
 			}
 
@@ -203,7 +204,7 @@ namespace starsky.Controllers
 		private void AddOrRemoveXmpSidecarFileToDatabase(FileIndexItem metaDataItem)
 		{
 			if ( _iStorage.ExistFile(ExtensionRolesHelper.ReplaceExtensionWithXmp(metaDataItem
-					.FilePath)) )
+				    .FilePath)) )
 			{
 				metaDataItem.AddSidecarExtension("xmp");
 				return;
@@ -310,7 +311,7 @@ namespace starsky.Controllers
 
 			// only used for direct import
 			if ( _iStorage.ExistFolder(FilenamesHelper.GetParentPath(to)) &&
-				 FilenamesHelper.IsValidFileName(FilenamesHelper.GetFileName(to)) )
+			     FilenamesHelper.IsValidFileName(FilenamesHelper.GetFileName(to)) )
 			{
 				Request.Headers["filename"] = FilenamesHelper.GetFileName(to);
 				return FilenamesHelper.GetParentPath(PathHelper.RemoveLatestSlash(to));

--- a/starsky/starskyimportercli/Program.cs
+++ b/starsky/starskyimportercli/Program.cs
@@ -5,6 +5,7 @@ using starsky.feature.import.Services;
 using starsky.foundation.database.Data;
 using starsky.foundation.database.Helpers;
 using starsky.foundation.injection;
+using starsky.foundation.platform.Exceptions;
 using starsky.foundation.platform.Helpers;
 using starsky.foundation.platform.Interfaces;
 using starsky.foundation.platform.Models;
@@ -50,7 +51,10 @@ namespace starskyimportercli
 
 			// Help and other Command Line Tools args are included in the ImporterCli 
 			var service = new ImportCli(import, appSettings, console, webLogger, exifToolDownload);
-			await service.Importer(args);
+			if ( !await service.Importer(args) )
+			{
+				throw new WebApplicationException("Import failed");
+			}
 		}
 	}
 }

--- a/starsky/starskytest/FakeMocks/FakeIImportQuery.cs
+++ b/starsky/starskytest/FakeMocks/FakeIImportQuery.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,12 +36,13 @@ namespace starskytest.FakeMocks
 		/// <param name="console"></param>
 		/// <param name="logger"></param>
 		/// <param name="dbContext"></param>
-		public FakeIImportQuery(IServiceScopeFactory scopeFactory, IConsole console, IWebLogger logger, ApplicationDbContext? dbContext = null)
+		public FakeIImportQuery(IServiceScopeFactory scopeFactory, IConsole console,
+			IWebLogger logger, ApplicationDbContext? dbContext = null)
 		{
 			_exist = new List<string>();
 			_isConnection = true;
 		}
-		
+
 		public async Task<bool> IsHashInImportDbAsync(string fileHashCode)
 		{
 			return _exist.Contains(fileHashCode);
@@ -51,7 +53,8 @@ namespace starskytest.FakeMocks
 			return _isConnection;
 		}
 
-		public async Task<bool> AddAsync(ImportIndexItem updateStatusContent, bool writeConsole = true)
+		public async Task<bool> AddAsync(ImportIndexItem updateStatusContent,
+			bool writeConsole = true)
 		{
 			_exist.Add(updateStatusContent.FileHash!);
 			return true;
@@ -62,22 +65,36 @@ namespace starskytest.FakeMocks
 			var newFakeList = new List<ImportIndexItem>();
 			foreach ( var exist in _exist )
 			{
-				newFakeList.Add(new ImportIndexItem
-				{
-					Status = ImportStatus.Ok,
-					FilePath = exist
-				});
+				newFakeList.Add(new ImportIndexItem { Status = ImportStatus.Ok, FilePath = exist });
 			}
+
 			return newFakeList;
 		}
 
-		public async Task<List<ImportIndexItem>> AddRangeAsync(List<ImportIndexItem> importIndexItemList)
+		public async Task<List<ImportIndexItem>> AddRangeAsync(
+			List<ImportIndexItem> importIndexItemList)
 		{
 			foreach ( var importIndexItem in importIndexItemList )
 			{
 				await AddAsync(importIndexItem);
 			}
+
 			return importIndexItemList;
+		}
+
+		public async Task<ImportIndexItem> RemoveItemAsync(ImportIndexItem importIndexItem)
+		{
+			try
+			{
+				_exist.Remove(importIndexItem.FilePath!);
+			}
+			catch ( ArgumentOutOfRangeException )
+			{
+				await Task.Delay(new Random().Next(1, 5));
+				_exist.Remove(importIndexItem.FilePath!);
+			}
+
+			return importIndexItem;
 		}
 
 		public async Task<bool> RemoveAsync(string fileHash)

--- a/starsky/starskytest/FakeMocks/FakeIStorage.cs
+++ b/starsky/starskytest/FakeMocks/FakeIStorage.cs
@@ -88,13 +88,7 @@ public class FakeIStorage : IStorage
 
 	public bool ExistFolder(string path)
 	{
-		if ( _exception == null )
-		{
-			return _outputSubPathFolders.Contains(path);
-		}
-
-		ExceptionCount++;
-		throw _exception;
+		return _outputSubPathFolders.Contains(path);
 	}
 
 	public FolderOrFileModel.FolderOrFileTypeList IsFolderOrFile(
@@ -359,6 +353,23 @@ public class FakeIStorage : IStorage
 		ArgumentNullException.ThrowIfNull(path);
 
 		_outputSubPathFiles.Add(path);
+
+		if ( _exception != null )
+		{
+			// When WriteStream crashed it can leave a file with 0 bytes
+			if ( _byteList.Any(p => p.Key == path) )
+			{
+				_byteList[path] = Encoding.UTF8.GetBytes(string.Empty);
+				return true;
+			}
+
+			_byteList.Add(path, Encoding.UTF8.GetBytes(string.Empty));
+			// Create 0 bytes file
+
+			ExceptionCount++;
+			throw _exception;
+		}
+
 
 		if ( stream.CanSeek )
 		{

--- a/starsky/starskytest/FakeMocks/FakeSelectorStorageByType.cs
+++ b/starsky/starskytest/FakeMocks/FakeSelectorStorageByType.cs
@@ -1,0 +1,32 @@
+using System;
+using starsky.foundation.storage.Interfaces;
+using starsky.foundation.storage.Storage;
+
+namespace starskytest.FakeMocks;
+
+public class FakeSelectorStorageByType : ISelectorStorage
+{
+	private readonly IStorage _subPathStorage;
+	private readonly IStorage _thumbnailStorage;
+	private readonly IStorage _hostFilesystemStorage;
+
+	public FakeSelectorStorageByType(IStorage subPathStorage, IStorage thumbnailStorage,
+		IStorage hostFilesystemStorage)
+	{
+		_subPathStorage = subPathStorage;
+		_thumbnailStorage = thumbnailStorage;
+		_hostFilesystemStorage = hostFilesystemStorage;
+	}
+
+	public IStorage Get(SelectorStorage.StorageServices storageServices)
+	{
+		return storageServices switch
+		{
+			SelectorStorage.StorageServices.SubPath => _subPathStorage,
+			SelectorStorage.StorageServices.HostFilesystem => _hostFilesystemStorage,
+			SelectorStorage.StorageServices.Thumbnail => _thumbnailStorage,
+			_ => throw new ArgumentOutOfRangeException(nameof(storageServices), storageServices,
+				null)
+		};
+	}
+}

--- a/starsky/starskytest/starsky.feature.import/Services/ImportCliTest.cs
+++ b/starsky/starskytest/starsky.feature.import/Services/ImportCliTest.cs
@@ -43,17 +43,19 @@ namespace starskytest.starsky.feature.import.Services
 		[TestMethod]
 		public async Task ImporterCli_ArgPath()
 		{
-			var fakeConsole = new FakeConsoleWrapper(new List<string>());
+			var webLogger = new FakeIWebLogger();
 			var storage = new FakeIStorage(new List<string> { "/" },
 				new List<string> { "/test" },
 				new List<byte[]>(Array.Empty<byte[]>()));
 
 			await new ImportCli(new FakeIImport(new FakeSelectorStorage(storage)),
-					new AppSettings(), fakeConsole, new FakeIWebLogger(),
+					new AppSettings(), new FakeConsoleWrapper(), webLogger,
 					new FakeExifToolDownload())
 				.Importer(
 					new List<string> { "-p", "/test" }.ToArray());
-			Assert.IsTrue(fakeConsole.WrittenLines.FirstOrDefault()?.Contains("Done Importing"));
+			Assert.IsTrue(
+				webLogger.TrackedInformation.Exists(
+					p => p.Item2?.Contains("Done Importing") == true));
 		}
 
 
@@ -82,34 +84,40 @@ namespace starskytest.starsky.feature.import.Services
 		[TestMethod]
 		public async Task ImporterCli_ArgPath_Verbose()
 		{
+			var webLogger = new FakeIWebLogger();
+
 			var fakeConsole = new FakeConsoleWrapper(new List<string>());
 			var storage = new FakeIStorage(new List<string> { "/" },
 				new List<string> { "/test" },
 				new List<byte[]>(Array.Empty<byte[]>()));
 
 			var cli = new ImportCli(new FakeIImport(new FakeSelectorStorage(storage)),
-				new AppSettings { Verbose = true }, fakeConsole, new FakeIWebLogger(),
+				new AppSettings { Verbose = true }, fakeConsole, webLogger,
 				new FakeExifToolDownload());
 
 			// verbose is entered here 
 			await cli.Importer(new List<string> { "-p", "/test", "-v", "true" }.ToArray());
 
-			Assert.IsTrue(fakeConsole.WrittenLines.LastOrDefault()?.Contains("Failed: 2"));
+			Assert.IsTrue(
+				webLogger.TrackedInformation.Exists(p => p.Item2?.Contains("Failed: 2") == true));
 		}
 
 		[TestMethod]
 		public async Task ImporterCli_ArgPath_Fail()
 		{
 			var fakeConsole = new FakeConsoleWrapper(new List<string>());
+			var webLogger = new FakeIWebLogger();
 			var storage = new FakeIStorage(new List<string> { "/" },
 				new List<string> { "/test" },
 				new List<byte[]>(Array.Empty<byte[]>())); // instead of new byte[0][]
 
 			await new ImportCli(new FakeIImport(new FakeSelectorStorage(storage)),
-					new AppSettings { Verbose = false }, fakeConsole, new FakeIWebLogger(),
+					new AppSettings { Verbose = false }, fakeConsole, webLogger,
 					new FakeExifToolDownload())
 				.Importer(new List<string> { "-p", "/test" }.ToArray());
-			Assert.IsTrue(fakeConsole.WrittenLines.LastOrDefault()?.Contains("Failed"));
+
+			Assert.IsTrue(
+				webLogger.TrackedInformation.Exists(p => p.Item2?.Contains("Failed") == true));
 		}
 	}
 }

--- a/starsky/starskytest/starsky.foundation.database/Import/ImportQueryTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/Import/ImportQueryTest.cs
@@ -27,31 +27,33 @@ namespace starskytest.starsky.foundation.database.Import
 			_serviceScope = CreateNewScope();
 			var scope = _serviceScope.CreateScope();
 			_dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-			
-			_importQuery = new ImportQuery(_serviceScope, new FakeConsoleWrapper(), new FakeIWebLogger());
+
+			_importQuery = new ImportQuery(_serviceScope, new FakeConsoleWrapper(),
+				new FakeIWebLogger());
 		}
 
 		private IServiceScopeFactory CreateNewScope()
 		{
 			var services = new ServiceCollection();
-			services.AddDbContext<ApplicationDbContext>(options => 
+			services.AddDbContext<ApplicationDbContext>(options =>
 				options.UseInMemoryDatabase(nameof(ImportQueryTest)));
 			services.AddSingleton<IConsole, FakeConsoleWrapper>();
 			var serviceProvider = services.BuildServiceProvider();
 			return serviceProvider.GetRequiredService<IServiceScopeFactory>();
 		}
-		
+
 		[TestMethod]
 		public void TestConnection_True()
 		{
-			var result =_importQuery.TestConnection();
+			var result = _importQuery.TestConnection();
 			Assert.IsTrue(result);
 		}
-		
+
 		[TestMethod]
 		public void TestConnection_Null()
 		{
-			var result = new ImportQuery(null, new FakeConsoleWrapper(), new FakeIWebLogger()).TestConnection();
+			var result = new ImportQuery(null, new FakeConsoleWrapper(), new FakeIWebLogger())
+				.TestConnection();
 			Assert.IsFalse(result);
 		}
 
@@ -69,7 +71,7 @@ namespace starskytest.starsky.foundation.database.Import
 			var result = await _importQuery.IsHashInImportDbAsync("TEST2");
 			Assert.IsTrue(result);
 		}
-		
+
 		[TestMethod]
 		public async Task IsHashInImportDbAsync_NotFound()
 		{
@@ -85,91 +87,168 @@ namespace starskytest.starsky.foundation.database.Import
 		[TestMethod]
 		public async Task IsHashInImportDbAsync_ContextFail()
 		{
-			var result = await new ImportQuery(null, 
+			var result = await new ImportQuery(null,
 				new FakeConsoleWrapper(), new FakeIWebLogger()).IsHashInImportDbAsync("TEST");
 			Assert.IsFalse(result);
 		}
-		
+
 		[TestMethod]
 		public async Task AddAsync()
 		{
-			var expectedResult = new ImportIndexItem {FileHash = "TEST3"};
+			var expectedResult = new ImportIndexItem { FileHash = "TEST3" };
 			var serviceScopeFactory = CreateNewScope();
 			var scope = serviceScopeFactory.CreateScope();
 			var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-			
-			await new ImportQuery(serviceScopeFactory, new FakeConsoleWrapper(), 
+
+			await new ImportQuery(serviceScopeFactory, new FakeConsoleWrapper(),
 				new FakeIWebLogger()).AddAsync(expectedResult);
-			
+
 			var queryFromDb = await dbContext.ImportIndex.FirstOrDefaultAsync(
 				p => p.FileHash == expectedResult.FileHash);
-			
-			Assert.AreEqual(expectedResult.FileHash,queryFromDb?.FileHash);
+
+			Assert.AreEqual(expectedResult.FileHash, queryFromDb?.FileHash);
 		}
-		
+
 		[TestMethod]
 		public async Task History()
 		{
 			var expectedResult = new ImportIndexItem
 			{
-				AddToDatabase = DateTime.UtcNow, 
-				FileHash = "TEST8"
+				AddToDatabase = DateTime.UtcNow, FileHash = "TEST8"
 			};
 			var serviceScopeFactory = CreateNewScope();
-			
-			await new ImportQuery(serviceScopeFactory, new FakeConsoleWrapper(), new FakeIWebLogger()).AddAsync(expectedResult);
 
-			var historyResult = new ImportQuery(serviceScopeFactory, 
+			await new ImportQuery(serviceScopeFactory, new FakeConsoleWrapper(),
+				new FakeIWebLogger()).AddAsync(expectedResult);
+
+			var historyResult = new ImportQuery(serviceScopeFactory,
 				new FakeConsoleWrapper(), new FakeIWebLogger()).History();
 
 			if ( historyResult.Count == 0 )
 			{
 				throw new WebException("should not be 0");
 			}
-			
+
 			Assert.IsTrue(historyResult.Exists(p => p.FileHash == "TEST8"));
 		}
-		
+
 		[TestMethod]
 		public async Task AddRangeAsync()
 		{
 			var expectedResult = new List<ImportIndexItem>
 			{
-				new ImportIndexItem {FileHash = "TEST4"},
-				new ImportIndexItem {FileHash = "TEST5"}
+				new ImportIndexItem { FileHash = "TEST4" },
+				new ImportIndexItem { FileHash = "TEST5" }
 			};
 			var serviceScopeFactory = CreateNewScope();
 			var scope = serviceScopeFactory.CreateScope();
 			var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-			
-			await new ImportQuery(serviceScopeFactory, new FakeConsoleWrapper(), 
+
+			await new ImportQuery(serviceScopeFactory, new FakeConsoleWrapper(),
 				new FakeIWebLogger()).AddRangeAsync(expectedResult);
-			
+
 			var queryFromDb = dbContext.ImportIndex
 				.Where(p => p.FileHash == "TEST4" || p.FileHash == "TEST5").ToList();
-			Assert.AreEqual(expectedResult.FirstOrDefault()?.FileHash, queryFromDb.FirstOrDefault()?.FileHash);
+			Assert.AreEqual(expectedResult.FirstOrDefault()?.FileHash,
+				queryFromDb.FirstOrDefault()?.FileHash);
 			Assert.AreEqual(expectedResult[1].FileHash, queryFromDb[1].FileHash);
 		}
-		
+
 		[TestMethod]
 		public void AddRange()
 		{
 			var expectedResult = new List<ImportIndexItem>
 			{
-				new ImportIndexItem {FileHash = "TEST4"},
-				new ImportIndexItem {FileHash = "TEST5"}
+				new ImportIndexItem { FileHash = "TEST4" },
+				new ImportIndexItem { FileHash = "TEST5" }
 			};
 			var serviceScopeFactory = CreateNewScope();
 			var scope = serviceScopeFactory.CreateScope();
 			var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-			
-			new ImportQuery(serviceScopeFactory, new FakeConsoleWrapper(), new FakeIWebLogger()).AddRange(expectedResult);
-			
+
+			new ImportQuery(serviceScopeFactory, new FakeConsoleWrapper(), new FakeIWebLogger())
+				.AddRange(expectedResult);
+
 			var queryFromDb = dbContext
 				.ImportIndex.Where(p => p.FileHash == "TEST4" || p.FileHash == "TEST5").ToList();
-			Assert.AreEqual(expectedResult.FirstOrDefault()!.FileHash, queryFromDb.FirstOrDefault()!.FileHash);
+			Assert.AreEqual(expectedResult.FirstOrDefault()!.FileHash,
+				queryFromDb.FirstOrDefault()!.FileHash);
 			Assert.AreEqual(expectedResult[1].FileHash, queryFromDb[1].FileHash);
 		}
+
+		[TestMethod]
+		public async Task RemoveItemAsync_RemovesItemFromImportIndex()
+		{
+			// Arrange
+			var importIndexItem = new ImportIndexItem { Id = 1825 };
+
+			// Set up a temporary in-memory database for testing
+			var serviceProvider = new ServiceCollection()
+				.AddDbContext<ApplicationDbContext>(options =>
+					options.UseInMemoryDatabase(databaseName: "TestDatabase123456789"))
+				.BuildServiceProvider();
+
+			using ( var scope = serviceProvider.CreateScope() )
+			{
+				var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+				// Add the importIndexItem to the import index
+				dbContext.ImportIndex.Add(importIndexItem);
+				await dbContext.SaveChangesAsync();
+			}
+
+			var scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+			var console = new FakeConsoleWrapper();
+			var logger = new FakeIWebLogger();
+			using ( var scope = serviceProvider.CreateScope() )
+			{
+				var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+				var importQuery = new ImportQuery(scopeFactory, console, logger, dbContext);
+
+				// Act
+				await importQuery.RemoveItemAsync(importIndexItem);
+			}
+
+			// Assert
+			using ( var scope = serviceProvider.CreateScope() )
+			{
+				var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+				// Ensure that the item is removed from the import index
+				Assert.IsFalse(dbContext.ImportIndex.Any(x => x.Id == importIndexItem.Id));
+			}
+		}
 		
+		[TestMethod]
+		public async Task RemoveAsync_Disposed()
+		{
+			var addedItems = new List<ImportIndexItem>
+			{
+				new ImportIndexItem {FileHash = "RemoveAsync_Disposed__1"},
+				new ImportIndexItem {FileHash = "RemoveAsync_Disposed__2"}
+			};
+			
+			var serviceScopeFactory = CreateNewScope();
+			var scope = serviceScopeFactory.CreateScope();
+			var dbContextDisposed = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+			await dbContextDisposed.ImportIndex.AddRangeAsync(addedItems);
+			await dbContextDisposed.SaveChangesAsync();
+		
+			// Dispose here
+			await dbContextDisposed.DisposeAsync();
+
+			var importQuery = new ImportQuery(serviceScopeFactory, new FakeConsoleWrapper(), new FakeIWebLogger(), dbContextDisposed);
+
+			await importQuery.RemoveItemAsync(addedItems[0]);
+			await importQuery.RemoveItemAsync(addedItems[1]);
+
+			var context = new InjectServiceScope(serviceScopeFactory).Context();
+			var queryFromDb = context.FileIndex.Where(p => 
+				p.FileHash == addedItems[0].FilePath || p.FileHash == addedItems[1].FilePath
+			).ToList();
+
+			Assert.AreEqual(0, queryFromDb.Count);
+		}
 	}
 }

--- a/starsky/starskytest/starsky.foundation.platform/Exceptions/WebApplicationExceptionTests.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Exceptions/WebApplicationExceptionTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using starsky.foundation.platform.Exceptions;
+
+namespace starskytest.starsky.foundation.platform.Exceptions;
+
+[TestClass]
+public class WebApplicationExceptionTests
+{
+	[TestMethod]
+	public void WebApplicationException_DefaultConstructor_Message()
+	{
+		// Arrange & Act
+		var exception = new WebApplicationException();
+
+		// Assert
+		Assert.AreEqual($"Exception of type '{typeof(WebApplicationException)}' was thrown.",
+			exception.Message);
+	}
+
+	[TestMethod]
+	public void WebApplicationException_ConstructorWithMessage_SetsMessageCorrectly()
+	{
+		// Arrange
+		const string message = "Test Message";
+
+		// Act
+		var exception = new WebApplicationException(message);
+
+		// Assert
+		Assert.AreEqual(message, exception.Message);
+	}
+
+	[TestMethod]
+	public void
+		WebApplicationException_ConstructorWithMessageAndInnerException_SetsMessageAndInnerExceptionCorrectly()
+	{
+		// Arrange
+		const string message = "Test Message";
+		var innerException = new Exception("Inner exception message");
+
+		// Act
+		var exception = new WebApplicationException(message, innerException);
+
+		// Assert
+		Assert.AreEqual(message, exception.Message);
+		Assert.AreEqual(innerException, exception.InnerException);
+	}
+
+	[TestMethod]
+	public void WebApplicationException_SerializationConstructor_SetsPropertiesCorrectly()
+	{
+		// Arrange
+		var message = "Test Message";
+		var innerException = new Exception("Inner exception message");
+		var serializationInfo =
+#pragma warning disable SYSLIB0050
+			new SerializationInfo(typeof(WebApplicationException), new FormatterConverter());
+#pragma warning restore SYSLIB0050
+		serializationInfo.AddValue("Message", message);
+		serializationInfo.AddValue("InnerException", innerException);
+		serializationInfo.AddValue("HelpURL", "help");
+		serializationInfo.AddValue("StackTraceString", "StackTraceString");
+		serializationInfo.AddValue("RemoteStackTraceString", "RemoteStackTraceString");
+		serializationInfo.AddValue("HResult", 1);
+		serializationInfo.AddValue("Source", "");
+
+		var streamingContext = new StreamingContext();
+		var constructorInfo = typeof(WebApplicationException).GetConstructor(
+			BindingFlags.NonPublic | BindingFlags.Instance, null,
+			new[] { typeof(SerializationInfo), typeof(StreamingContext) }, null);
+
+		// Act
+		var exception =
+			( WebApplicationException )constructorInfo!.Invoke(new object[]
+			{
+				serializationInfo, streamingContext
+			});
+
+		// Assert
+		Assert.AreEqual(message, exception.Message);
+		Assert.AreEqual(innerException, exception.InnerException);
+	}
+}

--- a/starsky/starskytest/starsky.foundation.storage/Helpers/StreamGetFirstBytesTest.cs
+++ b/starsky/starskytest/starsky.foundation.storage/Helpers/StreamGetFirstBytesTest.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using starsky.foundation.storage.Helpers;
+
+namespace starskytest.starsky.foundation.storage.Helpers;
+
+[TestClass]
+public class StreamGetFirstBytesTest
+{
+	[TestMethod]
+	public async Task GetFirstBytesAsync_ReturnsCorrectNumberOfBytes()
+	{
+		// Arrange
+		var testData = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+		var originalStream = new MemoryStream(testData);
+
+		// Act
+		var resultStream = await StreamGetFirstBytes.GetFirstBytesAsync(originalStream, 5);
+
+		// Assert
+		Assert.AreEqual(5, resultStream.Length);
+	}
+
+	[TestMethod]
+	public async Task GetFirstBytesAsync_ReturnsCorrectData()
+	{
+		// Arrange
+		var testData = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+		var originalStream = new MemoryStream(testData);
+
+		// Act
+		var resultStream = await StreamGetFirstBytes.GetFirstBytesAsync(originalStream, 5);
+
+		// Assert
+		var resultData = resultStream.ToArray();
+		CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5 }, resultData);
+	}
+
+	[TestMethod]
+	public async Task GetFirstBytesAsync_ReturnsEmptyStreamIfOriginalStreamIsEmpty()
+	{
+		// Arrange
+		var originalStream = new MemoryStream();
+
+		// Act
+		var resultStream = await StreamGetFirstBytes.GetFirstBytesAsync(originalStream, 5);
+
+		// Assert
+		Assert.AreEqual(0, resultStream.Length);
+	}
+
+	[TestMethod]
+	public async Task GetFirstBytesAsync_ReturnsEmptyStreamIfRequestedCountIsZero()
+	{
+		// Arrange
+		var testData = new byte[] { 1, 2, 3, 4, 5 };
+		var originalStream = new MemoryStream(testData);
+
+		// Act
+		var resultStream = await StreamGetFirstBytes.GetFirstBytesAsync(originalStream, 0);
+
+		// Assert
+		Assert.AreEqual(0, resultStream.Length);
+	}
+
+	[TestMethod]
+	[SuppressMessage("ReSharper", "MustUseReturnValue")]
+	public async Task GetFirstBytesAsync_SourceStreamContentRemainsSame()
+	{
+		// Arrange
+		var testData = new byte[] { 1, 2, 3, 4, 5 };
+		var originalStream = new MemoryStream(testData);
+
+		// Create a copy of the original stream content
+		var originalContent = new byte[testData.Length];
+		originalStream.Position = 0;
+		await originalStream.ReadAsync(originalContent, 0, originalContent.Length);
+
+		// Act
+		var resultStream = await StreamGetFirstBytes.GetFirstBytesAsync(originalStream, 5);
+
+		// Create a copy of the result stream content
+		var resultContent = new byte[resultStream.Length];
+		resultStream.Position = 0;
+		await resultStream.ReadAsync(resultContent, 0, resultContent.Length);
+
+		// Assert
+		CollectionAssert.AreEqual(originalContent, resultContent);
+	}
+}

--- a/starsky/starskytest/starsky.foundation.storage/Helpers/StreamGetFirstBytesTest.cs
+++ b/starsky/starskytest/starsky.foundation.storage/Helpers/StreamGetFirstBytesTest.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using starsky.foundation.storage.Helpers;
@@ -67,6 +68,8 @@ public class StreamGetFirstBytesTest
 
 	[TestMethod]
 	[SuppressMessage("ReSharper", "MustUseReturnValue")]
+	[SuppressMessage("Performance",
+		"CA1835:Prefer the \'Memory\'-based overloads for \'ReadAsync\' and \'WriteAsync\'")]
 	public async Task GetFirstBytesAsync_SourceStreamContentRemainsSame()
 	{
 		// Arrange
@@ -76,7 +79,8 @@ public class StreamGetFirstBytesTest
 		// Create a copy of the original stream content
 		var originalContent = new byte[testData.Length];
 		originalStream.Position = 0;
-		await originalStream.ReadAsync(originalContent, 0, originalContent.Length);
+		await originalStream.ReadAsync(originalContent, 0, originalContent.Length,
+			CancellationToken.None);
 
 		// Act
 		var resultStream = await StreamGetFirstBytes.GetFirstBytesAsync(originalStream, 5);
@@ -84,7 +88,8 @@ public class StreamGetFirstBytesTest
 		// Create a copy of the result stream content
 		var resultContent = new byte[resultStream.Length];
 		resultStream.Position = 0;
-		await resultStream.ReadAsync(resultContent, 0, resultContent.Length);
+		await resultStream.ReadAsync(resultContent, 0, resultContent.Length,
+			CancellationToken.None);
 
 		// Assert
 		CollectionAssert.AreEqual(originalContent, resultContent);

--- a/starsky/starskytest/starsky.foundation.storage/Storage/StorageThumbnailFilesystemTest.cs
+++ b/starsky/starskytest/starsky.foundation.storage/Storage/StorageThumbnailFilesystemTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;

--- a/starsky/starskytest/starsky.foundation.storage/Storage/StorageThumbnailFilesystemTest.cs
+++ b/starsky/starskytest/starsky.foundation.storage/Storage/StorageThumbnailFilesystemTest.cs
@@ -163,27 +163,6 @@ namespace starskytest.starsky.foundation.storage.Storage
 			File.Delete(Path.Combine(createNewImage.BasePath,
 				"StorageThumbnailFilesystemTest_WriteStreamAsync.jpg"));
 		}
-
-		[TestMethod]
-		public void SetLastWriteTime_File()
-		{
-			// Currently on results the time
-			var shouldBe = DateTime.Now.AddDays(-1);
-			var result = _thumbnailStorage.SetLastWriteTime("anything", shouldBe);
-
-			Assert.AreEqual(shouldBe, result);
-		}
-
-		[TestMethod]
-		public void SetLastWriteTime_File_Null()
-		{
-			// Currently on results the time
-			var shouldBe = DateTime.Now;
-			var result = _thumbnailStorage.SetLastWriteTime("anything");
-
-			Assert.AreEqual(shouldBe.Year, result.Year);
-			Assert.AreEqual(shouldBe.Month, result.Month);
-			Assert.AreEqual(shouldBe.Day, result.Day);
-		}
+		
 	}
 }

--- a/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolTest.cs
@@ -16,93 +16,81 @@ namespace starskytest.starsky.foundation.writemeta.Helpers
 	[TestClass]
 	public sealed class ExifToolTest
 	{
-
 		[TestMethod]
 		[ExpectedException(typeof(ArgumentException))]
 		public async Task ExifTool_NotFound_Exception()
 		{
-			var appSettings = new AppSettings
-			{
-				ExifToolPath = "Z://Non-exist",
-			};
+			var appSettings = new AppSettings { ExifToolPath = "Z://Non-exist", };
 
-			var fakeStorage = new FakeIStorage(new List<string>{"/"}, 
-				new List<string>{"/test.jpg"}, 
-				new List<byte[]>{CreateAnImage.Bytes.ToArray()});
-			
-			await new ExifToolService(new FakeSelectorStorage(fakeStorage), appSettings, new FakeIWebLogger())
-				.WriteTagsAsync("/test.jpg","-Software=\"Qdraw 2.0\"");
+			var fakeStorage = new FakeIStorage(new List<string> { "/" },
+				new List<string> { "/test.jpg" },
+				new List<byte[]> { CreateAnImage.Bytes.ToArray() });
+
+			await new ExifToolService(new FakeSelectorStorage(fakeStorage), appSettings,
+					new FakeIWebLogger())
+				.WriteTagsAsync("/test.jpg", "-Software=\"Qdraw 2.0\"");
 		}
-		
+
 		[TestMethod]
 		[ExpectedException(typeof(ArgumentException))]
 		public async Task ExifTool_WriteTagsThumbnailAsync_NotFound_Exception()
 		{
-			var appSettings = new AppSettings
-			{
-				ExifToolPath = "Z://Non-exist",
-			};
+			var appSettings = new AppSettings { ExifToolPath = "Z://Non-exist", };
 
-			var fakeStorage = new FakeIStorage(new List<string>{"/"}, 
-				new List<string>{"/test.jpg"}, 
-				new List<byte[]>{CreateAnImage.Bytes.ToArray()});
-			
-			await new ExifToolService(new FakeSelectorStorage(fakeStorage), appSettings, new FakeIWebLogger())
-				.WriteTagsThumbnailAsync("/test.jpg","-Software=\"Qdraw 2.0\"");
+			var fakeStorage = new FakeIStorage(new List<string> { "/" },
+				new List<string> { "/test.jpg" },
+				new List<byte[]> { CreateAnImage.Bytes.ToArray() });
+
+			await new ExifToolService(new FakeSelectorStorage(fakeStorage), appSettings,
+					new FakeIWebLogger())
+				.WriteTagsThumbnailAsync("/test.jpg", "-Software=\"Qdraw 2.0\"");
 		}
 
 		[TestMethod]
 		public async Task ExifTool_RenameThumbnailByStream_Length26()
 		{
-			var appSettings = new AppSettings
-			{
-				ExifToolPath = "Z://Non-exist",
-			};
+			var appSettings = new AppSettings { ExifToolPath = "Z://Non-exist", };
 
-			var fakeStorage = new FakeIStorage(new List<string>{"/"}, 
-				new List<string>{"/test.jpg"}, 
-				new List<byte[]>{CreateAnImage.Bytes.ToArray()});
-			
-			var result = await new ExifTool(fakeStorage, fakeStorage, appSettings, new FakeIWebLogger())
-				.RenameThumbnailByStream("OLDHASH",new MemoryStream(),true);
+			var fakeStorage = new FakeIStorage(new List<string> { "/" },
+				new List<string> { "/test.jpg" },
+				new List<byte[]> { CreateAnImage.Bytes.ToArray() });
 
-			Assert.AreEqual(26,result.Length);
+			var result =
+				await new ExifTool(fakeStorage, fakeStorage, appSettings, new FakeIWebLogger())
+					.RenameThumbnailByStream("OLDHASH", new MemoryStream(), true);
+
+			Assert.AreEqual(26, result.Length);
 		}
-		
+
 		[TestMethod]
 		public async Task ExifTool_RenameThumbnailByStream_Fail()
 		{
-			var appSettings = new AppSettings
-			{
-				ExifToolPath = "Z://Non-exist",
-			};
+			var appSettings = new AppSettings { ExifToolPath = "Z://Non-exist", };
 
-			var fakeStorage = new FakeIStorage(new List<string>{"/"}, 
-				new List<string>{"/test.jpg"}, 
-				new List<byte[]>{CreateAnImage.Bytes.ToArray()});
-			
-			var result = await new ExifTool(fakeStorage, fakeStorage, appSettings, new FakeIWebLogger())
-				.RenameThumbnailByStream("OLDHASH",new MemoryStream(),false);
+			var fakeStorage = new FakeIStorage(new List<string> { "/" },
+				new List<string> { "/test.jpg" },
+				new List<byte[]> { CreateAnImage.Bytes.ToArray() });
 
-			Assert.AreEqual(0,result.Length);
+			var result =
+				await new ExifTool(fakeStorage, fakeStorage, appSettings, new FakeIWebLogger())
+					.RenameThumbnailByStream("OLDHASH", new MemoryStream(), false);
+
+			Assert.AreEqual(0, result.Length);
 		}
-		
+
 		[TestMethod]
 		public async Task ExifTool_RenameThumbnailByStream_NotDisposed_CanWrite()
 		{
-			var appSettings = new AppSettings
-			{
-				ExifToolPath = "Z://Non-exist",
-			};
+			var appSettings = new AppSettings { ExifToolPath = "Z://Non-exist", };
 
-			var fakeStorage = new FakeIStorage(new List<string>{"/"}, 
-				new List<string>{"/test.jpg"}, 
-				new List<byte[]>{CreateAnImage.Bytes.ToArray()});
+			var fakeStorage = new FakeIStorage(new List<string> { "/" },
+				new List<string> { "/test.jpg" },
+				new List<byte[]> { CreateAnImage.Bytes.ToArray() });
 
 			var stream = new MemoryStream();
 			await new ExifTool(fakeStorage, fakeStorage, appSettings, new FakeIWebLogger())
-				.RenameThumbnailByStream("OLDHASH",stream,true);
-			
+				.RenameThumbnailByStream("OLDHASH", stream, true);
+
 			Assert.IsTrue(stream.CanWrite);
 		}
 
@@ -118,22 +106,19 @@ namespace starskytest.starsky.foundation.writemeta.Helpers
 		public async Task RunProcessAsync_RunChildObject_UnixOnly()
 		{
 			// Unix only
-			var appSettings = new AppSettings
-			{
-				Verbose = true, 
-				ExifToolPath = "/bin/ls"
-			};
+			var appSettings = new AppSettings { Verbose = true, ExifToolPath = "/bin/ls" };
 			if ( appSettings.IsWindows || !File.Exists("/bin/ls") )
 			{
 				Assert.Inconclusive("This test if for Unix Only");
 				return;
 			}
+
 			var runner = new StreamToStreamRunner(appSettings,
 				new MemoryStream(Array.Empty<byte>()), new FakeIWebLogger());
-			var result = await runner.RunProcessAsync(string.Empty);
-			
+			var result = await runner.RunProcessAsync(string.Empty, "test");
+
 			await StreamToStringHelper.StreamToStringAsync(result, false);
-			
+
 			Assert.AreEqual(0, result.Length);
 		}
 
@@ -142,9 +127,9 @@ namespace starskytest.starsky.foundation.writemeta.Helpers
 		{
 			var storage =
 				new FakeIStorage(new ObjectDisposedException("disposed"));
-			
-			var exifTool = new ExifTool(storage, 
-				storage, 
+
+			var exifTool = new ExifTool(storage,
+				storage,
 				new AppSettings(), new FakeIWebLogger());
 
 			var exceptionMessage = string.Empty;
@@ -157,12 +142,11 @@ namespace starskytest.starsky.foundation.writemeta.Helpers
 				// Expected
 				exceptionMessage = e.Message;
 			}
-			
+
 			Assert.IsTrue(exceptionMessage.StartsWith("Cannot access a disposed object."));
 			Assert.IsTrue(exceptionMessage.EndsWith("Object name: 'disposed'."));
-			
-			Assert.AreEqual(1,storage.ExceptionCount);
-		}
 
+			Assert.AreEqual(1, storage.ExceptionCount);
+		}
 	}
 }


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

Corrupt images where generated due import (Issue started with .NET 8)

<!--- Why is this change required? What problem does it solve? -->
```
info: app[0]\n' +
    '      [Import] Next Action = Copy /opt/starsky/starsky-tools/dropbox-import/temp/2024-02-18 09.32.21-1.jpg /2024/02/2024_02_18/20240218_093221_d_1.jpg\n',
  stderr: 'Unhandled exception. System.ObjectDisposedException: Cannot access a closed file.\n' +
    '   at System.IO.FileStream.FlushAsync(CancellationToken cancellationToken)\n' +
    '   at System.IO.Stream.FlushAsync()\n' +
    '   at starsky.feature.import.Services.Import.CopyStream(ImportIndexItem importIndexItem, ImportSettingsModel importSettings) in /home/vsts/work/1/s/starsky/starsky.feature.import/Services/Import.cs:line 688\n' +
    '   at starsky.feature.import.Services.Import.Importer(ImportIndexItem importIndexItem, ImportSettingsModel importSettings) in /home/vsts/work/1/s/starsky/starsky.feature.import/Services/Import.cs:line 609\n' +
    '   at starsky.feature.import.Services.Import.<>c__DisplayClass26_0.<<Importer>b__0>d.MoveNext() in /home/vsts/work/1/s/starsky/starsky.feature.import/Services/Import.cs:line 547\n' +
    '--- End of stack trace from previous location ---\n' +
    '   at starsky.foundation.platform.Extensions.EnumerableExtensions.ForEachAsync[TSource,TResult](IEnumerable`1 items, Func`2 action, Int32 maxDegreesOfParallelism) in /home/vsts/work/1/s/starsky/starsky.foundation.platform/Extensions/EnumerableExtensions.cs:line 40\n' +
    '   at starsky.feature.import.Services.Import.Importer(IEnumerable`1 inputFullPathList, ImportSettingsModel importSettings) in /home/vsts/work/1/s/starsky/starsky.feature.import/Services/Import.cs:line 544\n' +
    '   at starsky.feature.import.Services.ImportCli.Importer(String[] args) in /home/vsts/work/1/s/starsky/starsky.feature.import/Services/ImportCli.cs:line 84\n' +
    '   at starskyimportercli.Program.Main(String[] args) in /home/vsts/work/1/s/starsky/starskyimportercli/Program.cs:line 54\n' +
    '   at starskyimportercli.Program.<Main>(String[] args)\n' +
    'Aborted\n'
```

```
fail: Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware[1]
      An unhandled exception has occurred while executing the request.
      System.AggregateException: One or more errors occurred. (Specified method is not supported.) (Unexpected end of Stream, the content may have already been read by another component. ) (Unexpected end of Stream, the content may have already been read by another component. )
       ---> System.NotSupportedException: Specified method is not supported.
         at Microsoft.AspNetCore.WebUtilities.MultipartReaderStream.Flush()
         at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
      --- End of stack trace from previous location ---
         at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
         at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
      --- End of stack trace from previous location ---
         at starsky.foundation.storage.Storage.StorageHostFullPathFilesystem.<>c__DisplayClass19_0.<<WriteStreamAsync>g__LocalRun|0>d.MoveNext() in C:\wsgit\starsky\starsky\starsky.foundation.storage\Storage\StorageHostFullPathFilesystem.cs:line 417
      --- End of stack trace from previous location ---
         at starsky.foundation.platform.Helpers.RetryHelper.DoAsyncWorker[T](Func`1 operation, TimeSpan delay, Int32 maxAttemptCount) in C:\wsgit\starsky\starsky\starsky.foundation.platform\Helpers\RetryHelper.cs:line 80
         --- End of inner exception stack trace ---
         at starsky.foundation.platform.Helpers.RetryHelper.DoAsyncWorker[T](Func`1 operation, TimeSpan delay, Int32 maxAttemptCount) in C:\wsgit\starsky\starsky\starsky.foundation.platform\Helpers\RetryHelper.cs:line 87
         at starsky.foundation.storage.Storage.StorageHostFullPathFilesystem.WriteStreamAsync(Stream stream, String path) in C:\wsgit\starsky\starsky\starsky.foundation.storage\Storage\StorageHostFullPathFilesystem.cs:line 423
         at starsky.foundation.http.Streaming.FileStreamingHelper.StreamFile(String contentType, Stream requestBody, AppSettings appSettings, ISelectorStorage selectorStorage, String headerFileName) in C:\wsgit\starsky\starsky\starsky.foundation.http\Streaming\FileStreamingHelper.cs:line 119
         at starsky.foundation.http.Streaming.FileStreamingHelper.StreamFile(HttpRequest request, AppSettings appSettings, ISelectorStorage selectorStorage) in C:\wsgit\starsky\starsky\starsky.foundation.http\Streaming\FileStreamingHelper.cs:line 49
         at starsky.Controllers.ImportController.IndexPost() in C:\wsgit\starsky\starsky\starsky\Controllers\ImportController.cs:line 81
         at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.TaskOfIActionResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
         at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)
         at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
         at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
         at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
         at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeInnerFilterAsync>g__Awaited|13_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
         at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
         at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
         at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
         at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeFilterPipelineAsync>g__Awaited|20_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
         at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
         at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
         at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
         at starsky.foundation.accountmanagement.Middleware.CheckIfAccountExistMiddleware.Invoke(HttpContext context) in C:\wsgit\starsky\starsky\starsky.foundation.accountmanagement\Middleware\CheckIfAccountExistMiddleware.cs:line 55
         at starsky.foundation.accountmanagement.Middleware.BasicAuthenticationMiddleware.Invoke(HttpContext context) in C:\wsgit\starsky\starsky\starsky.foundation.accountmanagement\Middleware\BasicAuthenticationMiddleware.cs:line 38
         at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
         at starsky.foundation.platform.Middleware.ContentSecurityPolicyMiddleware.Invoke(HttpContext httpContext) in C:\wsgit\starsky\starsky\starsky.foundation.platform\Middleware\ContentSecurityPolicyMiddleware.cs:line 103
         at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)
         at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
         at Microsoft.AspNetCore.Builder.Extensions.UsePathBaseMiddleware.InvokeCore(HttpContext context, PathString matchedPath, PathString remainingPath)
         at Microsoft.AspNetCore.Diagnostics.StatusCodePagesMiddleware.Invoke(HttpContext context)
         at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)
       ---> (Inner Exception #1) System.IO.IOException: Unexpected end of Stream, the content may have already been read by another component.
         at Microsoft.AspNetCore.WebUtilities.MultipartReaderStream.ReadAsync(Memory`1 buffer, CancellationToken cancellationToken)
```

```
leMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
         at starsky.foundation.storage.Storage.StorageHostFullPathFilesystem.<>c__DisplayClass19_0.<<WriteStreamAsync>g__LocalRun|0>d.MoveNext() in C:\wsgit\starsky\starsky\starsky.foundation.storage\Storage\StorageHostFullPathFilesystem.cs:line 409
      --- End of stack trace from previous location ---
         at starsky.foundation.platform.Helpers.RetryHelper.DoAsyncWorker[T](Func`1 operation, TimeSpan delay, Int32 maxAttemptCount) in C:\wsgit\starsky\starsky\starsky.foundation.platform\Helpers\RetryHelper.cs:line 80
         --- End of inner exception stack trace ---
         at starsky.foundation.platform.Helpers.RetryHelper.DoAsyncWorker[T](Func`1 operation, TimeSpan delay, Int32 maxAttemptCount) in C:\wsgit\starsky\starsky\starsky.foundation.platform\Helpers\RetryHelper.cs:line 87
         at starsky.foundation.storage.Storage.StorageHostFullPathFilesystem.WriteStreamAsync(Stream stream, String path) in C:\wsgit\starsky\starsky\starsky.foundation.storage\Storage\StorageHostFullPathFilesystem.cs:line 423
         at starsky.foundation.writemeta.Helpers.ExifTool.WriteTagsAndRenameThumbnailInternalAsync(String subPath, String beforeFileHash, String command, CancellationToken cancellationToken) in C:\wsgit\starsky\starsky\starsky.foundation.writemeta\Helpers\ExifTool.cs:line 82
         at starsky.foundation.writemeta.Helpers.ExifTool.WriteTagsAndRenameThumbnailAsync(String subPath, String beforeFileHash, String command, CancellationToken cancellationToken) in C:\wsgit\starsky\starsky\starsky.foundation.writemeta\Helpers\ExifTool.cs:line 51
         at starsky.foundation.writemeta.Services.ExifToolService.WriteTagsAndRenameThumbnailAsync(String subPath, String beforeFileHash, String command, CancellationToken cancellationToken) in C:\wsgit\starsky\starsky\starsky.foundation.writemeta\Services\ExifToolService.cs:line 40
         at starsky.foundation.writemeta.Helpers.ExifToolCmdHelper.UpdateAsync(FileIndexItem updateModel, List`1 inputSubPaths, List`1 comparedNames, Boolean includeSoftware, Boolean renameThumbnail, CancellationToken cancellationToken) in C:\wsgit\starsky\starsky\starsky.foundation.writemeta\Helpers\ExifToolCmdHelper.cs:line 233
         at starsky.feature.metaupdate.Services.MetaUpdateService.UpdateWriteDiskDatabase(FileIndexItem fileIndexItem, List`1 comparedNamesList, Int32 rotateClock) in C:\wsgit\starsky\starsky\starsky.feature.metaupdate\Services\MetaUpdateService.cs:line 144
         at starsky.feature.metaupdate.Services.MetaUpdateService.UpdateAsync(Dictionary`2 changedFileIndexItemName, List`1 fileIndexResultsList, FileIndexItem inputModel, Boolean collections, Boolean append, Int32 rotateClock) in C:\wsgit\starsky\starsky\starsky.feature.metaupdate\Services\MetaUpdateService.cs:line 99         at starsky.Controllers.MetaUpdateController.<>c__DisplayClass6_0.<<UpdateAsync>b__0>d.MoveNext() in C:\wsgit\starsky\starsky\starsky\Controllers\MetaUpdateController.cs:line 88
      --- End of stack trace from previous location ---
         at starsky.foundation.worker.Helpers.ProcessTaskQueue.ExecuteTask(Func`2 workItem, IWebLogger logger, IBaseBackgroundTaskQueue taskQueue, CancellationToken cancellationToken) in C:\wsgit\starsky\starsky\starsky.foundation.worker\Helpers\ProcessTaskQueue.cs:line 107
       ---> (Inner Exception #1) System.IO.IOException: The process cannot access the file 'C:\testcontent\20221029_101722_DSC05623.xmp' because it is being used by another process.
         at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
         at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
         at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
         at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
         at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
         at starsky.foundation.storage.Storage.StorageHostFullPathFilesystem.<>c__DisplayClass19_0.<<WriteStreamAsync>g__LocalRun|0>d.MoveNext() in C:\wsgit\starsky\starsky\starsky.foundation.storage\Storage\StorageHostFullPathFilesystem.cs:line 409
      --- End of stack trace from previous location ---
         at starsky.foundation.platform.Helpers.RetryHelper.DoAsyncWorker[T](Func`1 operation, TimeSpan delay, Int32 maxAttemptCount) in C:\wsgit\starsky\starsky\starsky.foundation.platform\Helpers\RetryHelper.cs:line 80<---

       ---> (Inner Exception #2) System.IO.IOException: The process cannot access the file 'C:\testcontent\20221029_101722_DSC05623.xmp' because it is being used by another process.
         at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
         at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
         at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
         at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
         at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
         at starsky.foundation.storage.Storage.StorageHostFullPathFilesystem.<>c__DisplayClass19_0.<<WriteStreamAsync>g__LocalRun|0>d.MoveNext() in C:\wsgit\starsky\starsky\starsky.foundation.storage\Storage\StorageHostFullPathFilesystem.cs:line 409
      --- End of stack trace from previous location ---
         at starsky.foundation.platform.Helpers.RetryHelper.DoAsyncWorker[T](Func`1 operation, TimeSpan delay, Int32 maxAttemptCount) in C:\wsgit\starsky\starsky\starsky.foundation.platform\Helpers\RetryHelper.cs:line 80<---


```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
