### PR TITLE
GetFileName refactor

### DIFF
--- a/history.md
+++ b/history.md
@@ -45,6 +45,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 - [x] (Changed) _Front-end_  Make prev / next more contrast (PR #1511)
 - [x] (Fixed) _Docs_ Demo site is not working (PR #1486)
+- [x] (Fixed) _Back-end_  GetFileNameRegex give longer to avoid timeouts (PR #1515)
 
 ## version 0.6.0 - 2024-03-15 {#v0.6.0}
 

--- a/history.md
+++ b/history.md
@@ -45,7 +45,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 - [x] (Changed) _Front-end_  Make prev / next more contrast (PR #1511)
 - [x] (Fixed) _Docs_ Demo site is not working (PR #1486)
-- [x] (Fixed) _Back-end_  GetFileNameRegex give longer to avoid timeouts (PR #1515)
+- [x] (Fixed) _Back-end_  GetFileNameRegex refactor to avoid timeouts (PR #1515)
 
 ## version 0.6.0 - 2024-03-15 {#v0.6.0}
 

--- a/starsky/starsky.foundation.platform/Helpers/PathHelper.cs
+++ b/starsky/starsky.foundation.platform/Helpers/PathHelper.cs
@@ -17,7 +17,7 @@ namespace starsky.foundation.platform.Helpers
 		[GeneratedRegex(
 			"[^/]+(?=(?:\\.[^.]+)?$)",
 			RegexOptions.CultureInvariant,
-			matchTimeoutMilliseconds: 300)]
+			matchTimeoutMilliseconds: 1000)]
 		private static partial Regex GetFileNameRegex();
 
 		/// <summary>

--- a/starsky/starsky.foundation.platform/Helpers/PathHelper.cs
+++ b/starsky/starsky.foundation.platform/Helpers/PathHelper.cs
@@ -32,7 +32,7 @@ namespace starsky.foundation.platform.Helpers
 
 		[SuppressMessage("Style", "IDE0057:Use range operator")]
 		[SuppressMessage("ReSharper", "ReplaceSliceWithRangeIndexer")]
-		private static ReadOnlySpan<char> GetFileNameUnix(ReadOnlySpan<char> path)
+		internal static ReadOnlySpan<char> GetFileNameUnix(ReadOnlySpan<char> path)
 		{
 			var length = GetPathRootUnix(path).Length;
 			var num = path.LastIndexOf('/');

--- a/starsky/starsky.foundation.platform/Helpers/PathHelper.cs
+++ b/starsky/starsky.foundation.platform/Helpers/PathHelper.cs
@@ -35,6 +35,78 @@ namespace starsky.foundation.platform.Helpers
 			return GetFileNameRegex().Match(filePath).Value;
 		}
 
+		private static string? GetFileNameHelper(string input)
+		{
+			      // Initialize variables to store the result
+        string result = "";
+        bool isValid = true;
+
+        // Define variables to keep track of the current position and length of the match
+        int startPos = 0;
+        int matchLength = 0;
+
+        // Iterate over the characters in the input string
+        for (int i = 0; i < input.Length; i++)
+        {
+            // If the current character is '/', it means the end of a potential match
+            if (input[i] == '/')
+            {
+                // Extract the potential match substring
+                string potentialMatch = input.Substring(startPos, matchLength);
+
+                // Check if the potential match matches the pattern [^/]+(?=(?:\.[^.]+)?$)
+                if (!potentialMatch.Contains("/") && (potentialMatch.Contains(".") || potentialMatch.EndsWith(".")))
+                {
+                    // Add the potential match to the result
+                    result += potentialMatch + "/";
+
+                    // Update the start position for the next potential match
+                    startPos = i + 1;
+                    matchLength = 0;
+                }
+                else
+                {
+                    // If the potential match does not match the pattern, set isValid to false and break the loop
+                    isValid = false;
+                    break;
+                }
+            }
+            else
+            {
+                // Increment the length of the potential match
+                matchLength++;
+            }
+        }
+
+        // Handle the last potential match after the loop
+        if (matchLength > 0)
+        {
+            string lastPotentialMatch = input.Substring(startPos, matchLength);
+            if (!lastPotentialMatch.Contains("/") && (lastPotentialMatch.Contains(".") || lastPotentialMatch.EndsWith(".")))
+            {
+                result += lastPotentialMatch;
+            }
+            else
+            {
+                isValid = false;
+            }
+        }
+
+        // If isValid is true and result is not empty, remove the trailing '/'
+        if (isValid && result.Length > 0)
+        {
+            result = result.TrimEnd('/');
+        }
+        else
+        {
+            // If the input string does not match the pattern, set result to null
+            result = null;
+        }
+
+        // Output the result
+        return result;
+		}
+
 		/// <summary>
 		/// Removes the latest backslash. Path.DirectorySeparatorChar
 		/// </summary>

--- a/starsky/starskytest/starsky.foundation.platform/Helpers/PathHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Helpers/PathHelperTest.cs
@@ -1,50 +1,35 @@
+using System;
 using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using starsky.foundation.platform.Helpers;
-using starsky.foundation.storage.Helpers;
-using starskytest.FakeCreateAn;
 
 namespace starskytest.starsky.foundation.platform.Helpers;
 
 [TestClass]
 public class PathHelperTests
 {
-	[TestMethod]
-	public void GetFileName_ReturnsValidFileName()
+	[DataTestMethod] // [Theory]
+	[DataRow("path/to/file.txt", "file.txt")]
+	[DataRow("file.txt", "file.txt")]
+	[DataRow("/file.txt", "file.txt")]
+	[DataRow("/test/file.txt", "file.txt")]
+	[DataRow("/test/file/", "")]
+	[DataRow("/test/file", "file")] // no backslash
+	public void GetFileName_ReturnsValidFileName(string input, string expectedFileName)
 	{
-		// Arrange
-		const string filePath = "path/to/file.txt";
-		const string expectedFileName = "file.txt";
-
 		// Act
-		var actualFileName = PathHelper.GetFileName(filePath);
+		var actualFileName = PathHelper.GetFileName(input);
 
 		// Assert
 		Assert.AreEqual(expectedFileName, actualFileName);
 	}
 
 	[TestMethod]
-	[ExpectedException(typeof(RegexMatchTimeoutException))]
-	public async Task GetFileName_ReturnsFileName_WithMaliciousInput()
+	[ExpectedException(typeof(ArgumentException))]
+	public void GetFileName_ReturnsFileName_WithMaliciousInput()
 	{
 		// Act and Assert
-		var test = await
-			StreamToStringHelper.StreamToStringAsync(
-				new MemoryStream(CreateAnImage.Bytes.ToArray()));
-		var test2 = await
-			StreamToStringHelper.StreamToStringAsync(
-				new MemoryStream(CreateAnImageA6600.Bytes.ToArray()));
-
-		var result = string.Empty;
-		for ( var i = 0; i < 1000; i++ )
-		{
-			result += test + test2 + test + test;
-		}
-
-		PathHelper.GetFileName(result);
+		PathHelper.GetFileName(TestContentVeryLongString);
 	}
 
 	[TestMethod]
@@ -104,11 +89,11 @@ public class PathHelperTests
 	public void RemoveLatestSlash_RemovesLatestSlash_WhenSlashExists()
 	{
 		// Arrange
-		string basePath = "/path/to/directory/";
-		string expectedPath = "/path/to/directory";
+		const string basePath = "/path/to/directory/";
+		const string expectedPath = "/path/to/directory";
 
 		// Act
-		string actualPath = PathHelper.RemoveLatestSlash(basePath);
+		var actualPath = PathHelper.RemoveLatestSlash(basePath);
 
 		// Assert
 		Assert.AreEqual(expectedPath, actualPath);
@@ -118,10 +103,10 @@ public class PathHelperTests
 	public void RemoveLatestSlash_DoesNotRemoveSlash_WhenSlashDoesNotExist()
 	{
 		// Arrange
-		string basePath = "/path/to/directory";
+		const string basePath = "/path/to/directory";
 
 		// Act
-		string actualPath = PathHelper.RemoveLatestSlash(basePath);
+		var actualPath = PathHelper.RemoveLatestSlash(basePath);
 
 		// Assert
 		Assert.AreEqual(basePath, actualPath);
@@ -131,7 +116,7 @@ public class PathHelperTests
 	public void RemoveLatestSlash_ReturnsEmptyString_WhenBasePathIsNull()
 	{
 		// Act
-		string actualPath = PathHelper.RemoveLatestSlash(null!);
+		var actualPath = PathHelper.RemoveLatestSlash(null!);
 
 		// Assert
 		Assert.AreEqual(string.Empty, actualPath);
@@ -141,10 +126,10 @@ public class PathHelperTests
 	public void RemoveLatestSlash_ReturnsEmptyString_WhenBasePathIsEmpty()
 	{
 		// Arrange
-		string basePath = string.Empty;
+		var basePath = string.Empty;
 
 		// Act
-		string actualPath = PathHelper.RemoveLatestSlash(basePath);
+		var actualPath = PathHelper.RemoveLatestSlash(basePath);
 
 		// Assert
 		Assert.AreEqual(string.Empty, actualPath);
@@ -154,10 +139,10 @@ public class PathHelperTests
 	public void RemoveLatestSlash_ReturnsEmptyString_WhenBasePathIsRoot()
 	{
 		// Arrange
-		string basePath = "/";
+		const string basePath = "/";
 
 		// Act
-		string actualPath = PathHelper.RemoveLatestSlash(basePath);
+		var actualPath = PathHelper.RemoveLatestSlash(basePath);
 
 		// Assert
 		Assert.AreEqual(string.Empty, actualPath);
@@ -263,7 +248,7 @@ public class PathHelperTests
 		const string expected = "/test/subfolder/file.txt";
 
 		// Act
-		string result = PathHelper.PrefixDbSlash(subPath);
+		var result = PathHelper.PrefixDbSlash(subPath);
 
 		// Assert
 		Assert.AreEqual(expected, result);
@@ -273,10 +258,10 @@ public class PathHelperTests
 	public void TestRemovePrefixDbSlash_WithLeadingSlash()
 	{
 		// Arrange
-		string subPath = "/path/to/file";
+		const string subPath = "/path/to/file";
 
 		// Act
-		string result = PathHelper.RemovePrefixDbSlash(subPath);
+		var result = PathHelper.RemovePrefixDbSlash(subPath);
 
 		// Assert
 		Assert.AreEqual("path/to/file", result);
@@ -286,10 +271,10 @@ public class PathHelperTests
 	public void TestRemovePrefixDbSlash_WithoutLeadingSlash()
 	{
 		// Arrange
-		string subPath = "path/to/file";
+		const string subPath = "path/to/file";
 
 		// Act
-		string result = PathHelper.RemovePrefixDbSlash(subPath);
+		var result = PathHelper.RemovePrefixDbSlash(subPath);
 
 		// Assert
 		Assert.AreEqual("path/to/file", result);
@@ -302,7 +287,7 @@ public class PathHelperTests
 		const string subPath = "/";
 
 		// Act
-		string result = PathHelper.RemovePrefixDbSlash(subPath);
+		var result = PathHelper.RemovePrefixDbSlash(subPath);
 
 		// Assert
 		Assert.AreEqual(string.Empty, result);
@@ -361,4 +346,65 @@ public class PathHelperTests
 		Assert.AreEqual("/path/to/file1", result[0]);
 		Assert.AreEqual("/path/to/file2", result[1]);
 	}
+
+	private const string TestContentVeryLongString =
+		"this-is-a-really-long-slug-that-goes-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-and-on-and-on-and-on-and-on-and-on-and-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-and-on-and-and-on-and-on-and-on-and-on-and-and-on-and-on-and-on-and-" +
+		"and-on-and-on-and-on-and-on-and-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-and-on-and-on-and-on-and-on-" +
+		"and-and-on-and-on-and-on-and-on-and-on-and-on-and-and-on-and-on-and-on-and-and-on-" +
+		"and-on-and-on-and-and-on-and-on-and-on-and-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-" +
+		"and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and" +
+		"-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on" +
+		"-and-on-and-on-and-on-and-on-and-and-on-and-on-and-on-and-on-and-on-and-on-and-" +
+		"on-and-on-and-on-and-and-on-and-and-on-and-on-and-on-and-and-on-and-and-on-and-" +
+		"on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-and-on-and" +
+		"-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and" +
+		"-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and" +
+		"-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and" +
+		"-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and-and";
 }

--- a/starsky/starskytest/starsky.foundation.platform/Helpers/PathHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Helpers/PathHelperTest.cs
@@ -28,7 +28,7 @@ public class PathHelperTests
 
 	[TestMethod]
 	[ExpectedException(typeof(RegexMatchTimeoutException))]
-	public async Task GetFileName_ReturnsFileName_WithMaliciousInput_UnixOnly()
+	public async Task GetFileName_ReturnsFileName_WithMaliciousInput()
 	{
 		// Act and Assert
 		var test = await
@@ -39,7 +39,7 @@ public class PathHelperTests
 				new MemoryStream(CreateAnImageA6600.Bytes.ToArray()));
 
 		var result = string.Empty;
-		for ( var i = 0; i < 200; i++ )
+		for ( var i = 0; i < 2000; i++ )
 		{
 			result += test + test2 + test + test;
 		}

--- a/starsky/starskytest/starsky.foundation.platform/Helpers/PathHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Helpers/PathHelperTest.cs
@@ -23,6 +23,20 @@ public class PathHelperTests
 		// Assert
 		Assert.AreEqual(expectedFileName, actualFileName);
 	}
+	
+	[DataTestMethod] // [Theory]
+	[DataRow("path/to/file.txt", "file.txt")]
+	[DataRow("/test/file/", "")]
+	[DataRow("/test/file", "file")] // no backslash
+	[DataRow("", "")]
+	public void GetFileNameUnix_ReturnsValidFileName(string input, string expectedFileName)
+	{
+		// Act
+		var actualFileName = PathHelper.GetFileNameUnix(input).ToString();
+
+		// Assert
+		Assert.AreEqual(expectedFileName, actualFileName);
+	}
 
 	[TestMethod]
 	[ExpectedException(typeof(ArgumentException))]

--- a/starsky/starskytest/starsky.foundation.platform/Helpers/PathHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Helpers/PathHelperTest.cs
@@ -39,7 +39,7 @@ public class PathHelperTests
 				new MemoryStream(CreateAnImageA6600.Bytes.ToArray()));
 
 		var result = string.Empty;
-		for ( var i = 0; i < 2000; i++ )
+		for ( var i = 0; i < 1000; i++ )
 		{
 			result += test + test2 + test + test;
 		}


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

```
Failed to execute PeriodicThumbnailScanHostedService with exception message One or more errors occurred. (The Regex engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.) (The Regex engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.) -    at starsky.foundation.platform.Helpers.RetryHelper.DoAsyncWorker[T](Func`1 operation, TimeSpan delay, Int32 maxAttemptCount) in /home/vsts/work/1/s/starsky/starsky.foundation.platform/Helpers/RetryHelper.cs:line 87   at starsky.foundation.database.Query.Query.GetObjectsByFileHashAsync(List`1 fileHashesList, Int32 retryCount) in /home/vsts/work/1/s/starsky/starsky.foundation.database/Query/QueryGetObjectsByFileHashAsync.cs:line 50   at starsky.feature.thumbnail.Services.DatabaseThumbnailGenerationService.StartBackgroundQueue(DateTime endTime) in /home/vsts/work/1/s/starsky/starsky.feature.thumbnail/Services/DatabaseThumbnailGenerationService.cs:line 51   at starsky.feature.thumbnail.Services.PeriodicThumbnailScanHostedService.RunJob(CancellationToken cancellationToken) in /home/vsts/work/1/s/starsky/starsky.feature.thumbnail/Services/PeriodicThumbnailScanHostedService.cs:line 106   at starsky.feature.thumbnail.Services.PeriodicThumbnailScanHostedService.RunJob(CancellationToken cancellationToken) in /home/vsts/work/1/s/starsky/starsky.feature.thumbnail/Services/PeriodicThumbnailScanHostedService.cs:line 112 -    at System.Text.RegularExpressions.RegexRunner.<CheckTimeout>g__ThrowRegexTimeout|25_0()   at System.Text.RegularExpressions.Generated.<RegexGenerator_g>F98A139365790CDF5422F6679F18BCAC76A69077D03DB0F256D624263779DCA15__GetFileNameRegex_12.RunnerFactory.Runner.TryMatchAtCurrentPosition(ReadOnlySpan`1 inputSpan) in /home/vsts/work/1/s/starsky/starsky.foundation.platform/System.Text.RegularExpressions.Generator/System.Text.RegularExpressions.Generator.RegexGenerator/RegexGenerator.g.cs:line 1814   at System.Text.RegularExpressions.Generated.<RegexGenerator_g>F98A139365790CDF5422F6679F18BCAC76A69077D03DB0F256D624263779DCA15__GetFileNameRegex_12.RunnerFactory.Runner.Scan(ReadOnlySpan`1 inputSpan) in /home/vsts/work/1/s/starsky/starsky.foundation.platform/System.Text.RegularExpressions.Generator/System.Text.RegularExpressions.Generator.RegexGenerator/RegexGenerator.g.cs:line 1721   at System.Text.RegularExpressions.Regex.ScanInternal(RegexRunnerMode mode, Boolean reuseMatchObject, String input, Int32 beginning, RegexRunner runner, ReadOnlySpan`1 span, Boolean returnNullIfReuseMatchObject)   at System.Text.RegularExpressions.Regex.RunSingleMatch(RegexRunnerMode mode, Int32 prevlen, String input, Int32 beginning, Int32 length, Int32 startat)   at starsky.foundation.platform.Helpers.PathHelper.GetFileName(String filePath) in /home/vsts/work/1/s/starsky/starsky.foundation.platform/Helpers/PathHelper.cs:line 35   at starsky.foundation.database.Models.FileIndexItem.SetFilePath(String value) in /home/vsts/work/1/s/starsky/starsky.foundation.database/Models/FileIndexItem.cs:line 84   at lambda_method171(Closure, QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator)   at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable`1.AsyncEnumerator.MoveNextAsync()   at Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync[TSource](IQueryable`1 source, CancellationToken cancellationToken)   at Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync[TSource](IQueryable`1 source, CancellationToken cancellationToken)   at starsky.foundation.database.Query.Query.<>c__DisplayClass55_0.<<GetObjectsByFileHashAsync>g__LocalQuery|0>d.MoveNext() in /home/vsts/work/1/s/starsky/starsky.foundation.database/Query/QueryGetObjectsByFileHashAsync.cs:line 28--- End of stack trace from previous location ---   at starsky.foundation.database.Query.Query.<>c__DisplayClass55_0.<<GetObjectsByFileHashAsync>g__LocalDefaultQuery|1>d.MoveNext() in /home/vsts/work/1/s/starsky/starsky.foundation.database/Query/QueryGetObjectsByFileHashAsync.cs:line 47--- End of stack trace from previous location ---   at starsky.foundation.platform.Helpers.RetryHelper.DoAsyncWorker[T](Func`1 operation, TimeSpan delay, Int32 maxAttemptCount) in /home/vsts/work/1/s/starsky/starsky.foundation.platform/Helpers/RetryHelper.cs:line 80
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
