### PR TITLE
Feature/202505 exif refactoring

### DIFF
--- a/history.md
+++ b/history.md
@@ -45,6 +45,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 - [x] (Added) _Back-end_ Support for webp and video thumbnails (PR #1833)
 - [x] (Added) _Back-end_ Sonarcloud code style improvements (PR #2141)
+- [x] (Changed) _Back-end_ Make exiftool responses more clear (PR #2143)
 
 ## version 0.6.8 - 2025-05-07 {#v0.6.8}
 

--- a/starsky/starsky.feature.geolookup/Services/GeoBackgroundTask.cs
+++ b/starsky/starsky.feature.geolookup/Services/GeoBackgroundTask.cs
@@ -102,7 +102,7 @@ public class GeoBackgroundTask : IGeoBackgroundTask
 
 			new ThumbnailFileMoveAllSizes(_thumbnailStorage, _appSettings, _logger).FileMove(
 				item.FileHash!,
-				newThumb);
+				newThumb, item.FilePath);
 			if ( _appSettings.IsVerbose() )
 			{
 				_logger.LogInformation("[/api/geo/sync] thumb rename + `" + item.FileHash + "`" +

--- a/starsky/starsky.feature.geolookup/Services/GeoBackgroundTask.cs
+++ b/starsky/starsky.feature.geolookup/Services/GeoBackgroundTask.cs
@@ -100,7 +100,8 @@ public class GeoBackgroundTask : IGeoBackgroundTask
 				continue;
 			}
 
-			new ThumbnailFileMoveAllSizes(_thumbnailStorage, _appSettings).FileMove(item.FileHash!,
+			new ThumbnailFileMoveAllSizes(_thumbnailStorage, _appSettings, _logger).FileMove(
+				item.FileHash!,
 				newThumb);
 			if ( _appSettings.IsVerbose() )
 			{

--- a/starsky/starsky.feature.geolookup/Services/GeoCli.cs
+++ b/starsky/starsky.feature.geolookup/Services/GeoCli.cs
@@ -177,7 +177,7 @@ public sealed class GeoCli
 				continue;
 			}
 
-			new ThumbnailFileMoveAllSizes(_thumbnailStorage, _appSettings).FileMove(
+			new ThumbnailFileMoveAllSizes(_thumbnailStorage, _appSettings, _logger).FileMove(
 				item.FileHash!, newThumb);
 			if ( _appSettings.IsVerbose() )
 			{

--- a/starsky/starsky.feature.geolookup/Services/GeoCli.cs
+++ b/starsky/starsky.feature.geolookup/Services/GeoCli.cs
@@ -178,7 +178,7 @@ public sealed class GeoCli
 			}
 
 			new ThumbnailFileMoveAllSizes(_thumbnailStorage, _appSettings, _logger).FileMove(
-				item.FileHash!, newThumb);
+				item.FileHash!, newThumb, item.FilePath);
 			if ( _appSettings.IsVerbose() )
 			{
 				_console.WriteLine("thumb+ `" + item.FileHash + "`" + newThumb);

--- a/starsky/starsky.feature.metaupdate/Services/MetaUpdateService.cs
+++ b/starsky/starsky.feature.metaupdate/Services/MetaUpdateService.cs
@@ -159,7 +159,7 @@ public class MetaUpdateService : IMetaUpdateService
 				  $"Null for: path:{fileIndexItem.FilePath} {DateTime.UtcNow.ToShortTimeString()}"
 				: $"[UpdateWriteDiskDatabase] ExifTool result: " +
 				  $"{result.Command} path:{fileIndexItem.FilePath} " +
-				  $"status: {string.Join(", ", result.NewFileHashesStatuses)}");
+				  $"status: {string.Join(", ", result.Rename)}");
 		}
 		else if ( fileIndexItem.ImageFormat != ExtensionRolesHelper.ImageFormat.xmp &&
 		          fileIndexItem.ImageFormat != ExtensionRolesHelper.ImageFormat.meta_json )

--- a/starsky/starsky.feature.metaupdate/Services/MetaUpdateService.cs
+++ b/starsky/starsky.feature.metaupdate/Services/MetaUpdateService.cs
@@ -148,15 +148,17 @@ public class MetaUpdateService : IMetaUpdateService
 				TimeSpan.FromSeconds(5));
 
 			// Do an Exif Sync for all files, including thumbnails
-			var (exifResult, newFileHashes) = await exifTool.UpdateAsync(fileIndexItem,
-				exifUpdateFilePaths, comparedNamesList, true, true);
+			var result = await exifTool.UpdateAsync(fileIndexItem,
+				exifUpdateFilePaths,
+				comparedNamesList, true, true);
 
-			await ApplyOrGenerateUpdatedFileHash(newFileHashes, fileIndexItem);
+			await ApplyOrGenerateUpdatedFileHash(result.NewFileHashes, fileIndexItem);
 
-			_logger.LogInformation(string.IsNullOrEmpty(exifResult)
+			_logger.LogInformation(string.IsNullOrEmpty(result.Command)
 				? $"[UpdateWriteDiskDatabase] ExifTool result is Nothing or " +
 				  $"Null for: path:{fileIndexItem.FilePath} {DateTime.UtcNow.ToShortTimeString()}"
-				: $"[UpdateWriteDiskDatabase] ExifTool result: {exifResult} path:{fileIndexItem.FilePath}");
+				: $"[UpdateWriteDiskDatabase] ExifTool result: " +
+				  $"{result.Command} path:{fileIndexItem.FilePath}");
 		}
 		else if ( fileIndexItem.ImageFormat != ExtensionRolesHelper.ImageFormat.xmp &&
 		          fileIndexItem.ImageFormat != ExtensionRolesHelper.ImageFormat.meta_json )
@@ -186,12 +188,13 @@ public class MetaUpdateService : IMetaUpdateService
 		if ( !string.IsNullOrWhiteSpace(newFileHashes.FirstOrDefault()) )
 		{
 			fileIndexItem.FileHash = newFileHashes.FirstOrDefault();
-			_logger.LogInformation($"use fileHash from exiftool {fileIndexItem.FileHash}");
+			_logger.LogInformation($"[MetaUpdateService] Use fileHash from exiftool " +
+			                       $"{fileIndexItem.FileHash}");
 			return;
 		}
 
 		// when newFileHashes is null or string.empty
-		// rename is done in the exiftool helper
+		// when not is empty: rename is done in the exiftool helper
 		var newFileHash =
 			( await new FileHash(_iStorage, _logger).GetHashCodeAsync(fileIndexItem.FilePath!) )
 			.Key;

