### PR TITLE
Feature/202411 notification error

### DIFF
--- a/history.md
+++ b/history.md
@@ -42,7 +42,8 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 ## List of versions
 
 ## version 0.6.4 - _(Unreleased)_ - 2024-11-?? {#v0.6.3}
-- nothing yet
+
+- [x] (Fixed) _Back-end_ Notification duplicate error handling (Issue #1832) (PR #1834)
   
 ## version 0.6.3 - 2024-11-14 {#v0.6.3}
 

--- a/starsky/starsky.feature.thumbnail/Services/PeriodicThumbnailScanHostedService.cs
+++ b/starsky/starsky.feature.thumbnail/Services/PeriodicThumbnailScanHostedService.cs
@@ -82,7 +82,9 @@ public class PeriodicThumbnailScanHostedService : BackgroundService
 		catch ( OperationCanceledException exception )
 		{
 			_logger.LogError(
-				$"[StartBackgroundAsync] catch-ed OperationCanceledException {exception.Message}",
+				$"[StartBackgroundAsync] catch-ed OperationCanceledException " +
+				$"Src:{exception.Source} Mes:{exception.Message} SaTtr:{exception.StackTrace}" +
+				$" Inner:{exception.InnerException?.StackTrace} HRes:{exception.HResult}",
 				exception);
 		}
 

--- a/starsky/starsky.foundation.database/Notifications/NotificationQuery.cs
+++ b/starsky/starsky.foundation.database/Notifications/NotificationQuery.cs
@@ -33,13 +33,6 @@ public sealed class NotificationQuery : INotificationQuery
 		_scopeFactory = scopeFactory;
 	}
 
-	public Task<NotificationItem> AddNotification<T>(ApiNotificationResponseModel<T> content)
-	{
-		var stringMessage = JsonSerializer.Serialize(content,
-			DefaultJsonSerializer.CamelCaseNoEnters);
-		return AddNotification(stringMessage);
-	}
-
 	public Task<List<NotificationItem>> GetNewerThan(DateTime parsedDateTime)
 	{
 		var unixTime = ( ( DateTimeOffset ) parsedDateTime ).ToUnixTimeSeconds() - 1;
@@ -58,6 +51,24 @@ public sealed class NotificationQuery : INotificationQuery
 		await _context.SaveChangesAsync();
 	}
 
+	/// <summary>
+	///     Add notification to the database
+	/// </summary>
+	/// <param name="content">Content</param>
+	/// <typeparam name="T">Type</typeparam>
+	/// <returns>DatabaseItem</returns>
+	public Task<NotificationItem> AddNotification<T>(ApiNotificationResponseModel<T> content)
+	{
+		var stringMessage = JsonSerializer.Serialize(content,
+			DefaultJsonSerializer.CamelCaseNoEnters);
+		return AddNotification(stringMessage);
+	}
+
+	/// <summary>
+	///     Add content to database
+	/// </summary>
+	/// <param name="content">json content</param>
+	/// <returns>item with id</returns>
 	public async Task<NotificationItem> AddNotification(string content)
 	{
 		var item = new NotificationItem

--- a/starsky/starsky.foundation.database/Notifications/NotificationQuery.cs
+++ b/starsky/starsky.foundation.database/Notifications/NotificationQuery.cs
@@ -120,8 +120,8 @@ public sealed class NotificationQuery : INotificationQuery
 				}
 				else
 				{
-					_logger.LogInformation(updateException,
-						"[AddNotification] save failed");
+					_logger.LogError(updateException,
+						$"[AddNotification] no solution maybe retry? M: {updateException.Message}");
 					throw;
 				}
 			}

--- a/starsky/starsky.foundation.database/Notifications/NotificationQuery.cs
+++ b/starsky/starsky.foundation.database/Notifications/NotificationQuery.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using starsky.foundation.database.Data;
@@ -15,49 +16,76 @@ using starsky.foundation.platform.Interfaces;
 using starsky.foundation.platform.JsonConverter;
 using starsky.foundation.platform.Models;
 
