### PR TITLE
.NET SDK Upgrade to 8.0.203

### DIFF
--- a/.github/workflows/desktop-release-on-tag-net-electron.yml
+++ b/.github/workflows/desktop-release-on-tag-net-electron.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.202
+          dotnet-version: 8.0.203
 
       - name: Build --no-unit-test linux-arm,linux-arm64,win-x64,osx-x64,linux-x64,osx-arm64 --ready-to-run
         shell: bash

--- a/.github/workflows/webapp-build-net-macos.yml
+++ b/.github/workflows/webapp-build-net-macos.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.202
+        dotnet-version: 8.0.203
         
     - name: "BuildNetCore (MacOS)"
       shell: bash

--- a/.github/workflows/webapp-build-net-ubuntu.yml
+++ b/.github/workflows/webapp-build-net-ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.202
+        dotnet-version: 8.0.203
 
     - name: Cache nuget packages (*nix)
       uses: actions/cache@v4

--- a/.github/workflows/webapp-build-net-windows.yml
+++ b/.github/workflows/webapp-build-net-windows.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.202
+        dotnet-version: 8.0.203
         
     - name: Build (Windows)
       shell: pwsh

--- a/.github/workflows/webapp-codecov-clientapp-netcore.yml
+++ b/.github/workflows/webapp-codecov-clientapp-netcore.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.202
+          dotnet-version: 8.0.203
  
       - name: Cache node modules clientapp (*nix)
         uses: actions/cache@v4

--- a/.github/workflows/webapp-sonarqube-clientapp-netcore.yml
+++ b/.github/workflows/webapp-sonarqube-clientapp-netcore.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.202
+          dotnet-version: 8.0.203
         
       - name: Use Java 17   
         uses: actions/setup-java@v4

--- a/.github/workflows/webapp-update-swagger-dotnet.yml
+++ b/.github/workflows/webapp-update-swagger-dotnet.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.202
+        dotnet-version: 8.0.203
 
     - name: Cache nuget packages (*nix)
       uses: actions/cache@v4

--- a/pipelines/azure/steps/use_dotnet_version.yml
+++ b/pipelines/azure/steps/use_dotnet_version.yml
@@ -1,8 +1,8 @@
 steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET SDK 8.0.202'
+    displayName: 'Use .NET SDK 8.0.203'
     enabled: true
     inputs:
       packageType: sdk
-      version: 8.0.202
+      version: 8.0.203
       installationPath: $(Agent.ToolsDirectory)/dotnet

--- a/starsky/global.json
+++ b/starsky/global.json
@@ -1,7 +1,7 @@
 {
     "strictVersion": true,
     "sdk": {
-        "version": "8.0.202",
+        "version": "8.0.203",
         "rollForward": "disable",
         "allowPrerelease": false
     }

--- a/starsky/starsky.foundation.platform/starsky.foundation.platform.csproj
+++ b/starsky/starsky.foundation.platform/starsky.foundation.platform.csproj
@@ -16,13 +16,13 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
         <!--      instead of : Microsoft.AspNetCore.Http.Abstractions" 2.2.0 -->
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="System.Buffers" Version="4.5.1"/>
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="8.0.0"/>

--- a/starsky/starskytest/starskytest.csproj
+++ b/starsky/starskytest/starskytest.csproj
@@ -21,10 +21,10 @@
     <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'"/>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'"/>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.3"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.2.2"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.2.2"/>


### PR DESCRIPTION
## Upgrade of .NET with newer SDK Version
- Install SDK version 8.0.203 on your development machine https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.3/8.0.3.md
- First test on linux-arm test envs before approve
- update azure runtime on test https://demostarsky.scm.azurewebsites.net/
- update docs with minimal version https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.203/starsky/readme.md
- update changelog https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.203/history.md

## When upgrading a major version
- when upgrading to newer major release check docker