--- a/starsky/starsky.feature.metaupdate/Services/MetaUpdateService.cs
+++ b/starsky/starsky.feature.metaupdate/Services/MetaUpdateService.cs
@@ -158,7 +158,8 @@ public class MetaUpdateService : IMetaUpdateService
 				? $"[UpdateWriteDiskDatabase] ExifTool result is Nothing or " +
 				  $"Null for: path:{fileIndexItem.FilePath} {DateTime.UtcNow.ToShortTimeString()}"
 				: $"[UpdateWriteDiskDatabase] ExifTool result: " +
-				  $"{result.Command} path:{fileIndexItem.FilePath}");
+				  $"{result.Command} path:{fileIndexItem.FilePath} " +
+				  $"status: {string.Join(", ", result.NewFileHashesStatuses)}");
 		}
 		else if ( fileIndexItem.ImageFormat != ExtensionRolesHelper.ImageFormat.xmp &&
 		          fileIndexItem.ImageFormat != ExtensionRolesHelper.ImageFormat.meta_json )

--- a/starsky/starsky.feature.webhtmlpublish/Services/WebHtmlPublishService.cs
+++ b/starsky/starsky.feature.webhtmlpublish/Services/WebHtmlPublishService.cs
@@ -400,7 +400,7 @@ public class WebHtmlPublishService : IWebHtmlPublishService
 	/// <summary>
 	///     Copy the metaData over the output path
 	/// </summary>
-	/// <param name="item">all the meta data</param>
+	/// <param name="item">all the metadata</param>
 	/// <param name="outputPath">absolute path on host disk</param>
 	private async Task MetaData(FileIndexItem item, string outputPath)
 	{

--- a/starsky/starsky.foundation.database/Thumbnails/ThumbnailQuery.cs
+++ b/starsky/starsky.foundation.database/Thumbnails/ThumbnailQuery.cs
@@ -345,7 +345,14 @@ public class ThumbnailQuery : IThumbnailQuery
 			.Where(hash => !string.IsNullOrWhiteSpace(hash))
 			.ToList();
 	}