-namespace starsky.foundation.database.Notifications
+namespace starsky.foundation.database.Notifications;
+
+[Service(typeof(INotificationQuery), InjectionLifetime = InjectionLifetime.Scoped)]
+public sealed class NotificationQuery : INotificationQuery
 {
-	[Service(typeof(INotificationQuery), InjectionLifetime = InjectionLifetime.Scoped)]
-	public sealed class NotificationQuery : INotificationQuery
+	private readonly ApplicationDbContext _context;
+	private readonly IWebLogger _logger;
+	private readonly IServiceScopeFactory _scopeFactory;
+
+	public NotificationQuery(ApplicationDbContext context, IWebLogger logger,
+		IServiceScopeFactory scopeFactory)
 	{
-		private readonly ApplicationDbContext _context;
-		private readonly IWebLogger _logger;
-		private readonly IServiceScopeFactory _scopeFactory;
+		_context = context;
+		_logger = logger;
+		_scopeFactory = scopeFactory;
+	}
 
-		public NotificationQuery(ApplicationDbContext context, IWebLogger logger,
-			IServiceScopeFactory scopeFactory)
+	public Task<NotificationItem> AddNotification<T>(ApiNotificationResponseModel<T> content)
+	{
+		var stringMessage = JsonSerializer.Serialize(content,
+			DefaultJsonSerializer.CamelCaseNoEnters);
+		return AddNotification(stringMessage);
+	}
+
+	public Task<List<NotificationItem>> GetNewerThan(DateTime parsedDateTime)
+	{
+		var unixTime = ( ( DateTimeOffset ) parsedDateTime ).ToUnixTimeSeconds() - 1;
+		return _context.Notifications.Where(x => x.DateTimeEpoch > unixTime).ToListAsync();
+	}
+
+	public Task<List<NotificationItem>> GetOlderThan(DateTime parsedDateTime)
+	{
+		var unixTime = ( ( DateTimeOffset ) parsedDateTime ).ToUnixTimeSeconds();
+		return _context.Notifications.Where(x => x.DateTimeEpoch < unixTime).ToListAsync();
+	}
+
+	public async Task RemoveAsync(IEnumerable<NotificationItem> content)
+	{
+		_context.Notifications.RemoveRange(content);
+		await _context.SaveChangesAsync();
+	}
+
+	public async Task<NotificationItem> AddNotification(string content)
+	{
+		var item = new NotificationItem
 		{
-			_context = context;
-			_logger = logger;
-			_scopeFactory = scopeFactory;
-		}
+			DateTime = DateTime.UtcNow,
+			DateTimeEpoch = DateTimeOffset.Now.ToUnixTimeSeconds(),
+			Content = content
+		};
 
-		public async Task<NotificationItem> AddNotification(string content)
+		return await RetryHelper.DoAsync(LocalAddQuery, TimeSpan.FromSeconds(1));
+
+		async Task<NotificationItem> LocalAdd(ApplicationDbContext context)
 		{
-			var item = new NotificationItem
+			try
 			{
-				DateTime = DateTime.UtcNow,
-				DateTimeEpoch = DateTimeOffset.Now.ToUnixTimeSeconds(),
-				Content = content
-			};
-
-			return await RetryHelper.DoAsync(LocalAddQuery, TimeSpan.FromSeconds(1));
-
-			async Task<NotificationItem> LocalAdd(ApplicationDbContext context)
+				context.Entry(item).State = EntityState.Added;
+				await context.Notifications.AddAsync(item);
+				await context.SaveChangesAsync();
+				return item;
+			}
+			catch ( DbUpdateException updateException )
 			{
-				try
-				{
-					context.Entry(item).State = EntityState.Added;
-					await context.Notifications.AddAsync(item);
-					await context.SaveChangesAsync();
-					return item;
-				}
-				catch ( DbUpdateConcurrencyException concurrencyException )
+				if ( updateException is DbUpdateConcurrencyException )
 				{
 					_logger.LogInformation(
 						"[AddNotification] try to fix DbUpdateConcurrencyException",
-						concurrencyException);
-					SolveConcurrency.SolveConcurrencyExceptionLoop(concurrencyException.Entries);
+						updateException);
+					SolveConcurrency.SolveConcurrencyExceptionLoop(updateException.Entries);
 					try
 					{
 						await _context.SaveChangesAsync();
@@ -68,48 +96,40 @@ namespace starsky.foundation.database.Notifications
 							"[AddNotification] save failed after DbUpdateConcurrencyException");
 					}
 				}
+				else if ( updateException.InnerException is SqliteException
+				         {
+					         SqliteErrorCode: 19
+				         } )
+				{
+					_logger.LogInformation($"[AddNotification] SqliteException retry next: " +
+					                       $"{updateException.InnerException.Message}");
 
-				return item;
+					item.Id = 0;
+					await LocalAddQuery();
+				}
+				else
+				{
+					_logger.LogInformation(updateException,
+						"[AddNotification] save failed");
+					throw;
+				}
 			}
 
