### PR TITLE
.NET SDK Upgrade to 8.0.408

### DIFF
--- a/.github/workflows/desktop-release-on-tag-net-electron.yml
+++ b/.github/workflows/desktop-release-on-tag-net-electron.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.407
+          dotnet-version: 8.0.408
 
       - name: Build --no-unit-test linux-arm,linux-arm64,win-x64,osx-x64,linux-x64,osx-arm64 --ready-to-run
         shell: bash

--- a/.github/workflows/webapp-build-net-macos.yml
+++ b/.github/workflows/webapp-build-net-macos.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.407
+        dotnet-version: 8.0.408
         
     - name: "BuildNetCore (MacOS)"
       shell: bash

--- a/.github/workflows/webapp-build-net-ubuntu.yml
+++ b/.github/workflows/webapp-build-net-ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.407
+        dotnet-version: 8.0.408
 
     - name: Cache nuget packages (*nix)
       uses: actions/cache@v4

--- a/.github/workflows/webapp-build-net-windows.yml
+++ b/.github/workflows/webapp-build-net-windows.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.407
+        dotnet-version: 8.0.408
         
     - name: Build (Windows)
       shell: pwsh

--- a/.github/workflows/webapp-codecov-clientapp-netcore.yml
+++ b/.github/workflows/webapp-codecov-clientapp-netcore.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.407
+          dotnet-version: 8.0.408
  
       - name: Cache node modules clientapp (*nix)
         uses: actions/cache@v4

--- a/.github/workflows/webapp-sonarqube-clientapp-netcore.yml
+++ b/.github/workflows/webapp-sonarqube-clientapp-netcore.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.407
+          dotnet-version: 8.0.408
         
       - name: Use Java 17   
         uses: actions/setup-java@v4

--- a/.github/workflows/webapp-update-swagger-dotnet.yml
+++ b/.github/workflows/webapp-update-swagger-dotnet.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.407
+        dotnet-version: 8.0.408
 
     - name: Cache nuget packages (*nix)
       uses: actions/cache@v4

--- a/pipelines/azure/steps/use_dotnet_version.yml
+++ b/pipelines/azure/steps/use_dotnet_version.yml
@@ -1,9 +1,9 @@
 steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET SDK 8.0.407'
+    displayName: 'Use .NET SDK 8.0.408'
     enabled: true
     inputs:
       packageType: sdk
-      version: 8.0.407
+      version: 8.0.408
       installationPath: $(Agent.ToolsDirectory)/dotnet
       performMultiLevelLookup: true