-	
+
+	/// <summary>
+	///     Internal Service to Rename ThumbnailQuery items
+	/// </summary>
+	/// <param name="dbContext">database context</param>
+	/// <param name="beforeFileHash">from hash</param>
+	/// <param name="newFileHash">to hash</param>
+	/// <returns>is success</returns>
 	private async Task<bool> RenameInternalAsync(ApplicationDbContext dbContext,
 		string? beforeFileHash, string? newFileHash)
 	{

--- a/starsky/starsky.foundation.storage/Storage/ThumbnailFileMoveAllSizes.cs
+++ b/starsky/starsky.foundation.storage/Storage/ThumbnailFileMoveAllSizes.cs
@@ -6,56 +6,35 @@ using starsky.foundation.storage.Interfaces;
 
 namespace starsky.foundation.storage.Storage;
 
-public sealed class ThumbnailFileMoveAllSizes
+public sealed class ThumbnailFileMoveAllSizes(
+	IStorage thumbnailStorage,
+	AppSettings appSettings,
+	IWebLogger logger)
 {
-	private readonly AppSettings _appSettings;
-	private readonly IWebLogger _logger;
-	private readonly IStorage _thumbnailStorage;
-
-	public ThumbnailFileMoveAllSizes(IStorage thumbnailStorage, AppSettings appSettings,
-		IWebLogger logger)
-	{
-		_thumbnailStorage = thumbnailStorage;
-		_appSettings = appSettings;
-		_logger = logger;
-	}
-
 	/// <summary>
 	///     Rename all thumbnails
 	/// </summary>
 	/// <param name="oldFileHash">from</param>
 	/// <param name="newHashCode">to</param>
 	/// <returns>Success, size</returns>
-	public List<(bool, ThumbnailSize)> FileMove(string oldFileHash, string newHashCode)
+	public List<(bool, ThumbnailSize)> FileMove(string oldFileHash, string newHashCode,
+		string? reference)
 	{
 		var status = new List<(bool, ThumbnailSize)>();
 		foreach ( var size in ThumbnailNameHelper.AllThumbnailSizes )
 		{
 			var oldName =
-				ThumbnailNameHelper.Combine(oldFileHash, size, _appSettings.ThumbnailImageFormat);
+				ThumbnailNameHelper.Combine(oldFileHash, size, appSettings.ThumbnailImageFormat);
 			var newName =
-				ThumbnailNameHelper.Combine(newHashCode, size, _appSettings.ThumbnailImageFormat);
+				ThumbnailNameHelper.Combine(newHashCode, size, appSettings.ThumbnailImageFormat);
 
-			var isSuccess = _thumbnailStorage.FileMove(oldName, newName);
+			var isSuccess = thumbnailStorage.FileMove(oldName, newName);
 
 			status.Add(( isSuccess, size ));
 		}
 
-		_logger.LogInformation($"[FileMove] O: {oldFileHash} - N: {newHashCode} - " +
-		                       $"{string.Join(", ", status)}");
+		logger.LogInformation($"[FileMove] {reference} \nO: {oldFileHash} - N: {newHashCode} - " +
+		                      $"{string.Join(", ", status)}");
 		return status;
 	}
 }
-
-// // Log
-// var messageSuccess = isSuccess ? "File successfully moved" : "File failed to move";
-// var message = $"[FileMove] {messageSuccess} from " +
-//               $"'{oldName}' to '{newName}' for size {size}.";
-//
-// if ( !isSuccess )
-// {
-// 	_logger.LogInformation(message);
-// 	continue;
-// }
-//
-// _logger.LogDebug(message);

--- a/starsky/starsky.foundation.storage/Storage/ThumbnailFileMoveAllSizes.cs
+++ b/starsky/starsky.foundation.storage/Storage/ThumbnailFileMoveAllSizes.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using starsky.foundation.platform.Interfaces;
 using starsky.foundation.platform.Models;
 using starsky.foundation.platform.Thumbnails;
 using starsky.foundation.storage.Interfaces;
@@ -7,35 +9,53 @@ namespace starsky.foundation.storage.Storage;
 public sealed class ThumbnailFileMoveAllSizes
 {
 	private readonly AppSettings _appSettings;
+	private readonly IWebLogger _logger;
 	private readonly IStorage _thumbnailStorage;
 
-	public ThumbnailFileMoveAllSizes(IStorage thumbnailStorage, AppSettings appSettings)
+	public ThumbnailFileMoveAllSizes(IStorage thumbnailStorage, AppSettings appSettings,
+		IWebLogger logger)
 	{
 		_thumbnailStorage = thumbnailStorage;
 		_appSettings = appSettings;
+		_logger = logger;
 	}
 
-	public void FileMove(string oldFileHash, string newHashCode)
+	/// <summary>
+	///     Rename all thumbnails
+	/// </summary>
+	/// <param name="oldFileHash">from</param>
+	/// <param name="newHashCode">to</param>
+	/// <returns>Success, size</returns>
+	public List<(bool, ThumbnailSize)> FileMove(string oldFileHash, string newHashCode)
 	{
-		_thumbnailStorage.FileMove(
-			ThumbnailNameHelper.Combine(oldFileHash, ThumbnailSize.Large,
-				_appSettings.ThumbnailImageFormat),
-			ThumbnailNameHelper.Combine(newHashCode, ThumbnailSize.Large,
-				_appSettings.ThumbnailImageFormat));
-		_thumbnailStorage.FileMove(
-			ThumbnailNameHelper.Combine(oldFileHash, ThumbnailSize.Small,
-				_appSettings.ThumbnailImageFormat),
-			ThumbnailNameHelper.Combine(newHashCode, ThumbnailSize.Small,
-				_appSettings.ThumbnailImageFormat));
-		_thumbnailStorage.FileMove(
-			ThumbnailNameHelper.Combine(oldFileHash, ThumbnailSize.ExtraLarge,
-				_appSettings.ThumbnailImageFormat),
-			ThumbnailNameHelper.Combine(newHashCode, ThumbnailSize.ExtraLarge,
-				_appSettings.ThumbnailImageFormat));
-		_thumbnailStorage.FileMove(
-			ThumbnailNameHelper.Combine(oldFileHash, ThumbnailSize.TinyMeta,
-				_appSettings.ThumbnailImageFormat),
-			ThumbnailNameHelper.Combine(newHashCode, ThumbnailSize.TinyMeta,
-				_appSettings.ThumbnailImageFormat));
+		var status = new List<(bool, ThumbnailSize)>();
+		foreach ( var size in ThumbnailNameHelper.AllThumbnailSizes )
+		{
+			var oldName =
+				ThumbnailNameHelper.Combine(oldFileHash, size, _appSettings.ThumbnailImageFormat);
+			var newName =
+				ThumbnailNameHelper.Combine(newHashCode, size, _appSettings.ThumbnailImageFormat);
+
+			var isSuccess = _thumbnailStorage.FileMove(oldName, newName);
+
+			status.Add(( isSuccess, size ));
+		}
+
+		_logger.LogInformation($"[FileMove] O: {oldFileHash} - N: {newHashCode} - " +
+		                       $"{string.Join(", ", status)}");
+		return status;
 	}
 }
+
+// // Log
+// var messageSuccess = isSuccess ? "File successfully moved" : "File failed to move";
+// var message = $"[FileMove] {messageSuccess} from " +
+//               $"'{oldName}' to '{newName}' for size {size}.";
+//
+// if ( !isSuccess )
+// {
+// 	_logger.LogInformation(message);
+// 	continue;
+// }
+//
+// _logger.LogDebug(message);

--- a/starsky/starsky.foundation.storage/Storage/ThumbnailNameHelper.cs
+++ b/starsky/starsky.foundation.storage/Storage/ThumbnailNameHelper.cs
@@ -11,20 +11,6 @@ namespace starsky.foundation.storage.Storage;
 /// </summary>
 public static partial class ThumbnailNameHelper
 {
-	/// <summary>
-	///     Without TinyMeta
-	/// </summary>
-	public static readonly ThumbnailSize[] GeneratedThumbnailSizes = new[]
-	{
-		ThumbnailSize.ExtraLarge, ThumbnailSize.Small, ThumbnailSize.Large
-	};
-
-	public static readonly ThumbnailSize[] SecondGeneratedThumbnailSizes = new[]
-	{
-		ThumbnailSize.Small, ThumbnailSize
-			.Large //  <- will be false when skipExtraLarge = true, its already created 
-	};
-
 	public static readonly ThumbnailSize[] AllThumbnailSizes = new[]
 	{
 		ThumbnailSize.TinyMeta, ThumbnailSize.ExtraLarge, ThumbnailSize.Small,
@@ -126,15 +112,15 @@ public static partial class ThumbnailNameHelper
 	}
 
 	/// <summary>
-	/// Replace at and digit with empty string
-	/// @\d+.?\w{0,4}
+	///     Replace at and digit with empty string
+	///     @\d+.?\w{0,4}
 	/// </summary>
 	/// <returns></returns>
 	[GeneratedRegex(@"@\d+.?\w{0,4}", RegexOptions.None, 1000)]
 	private static partial Regex AtDigitAndExtensionRegex();
 
 	/// <summary>
-	/// Remove @2000 or @2000.jpg 
+	///     Remove @2000 or @2000.jpg
 	/// </summary>
 	/// <param name="thumbnailOutputHash">input hash with extension</param>
 	/// <returns>fileHash without suffix and or extension</returns>

--- a/starsky/starsky.foundation.sync/SyncServices/SyncMultiFile.cs
+++ b/starsky/starsky.foundation.sync/SyncServices/SyncMultiFile.cs
@@ -130,8 +130,8 @@ public sealed class SyncMultiFile
 
 		if ( addParentFolder )
 		{
-			_logger.LogInformation("Add Parent Folder For: " +
-			                       string.Join(",", dbItems.Select(p => p.FilePath)));
+			_logger.LogDebug("[SyncMultiFile] Add Parent Folder For: " +
+			                 string.Join(",", dbItems.Select(p => p.FilePath)));
 
 			dbItems = await new AddParentList(_subPathStorage, _query).AddParentItems(dbItems);
 		}

--- a/starsky/starsky.foundation.sync/SyncServices/SyncMultiFile.cs
+++ b/starsky/starsky.foundation.sync/SyncServices/SyncMultiFile.cs
@@ -90,7 +90,8 @@ public sealed class SyncMultiFile
 			FileIndexItem.ExifStatus.DeletedAndSame);
 
 		var statusItems = _checkForStatusNotOkHelper
-			.CheckForStatusNotOk(dbItems.Select(p => p.FilePath).Cast<string>()).ToList();
+			.CheckForStatusNotOk(
+				dbItems.Select(p => p.FilePath).Cast<string>()).ToList();
 		UpdateCheckStatus(dbItems, statusItems);
 
 		AddSidecarExtensionData(dbItems, statusItems);
@@ -103,7 +104,8 @@ public sealed class SyncMultiFile
 			.ForEachAsync(
 				async dbItem => await new SizeFileHashIsTheSameHelper(_subPathStorage, _logger)
 					.SizeFileHashIsTheSame(dbItems
-							.Where(p => p.FileCollectionName == dbItem.FileCollectionName).ToList(),
+							.Where(p =>
+								p.FileCollectionName == dbItem.FileCollectionName).ToList(),
 						dbItem.FilePath!),
 				_appSettings.MaxDegreesOfParallelism);
 

--- a/starsky/starsky.foundation.sync/SyncServices/SyncSingleFile.cs
+++ b/starsky/starsky.foundation.sync/SyncServices/SyncSingleFile.cs
@@ -63,8 +63,8 @@ public sealed class SyncSingleFile
 		// route with database check
 		if ( _appSettings.ApplicationType == AppSettings.StarskyAppType.WebController )
 		{
-			_logger.LogInformation($"[SingleFile/db] info {subPath} " +
-			                       Synchronize.DateTimeDebug());
+			_logger.LogDebug($"[SingleFile/db] info {subPath} " +
+			                 Synchronize.DateTimeDebug());
 		}
 
 		// ignore all the 'wrong' files

--- a/starsky/starsky.foundation.writemeta/Helpers/ExifTool.cs
+++ b/starsky/starsky.foundation.writemeta/Helpers/ExifTool.cs
@@ -136,7 +136,6 @@ public sealed class ExifTool : IExifTool
 	/// <param name="isSuccess">isHashing success, otherwise skip this</param>
 	/// <param name="cancellationToken">cancel Token</param>
 	/// <returns></returns>
-	[SuppressMessage("ReSharper", "MustUseReturnValue")]
 	internal async Task<string> RenameThumbnailByStream(
 		string beforeFileHash, Stream stream, bool isSuccess,
 		CancellationToken cancellationToken = default)
@@ -163,7 +162,7 @@ public sealed class ExifTool : IExifTool
 			return newHashCode;
 		}
 