-			async Task<NotificationItem> LocalAddQuery()
+			return item;
+		}
+
+		async Task<NotificationItem> LocalAddQuery()
+		{
+			try
 			{
-				try
-				{
-					return await LocalAdd(_context);
-				}
-				catch ( ObjectDisposedException )
-				{
-					// Include create new scope factory
-					var context = new InjectServiceScope(_scopeFactory).Context();
-					return await LocalAdd(context);
-				}
+				return await LocalAdd(_context);
 			}
-		}
-
-		public Task<NotificationItem> AddNotification<T>(ApiNotificationResponseModel<T> content)
-		{
-			var stringMessage = JsonSerializer.Serialize(content,
-				DefaultJsonSerializer.CamelCaseNoEnters);
-			return AddNotification(stringMessage);
-		}
-
-		public Task<List<NotificationItem>> GetNewerThan(DateTime parsedDateTime)
-		{
-			var unixTime = ( ( DateTimeOffset ) parsedDateTime ).ToUnixTimeSeconds() - 1;
-			return _context.Notifications.Where(x => x.DateTimeEpoch > unixTime).ToListAsync();
-		}
-
-		public Task<List<NotificationItem>> GetOlderThan(DateTime parsedDateTime)
-		{
-			var unixTime = ( ( DateTimeOffset ) parsedDateTime ).ToUnixTimeSeconds();
-			return _context.Notifications.Where(x => x.DateTimeEpoch < unixTime).ToListAsync();
-		}
-
-		public async Task RemoveAsync(IEnumerable<NotificationItem> content)
-		{
-			_context.Notifications.RemoveRange(content);
-			await _context.SaveChangesAsync();
+			catch ( ObjectDisposedException )
+			{
+				// Include create new scope factory
+				var context = new InjectServiceScope(_scopeFactory).Context();
+				return await LocalAdd(context);
+			}
 		}
 	}
 }

--- a/starsky/starsky.foundation.webtelemetry/Helpers/SetupLogging.cs
+++ b/starsky/starsky.foundation.webtelemetry/Helpers/SetupLogging.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -9,40 +10,44 @@ using starsky.foundation.platform.Interfaces;
 using starsky.foundation.platform.Models;
 using starsky.foundation.platform.Services;
 
-namespace starsky.foundation.webtelemetry.Helpers
+namespace starsky.foundation.webtelemetry.Helpers;
+
+public static class SetupLogging
 {
-	public static class SetupLogging
+	private const string HostNameKey = "host.name";
+	private static readonly KeyValuePair<string, object> HostNameKeyValue = new(HostNameKey,
+		Environment.MachineName);
+
+	[SuppressMessage("Usage", "S4792:Make sure that this logger's configuration is safe.")]
+	public static void AddTelemetryLogging(this IServiceCollection services,
+		AppSettings appSettings)
 	{
-		[SuppressMessage("Usage", "S4792:Make sure that this logger's configuration is safe.")]
-		public static void AddTelemetryLogging(this IServiceCollection services,
-			AppSettings appSettings)
+		services.AddLogging(logging =>
 		{
-			services.AddLogging(logging =>
+			logging.ClearProviders();
+			logging.AddConsole();
+
+			if ( !string.IsNullOrEmpty(appSettings.OpenTelemetry?.LogsEndpoint) )
 			{
-				logging.ClearProviders();
-				logging.AddConsole();
+				logging.AddOpenTelemetry(
+					builder =>
+						builder.AddOtlpExporter(
+								options =>
+								{
+									options.Protocol = OtlpExportProtocol.HttpProtobuf;
+									options.Headers = appSettings.OpenTelemetry.GetLogsHeader();
+									options.Endpoint =
+										new Uri(appSettings.OpenTelemetry.LogsEndpoint);
+								})
+							.SetResourceBuilder(
+								ResourceBuilder.CreateDefault()
+									.AddService(appSettings.OpenTelemetry.GetServiceName())
+									.AddAttributes([HostNameKeyValue])
+							)
+				);
+			}
+		});
 
-				if ( !string.IsNullOrEmpty(appSettings.OpenTelemetry?.LogsEndpoint) )
-				{
-					logging.AddOpenTelemetry(
-						builder =>
-							builder.AddOtlpExporter(
-									options =>
-									{
-										options.Protocol = OtlpExportProtocol.HttpProtobuf;
-										options.Headers = appSettings.OpenTelemetry.GetLogsHeader();
-										options.Endpoint =
-											new Uri(appSettings.OpenTelemetry.LogsEndpoint);
-									})
-								.SetResourceBuilder(
-									ResourceBuilder.CreateDefault()
-										.AddService(appSettings.OpenTelemetry.GetServiceName())
-								)
-					);
-				}
-			});
-
-			services.AddScoped<IWebLogger, WebLogger>();
-		}
+		services.AddScoped<IWebLogger, WebLogger>();
 	}
 }

