### PR TITLE
"Failed to execute PeriodicThumbnailScanHostedService with exception …

### DIFF
--- a/starsky/starsky.foundation.platform/Helpers/FilenamesHelper.cs
+++ b/starsky/starsky.foundation.platform/Helpers/FilenamesHelper.cs
@@ -117,7 +117,7 @@ namespace starsky.foundation.platform.Helpers
 		[GeneratedRegex(
 			".+(?=\\/[^/]+$)",
 			RegexOptions.CultureInvariant,
-			matchTimeoutMilliseconds: 100)]
+			matchTimeoutMilliseconds: 200)]
 		private static partial Regex ParentPathRegex();
 
 		/// <summary>


### PR DESCRIPTION
…message One or more errors occurred. (The Regex engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.) (The Regex engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.) -    at starsky.foundation.platform.Helpers.RetryHelper.DoAsyncWorker[T](Func`1 operation, TimeSpan delay, Int32 maxAttemptCount) in /home/vsts/work/1/s/starsky/starsky.foundation.platform/Helpers/RetryHelper.cs:line 87\n   at starsky.foundation.database.Query.Query.GetObjectsByFileHashAsync(List`1 fileHashesList, Int32 retryCount) in /home/vsts/work/1/s/starsky/starsky.foundation.database/Query/QueryGetObjectsByFileHashAsync.cs:line 50\n   at starsky.feature.thumbnail.Services.DatabaseThumbnailGenerationService.StartBackgroundQueue(DateTime endTime) in /home/vsts/work/1/s/starsky/starsky.feature.thumbnail/Services/DatabaseThumbnailGenerationService.cs:line 51\n   at starsky.feature.thumbnail.Services.PeriodicThumbnailScanHostedService.RunJob(CancellationToken cancellationToken) in /home/vsts/work/1/s/starsky/starsky.feature.thumbnail/Services/PeriodicThumbnailScanHostedService.cs:line 106\n   at starsky.feature.thumbnail.Services.PeriodicThumbnailScanHostedService.RunJob(CancellationToken cancellationToken) in /home/vsts/work/1/s/starsky/starsky.feature.thumbnail/Services/PeriodicThumbnailScanHostedService.cs:line 112 -    at System.Text.RegularExpressions.RegexRunner.<CheckTimeout>g__ThrowRegexTimeout|25_0()\n   at System.Text.RegularExpressions.Generated.<RegexGenerator_g>F98A139365790CDF5422F6679F18BCAC76A69077D03DB0F256D624263779DCA15__ParentPathRegex_4.RunnerFactory.Runner.TryMatchAtCurrentPosition(ReadOnlySpan`1 inputSpan) in /home/vsts/work/1/s/starsky/starsky.foundation.platform/System.Text.RegularExpressions.Generator/System.Text.RegularExpressions.Generator.RegexGenerator/RegexGenerator.g.cs:line 1148\n   at System.Text.RegularExpressions.Generated.<RegexGenerator_g>F98A139365790CDF5422F6679F18BCAC76A69077D03DB0F256D624263779DCA15__ParentPathRegex_4.RunnerFactory.Runner.Scan(ReadOnlySpan`1 inputSpan) in /home/vsts/work/1/s/starsky/starsky.foundation.platform/System.Text.RegularExpressions.Generator/System.Text.RegularExpressions.Generator.RegexGenerator/RegexGenerator.g.cs:line 1051\n   at System.Text.RegularExpressions.Regex.ScanInternal(RegexRunnerMode mode, Boolean reuseMatchObject, String input, Int32 beginning, RegexRunner runner, ReadOnlySpan`1 span, Boolean returnNullIfReuseMatchObject)\n   at System.Text.RegularExpressions.Regex.RunSingleMatch(RegexRunnerMode mode, Int32 prevlen, String input, Int32 beginning, Int32 length, Int32 startat)\n   at starsky.foundation.platform.Helpers.FilenamesHelper.GetParentPath(String filePath) in /home/vsts/work/1/s/starsky/starsky.foundation.platform/Helpers/FilenamesHelper.cs:line 135\n   at starsky.foundation.database.Models.FileIndexItem.SetFilePath(String value) in /home/vsts/work/1/s/starsky/starsky.foundation.database/Models/FileIndexItem.cs:line 79\n   at lambda_method239(Closure, QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator)\n   at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable`1.AsyncEnumerator.MoveNextAsync()\n   at Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync[TSource](IQueryable`1 source, CancellationToken cancellationToken)\n   at Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync[TSource](IQueryable`1 source, CancellationToken cancellationToken)\n   at starsky.foundation.database.Query.Query.<>c__DisplayClass55_0.<<GetObjectsByFileHashAsync>g__LocalQuery|0>d.MoveNext() in /home/vsts/work/1/s/starsky/starsky.foundation.database/Query/QueryGetObjectsByFileHashAsync.cs:line 28\n--- End of stack trace from previous location ---\n   at starsky.foundation.database.Query.Query.<>c__DisplayClass55_0.<<GetObjectsByFileHashAsync>g__LocalDefaultQuery|1>d.MoveNext() in /home/vsts/work/1/s/starsky/starsky.foundation.database/Query/QueryGetObjectsByFileHashAsync.cs:line 47\n--- End of stack trace from previous location ---\n   at starsky.foundation.platform.Helpers.RetryHelper.DoAsyncWorker[T](Func`1 operation, TimeSpan delay, Int32 maxAttemptCount) in /home/vsts/work/1/s/starsky/starsky.foundation.platform/Helpers/RetryHelper.cs:line 80"

# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