-		var service = new ThumbnailFileMoveAllSizes(_thumbnailStorage, _appSettings);
+		var service = new ThumbnailFileMoveAllSizes(_thumbnailStorage, _appSettings, _logger);
 		service.FileMove(beforeFileHash, newHashCode);
 
 		return newHashCode;

--- a/starsky/starsky.foundation.writemeta/Helpers/ExifToolCmdHelper.cs
+++ b/starsky/starsky.foundation.writemeta/Helpers/ExifToolCmdHelper.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -213,22 +212,27 @@ public sealed class ExifToolCmdHelper
 			}
 
 			var beforeFileHash = await BeforeFileHash(updateModel, path);
+			// var beforeFileHashExists = _thumbnailStorage.ExistFile(beforeFileHash);
+
 			var newFileHash = ( await _exifTool.WriteTagsAndRenameThumbnailAsync(path,
 				beforeFileHash, command, cancellationToken) ).Value;
 
 			result.NewFileHashes.Add(newFileHash);
+
+			// var newFileHashExists = _thumbnailStorage.ExistFile(updateModel.FileHash!);
+			// result.NewFileHashesStatuses.Add(
+			// 	new ValueTuple<bool, bool, string?>(beforeFileHashExists,
+			// 		newFileHashExists, updateModel.FileHash));
+
 			await _thumbnailQuery.RenameAsync(beforeFileHash, newFileHash);
 		}
 
-		var exists = !string.IsNullOrEmpty(updateModel.FileHash) &&
-		             _thumbnailStorage.ExistFile(updateModel.FileHash);
-		if ( exists )
-		{
-			await _exifTool.WriteTagsThumbnailAsync(updateModel.FileHash!, command);
-		}
-
-		result.NewFileHashesStatuses.Add(
-			new ValueTuple<bool, string?>(exists, updateModel.FileHash));
+		// var exists = !string.IsNullOrEmpty(updateModel.FileHash) &&
+		//              _thumbnailStorage.ExistFile(updateModel.FileHash);
+		// if ( exists )
+		// {
+		// 	await _exifTool.WriteTagsThumbnailAsync(updateModel.FileHash!, command);
+		// }
 
 		return result;
 	}

--- a/starsky/starsky.foundation.writemeta/Helpers/ExifToolCmdHelper.cs
+++ b/starsky/starsky.foundation.writemeta/Helpers/ExifToolCmdHelper.cs
@@ -212,7 +212,6 @@ public sealed class ExifToolCmdHelper
 			}
 
 			var beforeFileHash = await BeforeFileHash(updateModel, path);
-			// var beforeFileHashExists = _thumbnailStorage.ExistFile(beforeFileHash);
 
 			var renameModel = await _exifTool.WriteTagsAndRenameThumbnailAsync(path,
 				beforeFileHash, command, cancellationToken);
@@ -220,23 +219,10 @@ public sealed class ExifToolCmdHelper
 			result.NewFileHashes.Add(renameModel.NewFileHash);
 			result.Rename.Add(renameModel);
 			await _thumbnailQuery.RenameAsync(beforeFileHash, renameModel.NewFileHash);
-
-			// var newFileHashExists = _thumbnailStorage.ExistFile(updateModel.FileHash!);
-			// result.NewFileHashesStatuses.Add(
-			// 	new ValueTuple<bool, bool, string?>(beforeFileHashExists,
-			// 		newFileHashExists, updateModel.FileHash));
 		}
-
-		// var exists = !string.IsNullOrEmpty(updateModel.FileHash) &&
-		//              _thumbnailStorage.ExistFile(updateModel.FileHash);
-		// if ( exists )
-		// {
-		// 	await _exifTool.WriteTagsThumbnailAsync(updateModel.FileHash!, command);
-		// }
 
 		return result;
 	}