--- a/starsky/global.json
+++ b/starsky/global.json
@@ -1,7 +1,7 @@
 {
     "strictVersion": true,
     "sdk": {
-        "version": "8.0.407",
+        "version": "8.0.408",
         "rollForward": "disable",
         "allowPrerelease": false
     }

--- a/starsky/starsky/starsky.csproj
+++ b/starsky/starsky/starsky.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <RuntimeFrameworkVersion>8.0.14</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion>8.0.15</RuntimeFrameworkVersion>
         <Description>An attempt to create a database driven photo library</Description>
         <!-- use node script to update version -->
         <Version>0.6.6</Version>

--- a/starsky/starskyadmincli/starskyadmincli.csproj
+++ b/starsky/starskyadmincli/starskyadmincli.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <!-- SonarQube needs this -->
         <ProjectGuid>{dcf1f6cb-1c65-4394-bef7-cccc2967b56c}</ProjectGuid>
-        <RuntimeFrameworkVersion>8.0.14</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion>8.0.15</RuntimeFrameworkVersion>
         <DebugType>Full</DebugType>
         <Version>0.6.6</Version>
         <Nullable>enable</Nullable>

--- a/starsky/starskydemoseedcli/starskydemoseedcli.csproj
+++ b/starsky/starskydemoseedcli/starskydemoseedcli.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <!-- SonarQube needs this -->
         <ProjectGuid>{215a3302-a418-4148-8d20-1127e27c3dae}</ProjectGuid>
-        <RuntimeFrameworkVersion>8.0.14</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion>8.0.15</RuntimeFrameworkVersion>
         <DebugType>Full</DebugType>
         <Version>0.6.6</Version>
         <Nullable>enable</Nullable>

--- a/starsky/starskygeocli/starskygeocli.csproj
+++ b/starsky/starskygeocli/starskygeocli.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <!-- SonarQube needs this -->
         <ProjectGuid>{a030c158-2f79-4317-a9f9-bdd46d66d1d8}</ProjectGuid>
-        <RuntimeFrameworkVersion>8.0.14</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion>8.0.15</RuntimeFrameworkVersion>
         <DebugType>Full</DebugType>
         <Version>0.6.6</Version>
         <Nullable>enable</Nullable>

--- a/starsky/starskyimportercli/starskyimportercli.csproj
+++ b/starsky/starskyimportercli/starskyimportercli.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <!-- SonarQube needs this -->
         <ProjectGuid>{23e4ea86-970a-4de1-badc-8d7e9d3d4dd6}</ProjectGuid>
-        <RuntimeFrameworkVersion>8.0.14</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion>8.0.15</RuntimeFrameworkVersion>
         <DebugType>Full</DebugType>
         <Version>0.6.6</Version>
         <Nullable>enable</Nullable>

--- a/starsky/starskysynchronizecli/starskysynchronizecli.csproj
+++ b/starsky/starskysynchronizecli/starskysynchronizecli.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <!-- SonarQube needs this -->
         <ProjectGuid>{7e1136a7-cc43-49d2-91d3-48e557f0fb66}</ProjectGuid>
-        <RuntimeFrameworkVersion>8.0.14</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion>8.0.15</RuntimeFrameworkVersion>
         <RootNamespace>starskysynchronizecli</RootNamespace>
         <Version>0.6.6</Version>
         <Nullable>enable</Nullable>

--- a/starsky/starskytest/starskytest.csproj
+++ b/starsky/starskytest/starskytest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <RuntimeFrameworkVersion>8.0.14</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion>8.0.15</RuntimeFrameworkVersion>
         <DebugType>Full</DebugType>
         <!-- SonarQube needs this -->
         <ProjectGuid>{b3342a3e-64e1-442f-b4f7-f7a718508aac}</ProjectGuid>

--- a/starsky/starskythumbnailcli/starskythumbnailcli.csproj
+++ b/starsky/starskythumbnailcli/starskythumbnailcli.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <!-- SonarQube needs this -->
         <ProjectGuid>{67e3fb34-1ca8-4a28-a0e0-00ff61821002}</ProjectGuid>
-        <RuntimeFrameworkVersion>8.0.14</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion>8.0.15</RuntimeFrameworkVersion>
         <RootNamespace>starskythumbnailcli</RootNamespace>
         <Version>0.6.6</Version>
         <Nullable>enable</Nullable>

--- a/starsky/starskythumbnailmetacli/starskythumbnailmetacli.csproj
+++ b/starsky/starskythumbnailmetacli/starskythumbnailmetacli.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <!-- SonarQube needs this -->
         <ProjectGuid>{a0cce905-ae43-4d1b-a97a-2bcd2c010ed1}</ProjectGuid>
-        <RuntimeFrameworkVersion>8.0.14</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion>8.0.15</RuntimeFrameworkVersion>
         <RootNamespace>starskythumbnailmetacli</RootNamespace>
         <Version>0.6.6</Version>
         <Nullable>enable</Nullable>

--- a/starsky/starskywebftpcli/starskywebftpcli.csproj
+++ b/starsky/starskywebftpcli/starskywebftpcli.csproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <ProjectGuid>{eb1d57d1-29d8-4bfb-950e-447ef8522a10}</ProjectGuid>
-        <RuntimeFrameworkVersion>8.0.14</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion>8.0.15</RuntimeFrameworkVersion>
         <DebugType>Full</DebugType>
         <Version>0.6.6</Version>
         <Nullable>enable</Nullable>

--- a/starsky/starskywebhtmlcli/starskywebhtmlcli.csproj
+++ b/starsky/starskywebhtmlcli/starskywebhtmlcli.csproj
@@ -3,7 +3,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <ProjectGuid>{76d7bf62-9f1d-48f1-9035-dceb01de55c3}</ProjectGuid>
-        <RuntimeFrameworkVersion>8.0.14</RuntimeFrameworkVersion>
+        <RuntimeFrameworkVersion>8.0.15</RuntimeFrameworkVersion>
         <LangVersion>8.0</LangVersion>
         <PreserveCompilationContext>true</PreserveCompilationContext>
         <DebugType>Full</DebugType>


### PR DESCRIPTION
## Upgrade of .NET with newer SDK Version
- Install SDK version 8.0.408 on your development machine https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.15/8.0.15.md
- First test on linux-arm test envs before approve
- update azure runtime on test https://demostarsky.scm.azurewebsites.net/
- update docs with minimal version https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.408/starsky/readme.md
- update changelog https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.408/history.md

## When upgrading a major version
- when upgrading to newer major release check docker