### PR TITLE
move / to const to be more clear

### DIFF
--- a/starsky/starsky.foundation.database/Helpers/Breadcrumbs.cs
+++ b/starsky/starsky.foundation.database/Helpers/Breadcrumbs.cs
@@ -6,6 +6,8 @@ namespace starsky.foundation.database.Helpers;
 
 public static class Breadcrumbs
 {
+	private const string PathSeparatorAlwaysUnixStyle = "/";
+
 	/// <summary>
 	///     Breadcrumb returns a list of parent folders
 	///     it does not contain the current folder
@@ -24,14 +26,14 @@ public static class Breadcrumbs
 
 		var breadcrumb = new List<string>();
 
-		var filePathArray = filePath.Split("/".ToCharArray());
+		var filePathArray = filePath.Split(PathSeparatorAlwaysUnixStyle.ToCharArray());
 
 		var dir = 0;
 		while ( dir < filePathArray.Length - 1 )
 		{
 			if ( string.IsNullOrEmpty(filePathArray[dir]) )
 			{
-				breadcrumb.Add("/");
+				breadcrumb.Add(PathSeparatorAlwaysUnixStyle);
 			}
 			else
 			{
@@ -41,7 +43,7 @@ public static class Breadcrumbs
 				{
 					if ( !string.IsNullOrEmpty(filePathArray[i]) )
 					{
-						itemStringBuilder.Append("/" + filePathArray[i]);
+						itemStringBuilder.Append(PathSeparatorAlwaysUnixStyle + filePathArray[i]);
 					}
 				}
 
@@ -59,7 +61,7 @@ public static class Breadcrumbs
 		filePath = PathHelper.RemoveLatestBackslash(filePath) ?? string.Empty;
 		if ( string.IsNullOrEmpty(filePath) )
 		{
-			filePath = "/";
+			filePath = PathSeparatorAlwaysUnixStyle;
 		}
 
 		return filePath;
@@ -67,9 +69,9 @@ public static class Breadcrumbs
 
 	private static string ShouldPrefixWithSlash(string filePath)
 	{
-		if ( filePath[0].ToString() != "/" )
+		if ( filePath[0].ToString() != PathSeparatorAlwaysUnixStyle )
 		{
-			filePath = "/" + filePath;
+			filePath = PathSeparatorAlwaysUnixStyle + filePath;
 		}
 
 		return filePath;

--- a/starsky/starsky.foundation.platform/Helpers/PathHelper.cs
+++ b/starsky/starsky.foundation.platform/Helpers/PathHelper.cs
@@ -4,215 +4,224 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 
-namespace starsky.foundation.platform.Helpers
+namespace starsky.foundation.platform.Helpers;
+
+public static class PathHelper
 {
-	public static class PathHelper
+	private const char PathSeparatorAlwaysUnixStyle = '/';
+
+	/// <summary>
+	///     Return value (works for POSIX/Windows paths)
+	/// </summary>
+	/// <param name="filePath">path to parse</param>
+	/// <returns></returns>
+	public static string GetFileName(string? filePath)
 	{
-		/// <summary>
-		/// Return value (works for POSIX/Windows paths)
-		/// </summary>
-		/// <param name="filePath">path to parse</param>
-		/// <returns></returns>
-		public static string GetFileName(string? filePath)
+		if ( string.IsNullOrEmpty(filePath) )
 		{
-			if ( string.IsNullOrEmpty(filePath) )
-			{
-				return string.Empty;
-			}
-
-			if ( filePath.Length >= 4095 )
-			{
-				// why? https://serverfault.com/questions/9546/filename-length-limits-on-linux
-				throw new ArgumentException("[PathHelper] FilePath over Unix limits", nameof(filePath));
-			}
-
-			var fileName = GetFileNameUnix(filePath.AsSpan());
-			return fileName.ToString();
+			return string.Empty;
 		}
 
-		[SuppressMessage("Style", "IDE0057:Use range operator")]
-		[SuppressMessage("ReSharper", "ReplaceSliceWithRangeIndexer")]
-		internal static ReadOnlySpan<char> GetFileNameUnix(ReadOnlySpan<char> path)
+		if ( filePath.Length >= 4095 )
 		{
-			var length = GetPathRootUnix(path).Length;
-			var num = path.LastIndexOf('/');
-			return path.Slice(num < length ? length : num + 1);
+			// why? https://serverfault.com/questions/9546/filename-length-limits-on-linux
+			throw new ArgumentException("[PathHelper] FilePath over Unix limits", nameof(filePath));
 		}
 
-		private static ReadOnlySpan<char> GetPathRootUnix(ReadOnlySpan<char> path)
+		var fileName = GetFileNameUnix(filePath.AsSpan());
+		return fileName.ToString();
+	}
+
+	[SuppressMessage("Style", "IDE0057:Use range operator")]
+	[SuppressMessage("ReSharper", "ReplaceSliceWithRangeIndexer")]
+	internal static ReadOnlySpan<char> GetFileNameUnix(ReadOnlySpan<char> path)
+	{
+		var length = GetPathRootUnix(path).Length;
+		var num = path.LastIndexOf(PathSeparatorAlwaysUnixStyle);
+		return path.Slice(num < length ? length : num + 1);
+	}
+
+	private static ReadOnlySpan<char> GetPathRootUnix(ReadOnlySpan<char> path)
+	{
+		return !IsPathRootedUnix(path) ? [] : $"{PathSeparatorAlwaysUnixStyle}".AsSpan();
+	}
+
+	private static bool IsPathRootedUnix(ReadOnlySpan<char> path)
+	{
+		return path.Length > 0 && path[0] == PathSeparatorAlwaysUnixStyle;
+	}
+
+	/// <summary>
+	///     Removes the latest backslash. Path.DirectorySeparatorChar
+	/// </summary>
+	/// <param name="basePath">The base path.</param>
+	/// <returns></returns>
+	public static string? RemoveLatestBackslash(string basePath = "/")
+	{
+		if ( string.IsNullOrWhiteSpace(basePath) )
 		{
-			return !IsPathRootedUnix(path) ? [] : "/".AsSpan();
+			return null;
 		}
 
-		private static bool IsPathRootedUnix(ReadOnlySpan<char> path) =>
-			path.Length > 0 && path[0] == '/';
-
-		/// <summary>
-		/// Removes the latest backslash. Path.DirectorySeparatorChar
-		/// </summary>
-		/// <param name="basePath">The base path.</param>
-		/// <returns></returns>
-		public static string? RemoveLatestBackslash(string basePath = "/")
+		// Depends on Platform
+		if ( basePath == PathSeparatorAlwaysUnixStyle.ToString() )
 		{
-			if ( string.IsNullOrWhiteSpace(basePath) )
-			{
-				return null;
-			}
-
-			// Depends on Platform
-			if ( basePath == "/" )
-			{
-				return basePath;
-			}
-
-			// remove latest backslash
-			if ( basePath.Substring(basePath.Length - 1, 1) ==
-				 Path.DirectorySeparatorChar.ToString() )
-			{
-				basePath = basePath.Substring(0, basePath.Length - 1);
-			}
-
 			return basePath;
 		}
 
-		/// <summary>
-		/// Removes the latest slash. (/) always unix style
-		/// </summary>
-		/// <param name="basePath">The base path.</param>
-		/// <returns></returns>
-		public static string RemoveLatestSlash(string basePath)
+		// remove latest backslash
+		if ( basePath.Substring(basePath.Length - 1, 1) ==
+		     Path.DirectorySeparatorChar.ToString() )
 		{
-			// don't know why it returns / > string.empty
-
-			// on all platforms the same
-			if ( string.IsNullOrWhiteSpace(basePath) || basePath == "/" )
-			{
-				return string.Empty;
-			}
-
-			// remove latest slash
-			if ( basePath.Substring(basePath.Length - 1, 1) == "/" )
-			{
-				basePath = basePath.Substring(0, basePath.Length - 1);
-			}
-
-			return basePath;
+			basePath = basePath.Substring(0, basePath.Length - 1);
 		}
 
-		/// <summary>
-		/// Add backSlash to configuration // or \\
-		/// Platform depended feature
-		/// </summary>
-		/// <param name="thumbnailTempFolder"></param>
-		/// <returns></returns>
-		public static string AddBackslash(string thumbnailTempFolder)
+		return basePath;
+	}
+
+	/// <summary>
+	///     Removes the latest slash. (/) always unix style
+	/// </summary>
+	/// <param name="basePath">The base path.</param>
+	/// <returns></returns>
+	public static string RemoveLatestSlash(string basePath)
+	{
+		// don't know why it returns / > string.empty
+
+		// on all platforms the same
+		if ( string.IsNullOrWhiteSpace(basePath) ||
+		     basePath == PathSeparatorAlwaysUnixStyle.ToString() )
 		{
-			// Add backSlash to configuration // or \\
-			// Platform depended feature
-			if ( string.IsNullOrWhiteSpace(thumbnailTempFolder) )
-			{
-				return thumbnailTempFolder;
-			}
+			return string.Empty;
+		}
 
-			if ( thumbnailTempFolder.Substring(thumbnailTempFolder.Length - 1,
-					1) != Path.DirectorySeparatorChar.ToString() )
-			{
-				thumbnailTempFolder += Path.DirectorySeparatorChar.ToString();
-			}
+		// remove latest slash
+		if ( basePath.Substring(basePath.Length - 1, 1) == PathSeparatorAlwaysUnixStyle.ToString() )
+		{
+			basePath = basePath.Substring(0, basePath.Length - 1);
+		}
 
+		return basePath;
+	}
+
+	/// <summary>
+	///     Add backSlash to configuration // or \\
+	///     Platform specific feature
+	/// </summary>
+	/// <param name="thumbnailTempFolder"></param>
+	/// <returns></returns>
+	public static string AddBackslash(string thumbnailTempFolder)
+	{
+		// Add backSlash to configuration // or \\
+		// Platform specific feature
+		if ( string.IsNullOrWhiteSpace(thumbnailTempFolder) )
+		{
 			return thumbnailTempFolder;
 		}
 
-		/// <summary>
-		/// Add / to end of file
-		/// </summary>
-		/// <param name="inputFolder">Input folder path</param>
-		/// <returns>value +/</returns>
-		public static string AddSlash(string inputFolder)
+		if ( thumbnailTempFolder.Substring(thumbnailTempFolder.Length - 1,
+			    1) != Path.DirectorySeparatorChar.ToString() )
 		{
-			if ( string.IsNullOrWhiteSpace(inputFolder) )
-			{
-				return inputFolder;
-			}
+			thumbnailTempFolder += Path.DirectorySeparatorChar.ToString();
+		}
 
-			if ( inputFolder.Substring(inputFolder.Length - 1, 1) != "/" )
-			{
-				inputFolder += "/";
-			}
+		return thumbnailTempFolder;
+	}
 
+	/// <summary>
+	///     Add / to end of file
+	/// </summary>
+	/// <param name="inputFolder">Input folder path</param>
+	/// <returns>value +/</returns>
+	public static string AddSlash(string inputFolder)
+	{
+		if ( string.IsNullOrWhiteSpace(inputFolder) )
+		{
 			return inputFolder;
 		}
 
-		/// <summary>
-		/// Add / (always) before string
-		/// </summary>
-		/// <param name="subPath">the subPath</param>
-		/// <returns>/subpath</returns>
-		public static string PrefixDbSlash(string subPath)
+		var lastLetter = inputFolder.Substring(
+			inputFolder.Length - 1, 1);
+		if ( lastLetter !=
+		     PathSeparatorAlwaysUnixStyle.ToString() )
 		{
-			// Add normal linux slash to beginning of the configuration
-			if ( string.IsNullOrWhiteSpace(subPath) )
-			{
-				return "/";
-			}
-
-			if ( subPath.Substring(0, 1) != "/" )
-			{
-				subPath = "/" + subPath;
-			}
-
-			return subPath;
+			inputFolder += PathSeparatorAlwaysUnixStyle.ToString();
 		}
 
-		/// <summary>
-		/// Remove / (always) before string
-		/// </summary>
-		/// <param name="subPath">subPath</param>
-		/// <returns>(without slash) subPath</returns>
-		public static string RemovePrefixDbSlash(string subPath)
+		return inputFolder;
+	}
+
+	/// <summary>
+	///     Add / (always) before string
+	/// </summary>
+	/// <param name="subPath">the subPath</param>
+	/// <returns>/subpath</returns>
+	public static string PrefixDbSlash(string subPath)
+	{
+		// Add normal linux slash to beginning of the configuration
+		if ( string.IsNullOrWhiteSpace(subPath) )
 		{
-			// Remove linux slash to beginning of the configuration
-			if ( string.IsNullOrWhiteSpace(subPath) )
-			{
-				return "/";
-			}
-
-			if ( subPath.Substring(0, 1) == "/" )
-			{
-				subPath = subPath.Remove(0, 1);
-			}
-
-			return subPath;
+			return PathSeparatorAlwaysUnixStyle.ToString();
 		}
 
-		/// <summary>
-		/// Split a list with divided by dot comma and blank values are removed
-		/// </summary>
-		/// <param name="f">input filePaths</param>
-		/// <returns>string array with seperated strings</returns>
-		public static string[] SplitInputFilePaths(string f)
+		if ( subPath.Substring(0, 1) !=
+		     PathSeparatorAlwaysUnixStyle.ToString() )
 		{
-			if ( string.IsNullOrEmpty(f) )
-			{
-				return [];
-			}
-
-			// input divided by dot comma and blank values are removed
-			var inputFilePaths = f.Split(";".ToCharArray());
-			inputFilePaths = inputFilePaths.Where(x => !string.IsNullOrEmpty(x)).ToArray();
-
-			// Remove duplicates from list
-			// have a single slash in front the path
-			var inputHashSet = new HashSet<string>();
-			foreach ( var path in inputFilePaths )
-			{
-				var subPath = RemovePrefixDbSlash(path);
-				subPath = PrefixDbSlash(subPath);
-
-				inputHashSet.Add(subPath);
-			}
-
-			return inputHashSet.ToArray();
+			subPath = PathSeparatorAlwaysUnixStyle + subPath;
 		}
+
+		return subPath;
+	}
+
+	/// <summary>
+	///     Remove / (always) before string
+	/// </summary>
+	/// <param name="subPath">subPath</param>
+	/// <returns>(without slash) subPath</returns>
+	public static string RemovePrefixDbSlash(string subPath)
+	{
+		// Remove linux slash to beginning of the configuration
+		if ( string.IsNullOrWhiteSpace(subPath) )
+		{
+			return PathSeparatorAlwaysUnixStyle.ToString();
+		}
+
+		if ( subPath.Substring(0, 1) ==
+		     PathSeparatorAlwaysUnixStyle.ToString() )
+		{
+			subPath = subPath.Remove(0, 1);
+		}
+
+		return subPath;
+	}
+
+	/// <summary>
+	///     Split a list with divided by dot comma and blank values are removed
+	/// </summary>
+	/// <param name="f">input filePaths</param>
+	/// <returns>string array with seperated strings</returns>
+	public static string[] SplitInputFilePaths(string f)
+	{
+		if ( string.IsNullOrEmpty(f) )
+		{
+			return [];
+		}
+
+		// input divided by dot comma and blank values are removed
+		var inputFilePaths = f.Split(";".ToCharArray());
+		inputFilePaths = inputFilePaths.Where(x => !string.IsNullOrEmpty(x)).ToArray();
+
+		// Remove duplicates from list
+		// have a single slash in front the path
+		var inputHashSet = new HashSet<string>();
+		foreach ( var path in inputFilePaths )
+		{
+			var subPath = RemovePrefixDbSlash(path);
+			subPath = PrefixDbSlash(subPath);
+
+			inputHashSet.Add(subPath);
+		}
+
+		return [.. inputHashSet];
 	}
 }


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request introduces a consistent use of a Unix-style path separator across the codebase by defining a constant for the path separator and replacing hardcoded path separators with this constant. The changes span multiple helper methods in the `Breadcrumbs` and `PathHelper` classes.

Key changes include:

### Path Separator Consistency:

* [`starsky/starsky.foundation.database/Helpers/Breadcrumbs.cs`](diffhunk://#diff-529cc63d8c88f2b5f3e1ec0b4dba997064253e80237b43f6af5b1b8c8d048a64R9-R10): Introduced `PathSeparatorAlwaysUnixStyle` constant and replaced hardcoded "/" with this constant in `BreadcrumbHelper` and related methods. [[1]](diffhunk://#diff-529cc63d8c88f2b5f3e1ec0b4dba997064253e80237b43f6af5b1b8c8d048a64R9-R10) [[2]](diffhunk://#diff-529cc63d8c88f2b5f3e1ec0b4dba997064253e80237b43f6af5b1b8c8d048a64L27-R36) [[3]](diffhunk://#diff-529cc63d8c88f2b5f3e1ec0b4dba997064253e80237b43f6af5b1b8c8d048a64L44-R46) [[4]](diffhunk://#diff-529cc63d8c88f2b5f3e1ec0b4dba997064253e80237b43f6af5b1b8c8d048a64L62-R74)

* [`starsky/starsky.foundation.platform/Helpers/PathHelper.cs`](diffhunk://#diff-d0b10f11c11700d3a632180da69c9dc50442398207c64aa0429e2b5d8be87f26L7-R12): Added `PathSeparatorAlwaysUnixStyle` constant and updated methods like `GetFileName`, `IsPathRootedUnix`, `RemoveLatestSlash`, `AddSlash`, `PrefixDbSlash`, and `RemovePrefixDbSlash` to use this constant instead of hardcoded path separators. [[1]](diffhunk://#diff-d0b10f11c11700d3a632180da69c9dc50442398207c64aa0429e2b5d8be87f26L7-R12) [[2]](diffhunk://#diff-d0b10f11c11700d3a632180da69c9dc50442398207c64aa0429e2b5d8be87f26L38-R52) [[3]](diffhunk://#diff-d0b10f11c11700d3a632180da69c9dc50442398207c64aa0429e2b5d8be87f26L63-R67) [[4]](diffhunk://#diff-d0b10f11c11700d3a632180da69c9dc50442398207c64aa0429e2b5d8be87f26L88-R99) [[5]](diffhunk://#diff-d0b10f11c11700d3a632180da69c9dc50442398207c64aa0429e2b5d8be87f26L104-R116) [[6]](diffhunk://#diff-d0b10f11c11700d3a632180da69c9dc50442398207c64aa0429e2b5d8be87f26L138-R148) [[7]](diffhunk://#diff-d0b10f11c11700d3a632180da69c9dc50442398207c64aa0429e2b5d8be87f26L156-R170) [[8]](diffhunk://#diff-d0b10f11c11700d3a632180da69c9dc50442398207c64aa0429e2b5d8be87f26L177-R190) [[9]](diffhunk://#diff-d0b10f11c11700d3a632180da69c9dc50442398207c64aa0429e2b5d8be87f26L215-R225)
<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