-
 
 	private async Task<string> BeforeFileHash(FileIndexItem updateModel, string path)
 	{

--- a/starsky/starsky.foundation.writemeta/Helpers/ExifToolCmdHelper.cs
+++ b/starsky/starsky.foundation.writemeta/Helpers/ExifToolCmdHelper.cs
@@ -14,6 +14,7 @@ using starsky.foundation.readmeta.Interfaces;
 using starsky.foundation.storage.Interfaces;
 using starsky.foundation.storage.Services;
 using starsky.foundation.writemeta.Interfaces;
+using starsky.foundation.writemeta.Models;
 using starsky.foundation.writemeta.Services;
 
 namespace starsky.foundation.writemeta.Helpers;
@@ -49,21 +50,6 @@ public sealed class ExifToolCmdHelper
 
 
 	/// <summary>
-	///     To update ExifTool (both Thumbnail as Storage item)
-	/// </summary>
-	/// <param name="updateModel"></param>
-	/// <param name="inputSubPaths"></param>
-	/// <param name="comparedNames"></param>
-	/// <param name="includeSoftware"></param>
-	/// <returns></returns>
-	public string Update(FileIndexItem updateModel, List<string> inputSubPaths,
-		List<string> comparedNames, bool includeSoftware = true)
-	{
-		return UpdateAsyncWrapperBoth(updateModel, inputSubPaths, comparedNames,
-			includeSoftware).Result;
-	}
-
-	/// <summary>
 	///     For Raw files us an external .xmp sidecar file, and add this to the PathsList
 	/// </summary>
 	/// <param name="inputSubPaths">list of files to update</param>
@@ -88,24 +74,6 @@ public sealed class ExifToolCmdHelper
 		return pathsList;
 	}
 
-	/// <summary>
-	///     Wrapper to do Async tasks -- add variable to test make it in a unit test shorter
-	/// </summary>
-	/// <param name="updateModel"></param>
-	/// <param name="inputSubPaths"></param>
-	/// <param name="comparedNames"></param>
-	/// <param name="includeSoftware"></param>
-	/// <returns></returns>
-	private Task<string> UpdateAsyncWrapperBoth(FileIndexItem updateModel,
-		List<string> inputSubPaths,
-		List<string> comparedNames, bool includeSoftware = true)
-	{
-		var task = Task.Run(() => UpdateAsync(updateModel, inputSubPaths,
-			comparedNames, includeSoftware, true));
-		return Task.FromResult(task.Wait(TimeSpan.FromSeconds(20))
-			? task.Result.Item1
-			: string.Empty);
-	}
 
 	/// <summary>
 	///     Get command line args for exifTool by updateModel as data, comparedNames
@@ -204,7 +172,7 @@ public sealed class ExifToolCmdHelper
 		}
 	}
 
-	public Task<ValueTuple<string, List<string>>> UpdateAsync(FileIndexItem updateModel,
+	public Task<ExifToolWriteResultModel> UpdateAsync(FileIndexItem updateModel,
 		List<string> comparedNames, bool includeSoftware = true, bool renameThumbnail = true)
 	{
 		var exifUpdateFilePaths = new List<string> { updateModel.FilePath! };
@@ -222,7 +190,7 @@ public sealed class ExifToolCmdHelper
 	/// <param name="renameThumbnail">update name</param>
 	/// <param name="cancellationToken">to cancel</param>
 	/// <returns>Tuple (command, hash)</returns>
-	public async Task<ValueTuple<string, List<string>>> UpdateAsync(FileIndexItem updateModel,
+	public async Task<ExifToolWriteResultModel> UpdateAsync(FileIndexItem updateModel,
 		List<string> inputSubPaths, List<string> comparedNames, bool includeSoftware,
 		bool renameThumbnail, CancellationToken cancellationToken = default)
 	{
@@ -234,7 +202,7 @@ public sealed class ExifToolCmdHelper
 
 		var command = ExifToolCommandLineArgs(updateModel, comparedNames, includeSoftware);
 
-		var fileHashes = new List<string>();
+		var result = new ExifToolWriteResultModel(command);
 		foreach ( var path in subPathsList.Where(path => _iStorage.ExistFile(path)) )
 		{
 			// to rename to filename of the thumbnail to the new hash
@@ -248,18 +216,23 @@ public sealed class ExifToolCmdHelper
 			var newFileHash = ( await _exifTool.WriteTagsAndRenameThumbnailAsync(path,
 				beforeFileHash, command, cancellationToken) ).Value;
 
-			fileHashes.Add(newFileHash);
+			result.NewFileHashes.Add(newFileHash);
 			await _thumbnailQuery.RenameAsync(beforeFileHash, newFileHash);
 		}
 
-		if ( !string.IsNullOrEmpty(updateModel.FileHash) &&
-		     _thumbnailStorage.ExistFile(updateModel.FileHash) )
+		var exists = !string.IsNullOrEmpty(updateModel.FileHash) &&
+		             _thumbnailStorage.ExistFile(updateModel.FileHash);
+		if ( exists )
 		{
-			await _exifTool.WriteTagsThumbnailAsync(updateModel.FileHash, command);
+			await _exifTool.WriteTagsThumbnailAsync(updateModel.FileHash!, command);
 		}
 
-		return new ValueTuple<string, List<string>>(command, fileHashes);
+		result.NewFileHashesStatuses.Add(
+			new ValueTuple<bool, string?>(exists, updateModel.FileHash));
+
+		return result;
 	}
+
 
 	private async Task<string> BeforeFileHash(FileIndexItem updateModel, string path)
 	{

--- a/starsky/starsky.foundation.writemeta/Interfaces/IExifTool.cs
+++ b/starsky/starsky.foundation.writemeta/Interfaces/IExifTool.cs
@@ -1,18 +1,17 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using starsky.foundation.writemeta.Models;
 
-namespace starsky.foundation.writemeta.Interfaces
+namespace starsky.foundation.writemeta.Interfaces;
+
+public interface IExifTool
 {
-	public interface IExifTool
-	{
-		Task<bool> WriteTagsAsync(string subPath, string command);
+	Task<bool> WriteTagsAsync(string subPath, string command);
 
-		Task<KeyValuePair<bool, string>> WriteTagsAndRenameThumbnailAsync(
-			string subPath,
-			string? beforeFileHash, string command,
-			CancellationToken cancellationToken = default);
+	Task<ExifToolWriteTagsAndRenameThumbnailModel> WriteTagsAndRenameThumbnailAsync(
+		string subPath,
+		string? beforeFileHash, string command,
+		CancellationToken cancellationToken = default);
 
-		Task<bool> WriteTagsThumbnailAsync(string fileHash, string command);
-	}
+	Task<bool> WriteTagsThumbnailAsync(string fileHash, string command);
 }

--- a/starsky/starsky.foundation.writemeta/Models/ExifToolCmdHelperWriteResultModel.cs
+++ b/starsky/starsky.foundation.writemeta/Models/ExifToolCmdHelperWriteResultModel.cs
@@ -2,9 +2,10 @@ using System.Collections.Generic;
 
 namespace starsky.foundation.writemeta.Models;
 
-public class ExifToolWriteResultModel(string command)
+public class ExifToolCmdHelperWriteResultModel(string command)
 {
 	public string Command { get; set; } = command;
 	public List<string> NewFileHashes { get; set; } = [];
-	public List<(bool, bool, string?)> NewFileHashesStatuses { get; set; } = [];
+	public List<ExifToolWriteTagsAndRenameThumbnailModel> Rename { get; set; } = [];
+	
 }

--- a/starsky/starsky.foundation.writemeta/Models/ExifToolWriteResultModel.cs
+++ b/starsky/starsky.foundation.writemeta/Models/ExifToolWriteResultModel.cs
@@ -6,5 +6,5 @@ public class ExifToolWriteResultModel(string command)
 {
 	public string Command { get; set; } = command;
 	public List<string> NewFileHashes { get; set; } = [];
-	public List<(bool, string?)> NewFileHashesStatuses { get; set; } = [];
+	public List<(bool, bool, string?)> NewFileHashesStatuses { get; set; } = [];
 }

--- a/starsky/starsky.foundation.writemeta/Models/ExifToolWriteResultModel.cs
+++ b/starsky/starsky.foundation.writemeta/Models/ExifToolWriteResultModel.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace starsky.foundation.writemeta.Models;
+
+public class ExifToolWriteResultModel(string command)
+{
+	public string Command { get; set; } = command;
+	public List<string> NewFileHashes { get; set; } = [];
+	public List<(bool, string?)> NewFileHashesStatuses { get; set; } = [];
+}

--- a/starsky/starsky.foundation.writemeta/Models/ExifToolWriteTagsAndRenameThumbnailModel.cs
+++ b/starsky/starsky.foundation.writemeta/Models/ExifToolWriteTagsAndRenameThumbnailModel.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using starsky.foundation.platform.Thumbnails;
+
+namespace starsky.foundation.writemeta.Models;
+
+public class ExifToolWriteTagsAndRenameThumbnailModel(
+	bool isSuccess,
+	string newFileHash,
+	List<(bool, ThumbnailSize)>? fileMoveResult = null)
+{
+	public bool IsSuccess { get; set; } = isSuccess;
+	public string NewFileHash { get; set; } = newFileHash;
+	public List<(bool, ThumbnailSize)>? FileMoveResult { get; set; } = fileMoveResult;
+
+	public override string ToString()
+	{
+		return $"S: {IsSuccess}, N:{NewFileHash} R: {string.Join(", ", FileMoveResult ?? [])}";
+	}
+}

--- a/starsky/starsky.foundation.writemeta/Services/ExifCopy.cs
+++ b/starsky/starsky.foundation.writemeta/Services/ExifCopy.cs
@@ -20,8 +20,8 @@ public sealed class ExifCopy
 		"</rdf:RDF>\n</x:xmpmeta>";
 
 	private readonly ExifToolCmdHelper _exifToolCmdHelper;
-	private readonly IStorage _subPathStorage;
 	private readonly IReadMeta _readMeta;
+	private readonly IStorage _subPathStorage;
 
 	public ExifCopy(IStorage subPathStorage, IStorage thumbnailStorage, IExifTool exifTool,
 		IReadMeta readMeta, IThumbnailQuery thumbnailQuery, IWebLogger logger)
@@ -92,6 +92,6 @@ public sealed class ExifCopy
 		comparedNames.Add(nameof(FileIndexItem.Software));
 		updateModel!.SetFilePath(toSubPath);
 		return ( await _exifToolCmdHelper.UpdateAsync(updateModel,
-			comparedNames, true, false) ).Item1;
+			comparedNames, true, false) ).Command;
 	}
 }

