### PR TITLE
.NET SDK Upgrade to 8.0.401

### DIFF
--- a/.github/workflows/desktop-release-on-tag-net-electron.yml
+++ b/.github/workflows/desktop-release-on-tag-net-electron.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.400
+          dotnet-version: 8.0.401
 
       - name: Build --no-unit-test linux-arm,linux-arm64,win-x64,osx-x64,linux-x64,osx-arm64 --ready-to-run
         shell: bash

--- a/.github/workflows/webapp-build-net-macos.yml
+++ b/.github/workflows/webapp-build-net-macos.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.400
+        dotnet-version: 8.0.401
         
     - name: "BuildNetCore (MacOS)"
       shell: bash

--- a/.github/workflows/webapp-build-net-ubuntu.yml
+++ b/.github/workflows/webapp-build-net-ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.400
+        dotnet-version: 8.0.401
 
     - name: Cache nuget packages (*nix)
       uses: actions/cache@v4

--- a/.github/workflows/webapp-build-net-windows.yml
+++ b/.github/workflows/webapp-build-net-windows.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.400
+        dotnet-version: 8.0.401
         
     - name: Build (Windows)
       shell: pwsh

--- a/.github/workflows/webapp-codecov-clientapp-netcore.yml
+++ b/.github/workflows/webapp-codecov-clientapp-netcore.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.400
+          dotnet-version: 8.0.401
  
       - name: Cache node modules clientapp (*nix)
         uses: actions/cache@v4

--- a/.github/workflows/webapp-sonarqube-clientapp-netcore.yml
+++ b/.github/workflows/webapp-sonarqube-clientapp-netcore.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.400
+          dotnet-version: 8.0.401
         
       - name: Use Java 17   
         uses: actions/setup-java@v4

--- a/.github/workflows/webapp-update-swagger-dotnet.yml
+++ b/.github/workflows/webapp-update-swagger-dotnet.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.400
+        dotnet-version: 8.0.401
 
     - name: Cache nuget packages (*nix)
       uses: actions/cache@v4

--- a/pipelines/azure/steps/use_dotnet_version.yml
+++ b/pipelines/azure/steps/use_dotnet_version.yml
@@ -1,8 +1,8 @@
 steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET SDK 8.0.400'
+    displayName: 'Use .NET SDK 8.0.401'
     enabled: true
     inputs:
       packageType: sdk
-      version: 8.0.400
+      version: 8.0.401
       installationPath: $(Agent.ToolsDirectory)/dotnet

--- a/starsky/global.json
+++ b/starsky/global.json
@@ -1,7 +1,7 @@
 {
     "strictVersion": true,
     "sdk": {
-        "version": "8.0.400",
+        "version": "8.0.401",
         "rollForward": "disable",
         "allowPrerelease": false
     }


### PR DESCRIPTION
## Upgrade of .NET with newer SDK Version
- Install SDK version 8.0.401 on your development machine https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.8/8.0.8.md
- First test on linux-arm test envs before approve
- update azure runtime on test https://demostarsky.scm.azurewebsites.net/
- update docs with minimal version https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.401/starsky/readme.md
- update changelog https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.401/history.md

## When upgrading a major version
- when upgrading to newer major release check docker