--- a/starsky/starskytest/starsky.foundation.database/NotificationsTest/NotificationQueryErrorTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/NotificationsTest/NotificationQueryErrorTest.cs
@@ -12,187 +12,186 @@ using starsky.foundation.database.Data;
 using starsky.foundation.database.Notifications;
 using starskytest.FakeMocks;
 
-namespace starskytest.starsky.foundation.database.NotificationsTest
+namespace starskytest.starsky.foundation.database.NotificationsTest;
+
+/// <summary>
+///     Error cases
+/// </summary>
+[TestClass]
+public sealed class NotificationQueryErrorTest
 {
-	
-	[TestClass]
-	public sealed class NotificationQueryErrorTest
+	private static bool IsCalledDbUpdateConcurrency { get; set; }
+
+	[TestMethod]
+	public async Task AddNotification_ConcurrencyException()
 	{
-		private static bool IsCalledDbUpdateConcurrency { get; set; }
+		IsCalledDbUpdateConcurrency = false;
+		var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+			.UseInMemoryDatabase("MovieListDatabase")
+			.Options;
 
-		private class UpdateEntryUpdateConcurrency : IUpdateEntry
-		{
-			public void SetOriginalValue(IProperty property, object? value)
-			{
-				throw new NotImplementedException();
-			}
-		
-			public void SetPropertyModified(IProperty property)
-			{
-				throw new NotImplementedException();
-			}
-		
-			public bool IsModified(IProperty property)
-			{
-				throw new NotImplementedException();
-			}
-		
-			public bool HasTemporaryValue(IProperty property)
-			{
-				throw new NotImplementedException();
-			}
-		
-			public bool IsStoreGenerated(IProperty property)
-			{
-				throw new NotImplementedException();
-			}
+		var fakeQuery = new NotificationQuery(
+			new AppDbContextConcurrencyException(options) { MinCount = 1 }, new FakeIWebLogger(),
+			null!);
+		await fakeQuery.AddNotification("");
 
-			public TProperty GetCurrentValue<TProperty>(IPropertyBase propertyBase)
-			{
-				throw new NotImplementedException();
-			}
-			
-			public object GetCurrentValue(IPropertyBase propertyBase)
-			{
-				throw new NotImplementedException();
-			}
-		
-			public TProperty GetOriginalValue<TProperty>(IProperty property)
-			{
-				throw new NotImplementedException();
-			}
-
-			public object GetOriginalValue(IPropertyBase propertyBase)
-			{
-				throw new NotImplementedException();
-			}
-			
-			public void SetStoreGeneratedValue(IProperty property, object? value,
-				bool setModified = true)
-			{
-				throw new NotImplementedException();
-			}
-			
-			public EntityEntry ToEntityEntry()
-			{
-				IsCalledDbUpdateConcurrency = true;
-				throw new DbUpdateConcurrencyException();
-				// System.NullReferenceException: Object reference not set to an instance of an object.
-			}
-
-			public object GetRelationshipSnapshotValue(IPropertyBase propertyBase)
-			{
-				throw new NotImplementedException();
-			}
-
-			public object GetPreStoreGeneratedCurrentValue(IPropertyBase propertyBase)
-			{
-				throw new NotImplementedException();
-			}
-
-			public bool IsConceptualNull(IProperty property)
-			{
-				throw new NotImplementedException();
-			}
-
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-			[SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")] 
-			public DbContext Context { get; }
-
-			// ReSharper disable once UnassignedGetOnlyAutoProperty
-			public IEntityType EntityType { get; }
-
-			public EntityState EntityState { get; set; }
-
-			// ReSharper disable once UnassignedGetOnlyAutoProperty
-			public IUpdateEntry SharedIdentityEntry { get; }
-#pragma warning restore 8618
-		}
-	
-		private class AppDbContextConcurrencyException : ApplicationDbContext
-		{
-			public AppDbContextConcurrencyException(DbContextOptions options) : base(options)
-			{
-			}
-
-			public int MinCount { get; set; }
-			
-			private int Count { get; set; }
-
-			public override int SaveChanges()
-			{
-				Count++;
-				if ( Count <= MinCount )
-				{
-					throw new DbUpdateConcurrencyException("t",
-						new List<IUpdateEntry>{new UpdateEntryUpdateConcurrency()});
-				}
-				return Count;
-			}	
-			
-			public override Task<int> SaveChangesAsync(
-				CancellationToken cancellationToken = default)
-			{
-				Count++;
-				if ( Count <= MinCount )
-				{
-					throw new DbUpdateConcurrencyException("t",
-						new List<IUpdateEntry>{new UpdateEntryUpdateConcurrency()});
-				}
-				return Task.FromResult(Count);
-			}
-		}
-		
-		[TestMethod]
-		public async Task AddNotification_ConcurrencyException()
-		{
-			IsCalledDbUpdateConcurrency = false;
-			var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-				.UseInMemoryDatabase(databaseName: "MovieListDatabase")
-				.Options;
-			
-			var fakeQuery = new NotificationQuery(new AppDbContextConcurrencyException(options)
-			{
-				MinCount = 1
-			},new FakeIWebLogger(),null!);
-			await fakeQuery.AddNotification("");
-			
-			Assert.IsTrue(IsCalledDbUpdateConcurrency);
-		}
-		
-		[TestMethod]
-		public async Task AddNotification_DoubleConcurrencyException()
-		{
-			IsCalledDbUpdateConcurrency = false;
-			var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-				.UseInMemoryDatabase(databaseName: "MovieListDatabase")
-				.Options;
-			
-			var fakeQuery = new NotificationQuery(new AppDbContextConcurrencyException(options)
-			{
-				MinCount = 2
-			},new FakeIWebLogger(),null!);
-			await fakeQuery.AddNotification("");
-			
-			Assert.IsTrue(IsCalledDbUpdateConcurrency);
-		}
-		
-		[TestMethod]
-		public async Task AddNotification_3ConcurrencyException()
-		{
-			IsCalledDbUpdateConcurrency = false;
-			var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-				.UseInMemoryDatabase(databaseName: "MovieListDatabase")
-				.Options;
-			
-			var fakeQuery = new NotificationQuery(new AppDbContextConcurrencyException(options)
-			{
-				MinCount = 3
-			},new FakeIWebLogger(),null!);
-			await fakeQuery.AddNotification("");
-			
-			Assert.IsTrue(IsCalledDbUpdateConcurrency);
-		}
+		Assert.IsTrue(IsCalledDbUpdateConcurrency);
 	}
 
+	[TestMethod]
+	public async Task AddNotification_DoubleConcurrencyException()
+	{
+		IsCalledDbUpdateConcurrency = false;
+		var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+			.UseInMemoryDatabase("MovieListDatabase")
+			.Options;
+
+		var fakeQuery = new NotificationQuery(
+			new AppDbContextConcurrencyException(options) { MinCount = 2 }, new FakeIWebLogger(),
+			null!);
+		await fakeQuery.AddNotification("");
+
+		Assert.IsTrue(IsCalledDbUpdateConcurrency);
+	}
+
+	[TestMethod]
+	public async Task AddNotification_3ConcurrencyException()
+	{
+		IsCalledDbUpdateConcurrency = false;
+		var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+			.UseInMemoryDatabase("MovieListDatabase")
+			.Options;
+
+		var fakeQuery = new NotificationQuery(
+			new AppDbContextConcurrencyException(options) { MinCount = 3 }, new FakeIWebLogger(),
+			null!);
+		await fakeQuery.AddNotification("");
+
+		Assert.IsTrue(IsCalledDbUpdateConcurrency);
+	}
+
+	private class UpdateEntryUpdateConcurrency : IUpdateEntry
+	{
+		public void SetOriginalValue(IProperty property, object? value)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void SetPropertyModified(IProperty property)
+		{
+			throw new NotImplementedException();
+		}
+
+		public bool IsModified(IProperty property)
+		{
+			throw new NotImplementedException();
+		}
+
+		public bool HasTemporaryValue(IProperty property)
+		{
+			throw new NotImplementedException();
+		}
+
+		public bool IsStoreGenerated(IProperty property)
+		{
+			throw new NotImplementedException();
+		}
+
+		public TProperty GetCurrentValue<TProperty>(IPropertyBase propertyBase)
+		{
+			throw new NotImplementedException();
+		}
+
+		public object GetCurrentValue(IPropertyBase propertyBase)
+		{
+			throw new NotImplementedException();
+		}
+
+		public TProperty GetOriginalValue<TProperty>(IProperty property)
+		{
+			throw new NotImplementedException();
+		}
+
+		public object GetOriginalValue(IPropertyBase propertyBase)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void SetStoreGeneratedValue(IProperty property, object? value,
+			bool setModified = true)
+		{
+			throw new NotImplementedException();
+		}
+
+		public EntityEntry ToEntityEntry()
+		{
+			IsCalledDbUpdateConcurrency = true;
+			throw new DbUpdateConcurrencyException();
+			// System.NullReferenceException: Object reference not set to an instance of an object.
+		}
+
+		public object GetRelationshipSnapshotValue(IPropertyBase propertyBase)
+		{
+			throw new NotImplementedException();
+		}
+
+		public object GetPreStoreGeneratedCurrentValue(IPropertyBase propertyBase)
+		{
+			throw new NotImplementedException();
+		}
+
+		public bool IsConceptualNull(IProperty property)
+		{
+			throw new NotImplementedException();
+		}
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+		[SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")]
+		public DbContext Context { get; }
+
+		// ReSharper disable once UnassignedGetOnlyAutoProperty
+		public IEntityType EntityType { get; }
+
+		public EntityState EntityState { get; set; }
+
+		// ReSharper disable once UnassignedGetOnlyAutoProperty
+		public IUpdateEntry SharedIdentityEntry { get; }
+#pragma warning restore 8618
+	}
+
+	private class AppDbContextConcurrencyException : ApplicationDbContext
+	{
+		public AppDbContextConcurrencyException(DbContextOptions options) : base(options)
+		{
+		}
+
+		public int MinCount { get; set; }
+
+		private int Count { get; set; }
+
+		public override int SaveChanges()
+		{
+			Count++;
+			if ( Count <= MinCount )
+			{
+				throw new DbUpdateConcurrencyException("t",
+					new List<IUpdateEntry> { new UpdateEntryUpdateConcurrency() });
+			}
+
+			return Count;
+		}
+
+		public override Task<int> SaveChangesAsync(
+			CancellationToken cancellationToken = default)
+		{
+			Count++;
+			if ( Count <= MinCount )
+			{
+				throw new DbUpdateConcurrencyException("t",
+					new List<IUpdateEntry> { new UpdateEntryUpdateConcurrency() });
+			}
+
+			return Task.FromResult(Count);
+		}
+	}
 }

--- a/starsky/starskytest/starsky.foundation.database/NotificationsTest/NotificationQueryErrorTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/NotificationsTest/NotificationQueryErrorTest.cs
@@ -80,7 +80,7 @@ public sealed class NotificationQueryErrorTest
 		var options = new DbContextOptionsBuilder<ApplicationDbContext>()
 			.UseInMemoryDatabase(nameof(AddNotification_ShouldHandleUniqueConstraintError))
 			.Options;
-		var context = new DbUpdateExceptionException(options)
+		var context = new DbUpdateExceptionApplicationDbContext(options)
 		{
 			MinCount = 1, InnerException = new SqliteException("t", 19, 19)
 		};
@@ -93,7 +93,7 @@ public sealed class NotificationQueryErrorTest
 		Assert.IsNotNull(result);
 		Assert.AreEqual(content, result.Content);
 	}
-	
+
 	[TestMethod]
 	public async Task AddNotification_ShouldRetry_GeneralException()
 	{
@@ -102,7 +102,7 @@ public sealed class NotificationQueryErrorTest
 		var options = new DbContextOptionsBuilder<ApplicationDbContext>()
 			.UseInMemoryDatabase(nameof(AddNotification_ShouldHandleUniqueConstraintError))
 			.Options;
-		var context = new DbUpdateExceptionException(options)
+		var context = new DbUpdateExceptionApplicationDbContext(options)
 		{
 			MinCount = 1, InnerException = new AggregateException("test")
 		};
@@ -205,14 +205,14 @@ public sealed class NotificationQueryErrorTest
 #pragma warning restore 8618
 	}
 
-	private class DbUpdateExceptionException(DbContextOptions options)
+	private class DbUpdateExceptionApplicationDbContext(DbContextOptions options)
 		: ApplicationDbContext(options)
 	{
-		public int MinCount { get; set; }
+		public required int MinCount { get; set; }
 
 		private int Count { get; set; }
 
-		public Exception InnerException { get; set; }
+		public required Exception InnerException { get; set; }
 
 		public override Task<int> SaveChangesAsync(
 			CancellationToken cancellationToken = default)


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request includes several updates and improvements across multiple files to enhance error handling, namespace usage, and logging. The most important changes include improving exception logging, updating namespaces to modern C# syntax, adding new methods for notification queries, and enhancing test coverage for error cases.

### Improvements to exception logging:
* [`starsky/starsky.feature.thumbnail/Services/PeriodicThumbnailScanHostedService.cs`](diffhunk://#diff-b1ca3443e210f1176d3ca43bc2efd3b94d918e45a3be6d11b2e707c5b21fd81fL85-R87): Enhanced the logging of `OperationCanceledException` to include additional details such as source, stack trace, inner exception, and HRESULT.

### Namespace updates:
* [`starsky/starsky.foundation.database/Notifications/NotificationQuery.cs`](diffhunk://#diff-5e493377f01681ba7d72ce0481a7ffcc82a65c15b027dd487d72ff39bfe1ba11L18-R20): Updated the namespace declaration to use modern C# syntax.
* [`starsky/starsky.foundation.webtelemetry/Helpers/SetupLogging.cs`](diffhunk://#diff-bf91ba1751ffb9f92e6fcec76bc4d73bbb27710b3f9c92c21142a086eec0cb0dL12-R20): Updated the namespace declaration to use modern C# syntax.
* [`starsky/starskytest/starsky.foundation.database/NotificationsTest/NotificationQueryErrorTest.cs`](diffhunk://#diff-f7bedb934b5060e0a8b663b6d381a34d572517b7f6c00327b6476806c253edd8L15-R118): Updated the namespace declaration to use modern C# syntax.

### Notification query enhancements:
* [`starsky/starsky.foundation.database/Notifications/NotificationQuery.cs`](diffhunk://#diff-5e493377f01681ba7d72ce0481a7ffcc82a65c15b027dd487d72ff39bfe1ba11R36-R71): Added new methods for querying notifications by date and for removing notifications, as well as handling `DbUpdateException` and `SqliteException` during notification addition. [[1]](diffhunk://#diff-5e493377f01681ba7d72ce0481a7ffcc82a65c15b027dd487d72ff39bfe1ba11R36-R71) [[2]](diffhunk://#diff-5e493377f01681ba7d72ce0481a7ffcc82a65c15b027dd487d72ff39bfe1ba11L55-R99) [[3]](diffhunk://#diff-5e493377f01681ba7d72ce0481a7ffcc82a65c15b027dd487d72ff39bfe1ba11R110-R127) [[4]](diffhunk://#diff-5e493377f01681ba7d72ce0481a7ffcc82a65c15b027dd487d72ff39bfe1ba11L89-L114)

### Logging setup improvements:
* [`starsky/starsky.foundation.webtelemetry/Helpers/SetupLogging.cs`](diffhunk://#diff-bf91ba1751ffb9f92e6fcec76bc4d73bbb27710b3f9c92c21142a086eec0cb0dR45): Added hostname attribute to telemetry logging configuration.

### Test coverage enhancements:
* [`starsky/starskytest/starsky.foundation.database/NotificationsTest/NotificationQueryErrorTest.cs`](diffhunk://#diff-f7bedb934b5060e0a8b663b6d381a34d572517b7f6c00327b6476806c253edd8R208-R230): Added new test methods to cover error cases such as concurrency exceptions, unique constraint violations, and general exceptions during notification addition. [[1]](diffhunk://#diff-f7bedb934b5060e0a8b663b6d381a34d572517b7f6c00327b6476806c253edd8R208-R230) [[2]](diffhunk://#diff-f7bedb934b5060e0a8b663b6d381a34d572517b7f6c00327b6476806c253edd8R249) [[3]](diffhunk://#diff-f7bedb934b5060e0a8b663b6d381a34d572517b7f6c00327b6476806c253edd8L142-L197)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