--- a/starsky/starsky.foundation.writemeta/Services/ExifToolHostStorage.cs
+++ b/starsky/starsky.foundation.writemeta/Services/ExifToolHostStorage.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using starsky.foundation.injection;
@@ -8,6 +7,7 @@ using starsky.foundation.storage.Interfaces;
 using starsky.foundation.storage.Storage;
 using starsky.foundation.writemeta.Helpers;
 using starsky.foundation.writemeta.Interfaces;
+using starsky.foundation.writemeta.Models;
 
 namespace starsky.foundation.writemeta.Services;
 
@@ -29,7 +29,7 @@ public sealed class ExifToolHostStorageService : IExifToolHostStorage
 		return await _exifTool.WriteTagsAsync(subPath, command);
 	}
 
-	public async Task<KeyValuePair<bool, string>> WriteTagsAndRenameThumbnailAsync(
+	public async Task<ExifToolWriteTagsAndRenameThumbnailModel> WriteTagsAndRenameThumbnailAsync(
 		string subPath, string? beforeFileHash,
 		string command, CancellationToken cancellationToken = default)
 	{

--- a/starsky/starsky.foundation.writemeta/Services/ExifToolService.cs
+++ b/starsky/starsky.foundation.writemeta/Services/ExifToolService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using starsky.foundation.injection;
@@ -8,6 +7,7 @@ using starsky.foundation.storage.Interfaces;
 using starsky.foundation.storage.Storage;
 using starsky.foundation.writemeta.Helpers;
 using starsky.foundation.writemeta.Interfaces;
+using starsky.foundation.writemeta.Models;
 
 namespace starsky.foundation.writemeta.Services;
 
@@ -32,7 +32,7 @@ public sealed class ExifToolService : IExifTool
 		return await _exifTool.WriteTagsAsync(subPath, command);
 	}
 
-	public async Task<KeyValuePair<bool, string>>
+	public async Task<ExifToolWriteTagsAndRenameThumbnailModel>
 		WriteTagsAndRenameThumbnailAsync(string subPath,
 			string? beforeFileHash, string command,
 			CancellationToken cancellationToken = default)

--- a/starsky/starskytest/FakeMocks/FakeExifTool.cs
+++ b/starsky/starskytest/FakeMocks/FakeExifTool.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using starsky.foundation.platform.Models;
@@ -7,6 +6,7 @@ using starsky.foundation.storage.Helpers;
 using starsky.foundation.storage.Interfaces;
 using starsky.foundation.storage.Services;
 using starsky.foundation.writemeta.Interfaces;
+using starsky.foundation.writemeta.Models;
 
 namespace starskytest.FakeMocks;
 
@@ -43,7 +43,7 @@ public sealed class FakeExifTool : IExifToolHostStorage
 		return true;
 	}
 
