### PR TITLE
.NET SDK Upgrade to 8.0.201

### DIFF
--- a/.github/workflows/auto-update-swagger-dotnet.yml
+++ b/.github/workflows/auto-update-swagger-dotnet.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.200
+        dotnet-version: 8.0.201
 
     - name: Cache nuget packages (*nix)
       uses: actions/cache@v4

--- a/.github/workflows/release-on-tag-netcore-desktop-electron.yml
+++ b/.github/workflows/release-on-tag-netcore-desktop-electron.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.200
+          dotnet-version: 8.0.201
 
       - name: Build --no-unit-test linux-arm,linux-arm64,win-x64,osx-x64,linux-x64,osx-arm64 --ready-to-run
         shell: bash

--- a/.github/workflows/starsky-codecov-clientapp-netcore.yml
+++ b/.github/workflows/starsky-codecov-clientapp-netcore.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.200
+          dotnet-version: 8.0.201
  
       - name: Cache node modules clientapp (*nix)
         uses: actions/cache@v4

--- a/.github/workflows/starsky-dotnetcore-ubuntu.yml
+++ b/.github/workflows/starsky-dotnetcore-ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.200
+        dotnet-version: 8.0.201
 
     - name: Cache nuget packages (*nix)
       uses: actions/cache@v4

--- a/.github/workflows/starsky-dotnetcore-windows.yml
+++ b/.github/workflows/starsky-dotnetcore-windows.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.200
+        dotnet-version: 8.0.201
         
     - name: Build (Windows)
       shell: pwsh

--- a/.github/workflows/starsky-sonarqube-clientapp-netcore.yml
+++ b/.github/workflows/starsky-sonarqube-clientapp-netcore.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.200
+          dotnet-version: 8.0.201
         
       - name: Use Java 17   
         uses: actions/setup-java@v4

--- a/.github/workflows/webapp-net-only-macos.yml
+++ b/.github/workflows/webapp-net-only-macos.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.200
+        dotnet-version: 8.0.201
         
     - name: "BuildNetCore (MacOS)"
       shell: bash

--- a/history.md
+++ b/history.md
@@ -42,8 +42,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 ## List of versions
 
 ## version 0.6.0-beta.2 -  _(Unreleased)_ - 2024-02-? {#v0.6.0-beta.2}
-
-- nothing yet
+- [x] (Changed) Back-end Upgrade to .NET 8 - SDK 8.0.201 (Runtime: 8.0.2) (PR #1402)
 
 ## version 0.6.0-beta.1 - 2024-02-18 {#v0.6.0-beta.1}
 

--- a/pipelines/azure/steps/use_dotnet_version.yml
+++ b/pipelines/azure/steps/use_dotnet_version.yml
@@ -1,8 +1,8 @@
 steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET SDK 8.0.200'
+    displayName: 'Use .NET SDK 8.0.201'
     enabled: true
     inputs:
       packageType: sdk
-      version: 8.0.200
+      version: 8.0.201
       installationPath: $(Agent.ToolsDirectory)/dotnet

--- a/starsky/global.json
+++ b/starsky/global.json
@@ -1,7 +1,7 @@
 {
     "strictVersion": true,
     "sdk": {
-        "version": "8.0.200",
+        "version": "8.0.201",
         "rollForward": "disable",
         "allowPrerelease": false
     }

--- a/starsky/readme.md
+++ b/starsky/readme.md
@@ -37,7 +37,7 @@ to compile the application for development
 git clone "https://github.com/qdraw/starsky.git"
 ```
 
-2. Get the `dotnet` 8.0.200 SDK. To get the 'Build apps - SDK' .NET Core from https://www.microsoft.com/net/download or https://versionsof.net/
+2. Get the `dotnet` 8.0.201 SDK. To get the 'Build apps - SDK' .NET Core from https://www.microsoft.com/net/download or https://versionsof.net/
 3. Get a recent version of nodejs (18.x or newer)
 
 4. Make a build of all the projects and run the tests


### PR DESCRIPTION
## Upgrade of .NET with newer SDK Version
- Install SDK version 8.0.201 on your development machine https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.2/8.0.2.md
- First test on linux-arm test envs before approve
- update azure runtime on test https://demostarsky.scm.azurewebsites.net/
- update docs with minimal version https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.201/starsky/readme.md
- update changelog https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.201/history.md

## When upgrading a major version
- when upgrading to newer major release check docker