-	public async Task<KeyValuePair<bool, string>> WriteTagsAndRenameThumbnailAsync(
+	public async Task<ExifToolWriteTagsAndRenameThumbnailModel> WriteTagsAndRenameThumbnailAsync(
 		string subPath, string? beforeFileHash,
 		string command, CancellationToken cancellationToken = default)
 	{
@@ -57,7 +57,7 @@ public sealed class FakeExifTool : IExifToolHostStorage
 
 		var newFileHash =
 			( await new FileHash(_iStorage, new FakeIWebLogger()).GetHashCodeAsync(subPath) ).Key;
-		return new KeyValuePair<bool, string>(true, newFileHash);
+		return new ExifToolWriteTagsAndRenameThumbnailModel(true, newFileHash);
 	}
 
 	public Task<bool> WriteTagsThumbnailAsync(string fileHash, string command)

--- a/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolCmdHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolCmdHelperTest.cs
@@ -23,7 +23,7 @@ public sealed class ExifToolCmdHelperTest
 	}
 
 	[TestMethod]
-	public void ExifToolCmdHelper_UpdateTest()
+	public async Task ExifToolCmdHelper_UpdateTest()
 	{
 		var updateModel = new FileIndexItem
 		{
@@ -63,29 +63,30 @@ public sealed class ExifToolCmdHelperTest
 			new List<string> { "/test.jpg" }, new List<byte[]>());
 
 		var fakeExifTool = new FakeExifTool(storage, _appSettings);
-		var helperResult = new ExifToolCmdHelper(fakeExifTool, storage, storage,
+		var helperResult = await new ExifToolCmdHelper(fakeExifTool, storage, storage,
 				new FakeReadMeta(), new FakeIThumbnailQuery(), new FakeIWebLogger())
-			.Update(updateModel, inputSubPaths, comparedNames);
+			.UpdateAsync(updateModel, comparedNames);
 
-		Assert.IsTrue(helperResult.Contains(updateModel.Tags));
-		Assert.IsTrue(helperResult.Contains(updateModel.Description));
+		Assert.IsTrue(helperResult.Command.Contains(updateModel.Tags));
+		Assert.IsTrue(helperResult.Command.Contains(updateModel.Description));
 		Assert.IsTrue(
-			helperResult.Contains(updateModel.Latitude.ToString(CultureInfo.InvariantCulture)));
+			helperResult.Command.Contains(
+				updateModel.Latitude.ToString(CultureInfo.InvariantCulture)));
 		Assert.IsTrue(
-			helperResult.Contains(
+			helperResult.Command.Contains(
 				updateModel.Longitude.ToString(CultureInfo.InvariantCulture)));
 		Assert.IsTrue(
-			helperResult.Contains(
+			helperResult.Command.Contains(
 				updateModel.LocationAltitude.ToString(CultureInfo.InvariantCulture)));
-		Assert.IsTrue(helperResult.Contains(updateModel.LocationCity));
-		Assert.IsTrue(helperResult.Contains(updateModel.LocationState));
-		Assert.IsTrue(helperResult.Contains(updateModel.LocationCountry));
-		Assert.IsTrue(helperResult.Contains(updateModel.LocationCountryCode));
-		Assert.IsTrue(helperResult.Contains(updateModel.Title));
+		Assert.IsTrue(helperResult.Command.Contains(updateModel.LocationCity));
+		Assert.IsTrue(helperResult.Command.Contains(updateModel.LocationState));
+		Assert.IsTrue(helperResult.Command.Contains(updateModel.LocationCountry));
+		Assert.IsTrue(helperResult.Command.Contains(updateModel.LocationCountryCode));
+		Assert.IsTrue(helperResult.Command.Contains(updateModel.Title));
 	}
 
 	[TestMethod]
-	public void ExifToolCmdHelper_Update_UpdateLocationAltitudeCommandTest()
+	public async Task ExifToolCmdHelper_Update_UpdateLocationAltitudeCommandTest()
 	{
 		var updateModel = new FileIndexItem { LocationAltitude = -41 };
 		var comparedNames = new List<string>
@@ -101,13 +102,13 @@ public sealed class ExifToolCmdHelperTest
 			new FakeIStorage(folderPaths, inputSubPaths);
 		var fakeExifTool = new FakeExifTool(storage, _appSettings);
 
-		var helperResult = new ExifToolCmdHelper(fakeExifTool,
+		var helperResult = await new ExifToolCmdHelper(fakeExifTool,
 				storage, storage,
 				new FakeReadMeta(), new FakeIThumbnailQuery(), new FakeIWebLogger())
-			.Update(updateModel, inputSubPaths, comparedNames);
+			.UpdateAsync(updateModel, comparedNames);
 
-		Assert.IsTrue(helperResult.Contains("-GPSAltitude=\"-41"));
-		Assert.IsTrue(helperResult.Contains("gpsaltituderef#=\"1"));
+		Assert.IsTrue(helperResult.Command.Contains("-GPSAltitude=\"-41"));
+		Assert.IsTrue(helperResult.Command.Contains("gpsaltituderef#=\"1"));
 	}
 
 	[TestMethod]
@@ -166,8 +167,8 @@ public sealed class ExifToolCmdHelperTest
 				new FakeReadMeta(), new FakeIThumbnailQuery(), new FakeIWebLogger())
 			.UpdateAsync(updateModel, comparedNames);
 
-		Assert.IsTrue(helperResult.Item1.Contains("tags"));
-		Assert.IsTrue(helperResult.Item1.Contains("Description"));
+		Assert.IsTrue(helperResult.Command.Contains("tags"));
+		Assert.IsTrue(helperResult.Command.Contains("Description"));
 	}
 
 	[TestMethod]
@@ -193,8 +194,8 @@ public sealed class ExifToolCmdHelperTest
 				new FakeReadMeta(), new FakeIThumbnailQuery(), new FakeIWebLogger())
 			.UpdateAsync(updateModel, comparedNames);
 
-		Assert.IsTrue(helperResult.Item1.Contains("tags"));
-		Assert.IsTrue(helperResult.Item1.Contains("Description"));
+		Assert.IsTrue(helperResult.Command.Contains("tags"));
+		Assert.IsTrue(helperResult.Command.Contains("Description"));
 	}
 
 

--- a/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolTest.cs
@@ -105,7 +105,7 @@ public sealed class ExifToolTest
 			await new ExifTool(fakeStorage, fakeStorage, appSettings, new FakeIWebLogger())
 				.RenameThumbnailByStream("OLDHASH", new MemoryStream(), true);
 
-		Assert.AreEqual(26, result.Length);
+		Assert.AreEqual(26, result.newHashCode.Length);
 	}
 
 	[TestMethod]
@@ -121,7 +121,7 @@ public sealed class ExifToolTest
 			await new ExifTool(fakeStorage, fakeStorage, appSettings, new FakeIWebLogger())
 				.RenameThumbnailByStream("OLDHASH", new MemoryStream(), false);
 
-		Assert.AreEqual(0, result.Length);
+		Assert.AreEqual(0, result.newHashCode.Length);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolTest.cs
@@ -103,7 +103,7 @@ public sealed class ExifToolTest
 
 		var result =
 			await new ExifTool(fakeStorage, fakeStorage, appSettings, new FakeIWebLogger())
-				.RenameThumbnailByStream("OLDHASH", new MemoryStream(), true);
+				.RenameThumbnailByStream("OLDHASH", new MemoryStream(), true, "test");
 
 		Assert.AreEqual(26, result.newHashCode.Length);
 	}
@@ -119,7 +119,7 @@ public sealed class ExifToolTest
 
 		var result =
 			await new ExifTool(fakeStorage, fakeStorage, appSettings, new FakeIWebLogger())
-				.RenameThumbnailByStream("OLDHASH", new MemoryStream(), false);
+				.RenameThumbnailByStream("OLDHASH", new MemoryStream(), false, "test");
 
 		Assert.AreEqual(0, result.newHashCode.Length);
 	}
@@ -135,7 +135,7 @@ public sealed class ExifToolTest
 
 		var stream = new MemoryStream();
 		await new ExifTool(fakeStorage, fakeStorage, appSettings, new FakeIWebLogger())
-			.RenameThumbnailByStream("OLDHASH", stream, true);
+			.RenameThumbnailByStream("OLDHASH", stream, true, "test");
 
 		Assert.IsTrue(stream.CanWrite);
 	}

--- a/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolHostStorageServiceTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolHostStorageServiceTest.cs
@@ -132,7 +132,7 @@ public sealed class ExifToolHostStorageServiceTest
 			hostFileSystemStorage.FolderDelete(outputPath);
 		}
 
-		Assert.IsFalse(renameThumbnailAsync.Key);
+		Assert.IsFalse(renameThumbnailAsync.IsSuccess);
 		Assert.IsTrue(fakeLogger.TrackedExceptions.Exists(p =>
 			p.Item2?.Contains("Fake Exiftool detected") == true));
 	}
@@ -195,7 +195,7 @@ public sealed class ExifToolHostStorageServiceTest
 			}
 		}
 
-		Assert.IsFalse(renameThumbnailAsync.Key);
+		Assert.IsFalse(renameThumbnailAsync.IsSuccess);
 		Assert.IsTrue(fakeLogger.TrackedExceptions.Exists(p =>
 			p.Item2?.Contains("Fake Exiftool detected") == true));
 	}

--- a/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolServiceTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolServiceTest.cs
@@ -67,7 +67,7 @@ public class ExifToolServiceTest
 		var result = await service.WriteTagsAndRenameThumbnailAsync(
 			"/image.jpg",
 			null, "");
-		Assert.IsFalse(result.Key);
+		Assert.IsFalse(result.IsSuccess);
 
 		CleanExifToolServiceTest();
 	}


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context
This pull request introduces several updates and refactors across multiple components, focusing on improving functionality, code maintainability, and logging. The most notable changes include adding logging capabilities to the `ThumbnailFileMoveAllSizes` class, enhancing the ExifTool integration with structured return types, and cleaning up unused or redundant code.

### Thumbnail Management Enhancements:
* Refactored `ThumbnailFileMoveAllSizes` to include a logger and return detailed results for thumbnail renaming operations. Added a new parameter `reference` to improve traceability.
* Removed redundant thumbnail size arrays (`GeneratedThumbnailSizes` and `SecondGeneratedThumbnailSizes`) from `ThumbnailNameHelper`, consolidating logic into `AllThumbnailSizes`.

### ExifTool Enhancements:
* Updated `ExifTool` methods to use structured return types (`ExifToolWriteTagsAndRenameThumbnailModel`) instead of `KeyValuePair`, improving readability and extensibility. [[1]](diffhunk://#diff-6263d880ac0286c317bd11824cd78ac03e9db8e96adbf3e7a11488de57fe282eL45-R46) [[2]](diffhunk://#diff-6263d880ac0286c317bd11824cd78ac03e9db8e96adbf3e7a11488de57fe282eL111-R113)
* Enhanced thumbnail renaming in `ExifTool` by adding a detailed result (`fileMoveResult`) for better debugging and tracking.

### Logging Improvements:
* Improved logging granularity across multiple files, switching from `LogInformation` to `LogDebug` where appropriate for less critical messages. [[1]](diffhunk://#diff-e0c265f7a90f260784f255573605f18a22a50bb9d9958851e2c32e616ee1010dL133-R135) [[2]](diffhunk://#diff-354e6c322e6642c8e89148347c746044ca6184a42103ce7a2ce19a9a35dfb6f4L66-R66)
* Standardized log messages for clarity in `MetaUpdateService` and other services.

### Code Cleanup and Refactoring:
* Removed unused methods and redundant code in `ExifToolCmdHelper`, simplifying the implementation. [[1]](diffhunk://#diff-7ffc78e02fb265216042f5be61833703279aa1a9840fcf0f9db1e792d2d59231L51-L65) [[2]](diffhunk://#diff-7ffc78e02fb265216042f5be61833703279aa1a9840fcf0f9db1e792d2d59231L91-L108)
* Consolidated and streamlined thumbnail-related logic across multiple files. [[1]](diffhunk://#diff-fe43a3ee49fd7aeb7a6f1108088b7e87c09a7243013d515c48af9db7944d8adfR1-R38) [[2]](diffhunk://#diff-61fa2263732715d27b02403684187f74a6f91a23161b122a85c4a5a8eac937cdL14-L27)

### Miscellaneous:
* Added a new internal method `RenameInternalAsync` in `ThumbnailQuery` to handle thumbnail renaming at the database level.

These changes collectively enhance the robustness, maintainability, and traceability of the codebase.
<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
