### PR TITLE
Feature/202505 localappsettings

### DIFF
--- a/documentation/docs/getting-started/configuration/config-options.md
+++ b/documentation/docs/getting-started/configuration/config-options.md
@@ -14,7 +14,7 @@ There are a few options that can be changed in the web application.
 
 These options are available though `appsettings.json` and environment variables.
 
-There are no mandatory options, but its recommended to change the storageFolder
+There are no mandatory options, but it's recommended to change the storageFolder
 to a folder on your local machine where the picture should be located.
 
 Environment variables are always preferred over `appsettings.json` values.
@@ -31,4 +31,11 @@ See the [Advanced options](../../advanced-options/starsky/readme.md) for more in
 Add the command line argument `--help` option to see all available options.
 The options are configured in `appsettings.json` and environment variables and command line
 arguments.
+
+## Manual Overwrite settings for Desktop
+
+If you want to manually overwrite the settings, you can use the `appsettings.local.json` file.
+This file is located for macOS `~/Library/Application Support/starsky/appsettings.local.json`
+and Windows `C:\Users\<username>\AppData\Local\starsky\appsettings.local.json`.
+When using the desktop app the environment variable `app__AppSettingsLocalPath` is used
 

--- a/documentation/docs/getting-started/configuration/desktop-open.md
+++ b/documentation/docs/getting-started/configuration/desktop-open.md
@@ -28,6 +28,10 @@ The UI writes the settings to the `appsettings.patch.json` file.
 You can use the `appsettings.patch.json` file to configure the desktop application
 or use the Settings in the web application.
 
+## Manual Overwrite settings for Desktop
+
+See [Manual Overwrite settings for Desktop](config-options.md#manual-overwrite-settings-for-desktop)
+
 ### DefaultDesktopEditor
 
 This setting is done by ImageFormat,

--- a/history.md
+++ b/history.md
@@ -46,6 +46,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 - [x] (Added) _Back-end_ Handle background jobs for small thumbnails. (PR #2147)
 - [x] (Changed) _Back-end_ Database Query Refactoring GetAllFilesQuery / GetAllObjects (PR #2147)
 - [x] (Added) _Back-end_ Quicklook and Shell32 Native Thumbnails for macOS and Windows (PR #2147)
+- [x] (Added) _Back-end_ Update docs and add env for manual config (PR #2158)
 
 ## version 0.7.0-beta.0 - 2025-05-14 {#v0.7.0-beta.0}
 

--- a/starsky/starsky.foundation.platform/Helpers/ArgsHelper.cs
+++ b/starsky/starsky.foundation.platform/Helpers/ArgsHelper.cs
@@ -482,7 +482,9 @@ public sealed class ArgsHelper
 			$"5. {Path.Combine(_appSettings.BaseDirectoryProject, "appsettings." + machineName + ".patch.json")}");
 		_console.WriteLine(
 			$"6. Environment variable: app__appsettingspath: {Environment.GetEnvironmentVariable("app__appsettingspath")}");
-		_console.WriteLine("7. Specific environment variables for example app__storageFolder");
+		_console.WriteLine(
+			$"7. Environment variable: app__appsettingslocalpath: {Environment.GetEnvironmentVariable("app__appsettingslocalpath")}");
+		_console.WriteLine("8. Specific environment variables for example app__storageFolder");
 
 		AppSpecificHelp();
 

--- a/starsky/starsky.foundation.platform/Helpers/SetupAppSettings.cs
+++ b/starsky/starsky.foundation.platform/Helpers/SetupAppSettings.cs
@@ -65,6 +65,8 @@ public static class SetupAppSettings
 		var appSettingsMachine = AppSettingsMachineNameWithDot();
 		var appSettingsPath =
 			Environment.GetEnvironmentVariable("app__appsettingspath") ?? string.Empty;
+		var appSettingsLocalPath =
+			Environment.GetEnvironmentVariable("app__appsettingslocalpath") ?? string.Empty;
 		return new List<string>
 		{
 			Path.Combine(baseDirectoryProject, "appsettings.json"),
@@ -72,7 +74,8 @@ public static class SetupAppSettings
 			Path.Combine(baseDirectoryProject, "appsettings.patch.json"),
 			Path.Combine(baseDirectoryProject, appSettingsMachine + "json"),
 			Path.Combine(baseDirectoryProject, appSettingsMachine + "patch.json"),
-			appSettingsPath
+			appSettingsPath,
+			appSettingsLocalPath
 		}.Where(p => !string.IsNullOrEmpty(p));
 	}
 

--- a/starsky/starsky.foundation.platform/Models/AppSettings.cs
+++ b/starsky/starsky.foundation.platform/Models/AppSettings.cs
@@ -99,6 +99,11 @@ public sealed class AppSettings
 	/// <summary>
 	///     Private: Location of AppSettings Path
 	/// </summary>
+	private string? _appSettingsLocalPathPrivate;
+
+	/// <summary>
+	///     Private: Location of AppSettings Path
+	/// </summary>
 	private string? _appSettingsPathPrivate;
 
 	// DatabaseType > above this one
@@ -165,6 +170,7 @@ public sealed class AppSettings
 
 		// Set the default write to appSettings file
 		AppSettingsPath = Path.Combine(BaseDirectoryProject, "appsettings.patch.json");
+		AppSettingsLocalPath = Path.Combine(BaseDirectoryProject, "appsettings.local.json");
 
 		// AddMemoryCache defaults in prop
 	}
@@ -380,12 +386,25 @@ public sealed class AppSettings
 	/// <summary>
 	///     To store the settings by user in the AppData folder
 	///     Used by the Desktop App
+	///     See also AppSettingsLocalPath
 	/// </summary>
 	public string AppSettingsPath
 	{
 		get => AssemblyDirectoryReplacer(_appSettingsPathPrivate);
 		// ReSharper disable once MemberCanBePrivate.Global
 		set => _appSettingsPathPrivate = value; // set by ctor
+	}
+
+	/// <summary>
+	///     To store the settings by user in the AppData folder
+	///     Used by the Desktop App
+	///     See also AppSettingsPath
+	/// </summary>
+	public string AppSettingsLocalPath
+	{
+		get => AssemblyDirectoryReplacer(_appSettingsLocalPathPrivate);
+		// ReSharper disable once MemberCanBePrivate.Global
+		set => _appSettingsLocalPathPrivate = value; // set by ctor
 	}
 
 	/// <summary>
@@ -966,6 +985,13 @@ public sealed class AppSettings
 		{
 			appSettings.AppSettingsPath =
 				appSettings.AppSettingsPath.Replace(userProfileFolder, "~");
+		}
+
+		if ( !string.IsNullOrEmpty(appSettings.AppSettingsLocalPath) &&
+		     !string.IsNullOrEmpty(userProfileFolder) )
+		{
+			appSettings.AppSettingsLocalPath =
+				appSettings.AppSettingsLocalPath.Replace(userProfileFolder, "~");
 		}
 
 		if ( appSettings.PublishProfiles != null )

--- a/starsky/starsky/readme.md
+++ b/starsky/starsky/readme.md
@@ -131,6 +131,13 @@ machinename with your computer name in lowercase)_
     _default none_
 40. `ThumbnailCleanupSkipOnStartup` Skip the cleanup of the thumbnail folder on startup
     _default false_
+41. `CpuUsageMaxPercentage` - Maximum CPU usage percentage for background tasks (default 75).
+42. `FfmpegSkipDownloadOnStartup` - Skip downloading FFmpeg on startup (default false).
+43. `FfmpegSkipPreflightCheck` - Skip preflight checks for FFmpeg (default false).
+44. `FfmpegPath` - Path to the FFmpeg executable.
+45. `SyncAlwaysUpdateLastEditedTime` - Update the last edited time in the database during sync (
+    default true).
+46. `UseSystemTrash` - Use the system trash for file deletions if supported (default null).
 
 ### Appsettings.json example
 

--- a/starsky/starsky/readme.md
+++ b/starsky/starsky/readme.md
@@ -97,37 +97,39 @@ machinename with your computer name in lowercase)_
 16. `httpsOn` Set all cookies in https Mode. You should enable before going to production. _(default
     false)_
 17. `Name` Name of the application, does not have much effect _(default Starsky)_
-18. `AppSettingsPath` To store the settings by user in the AppData folder _(default empty string)_
-19. `UseRealtime` Update the user interface realtime _default true_
-20. `UseDiskWatcher` Watch the disk for changes and update the database _default true_
-21. `CheckForUpdates` Check if there are updates on github and notify the user _default true_
-22. `SyncIgnore` Ignore pattern to not include disk items while running sync, uses always unix style
+18. `AppSettingsPath` To store the settings by user (can overwritten by app when clicking in
+    settings) in the AppData folder _(default empty string)_
+19. `appsettingsLocalPath` To store manual settings in the AppData folder _(default empty string)_
+20. `UseRealtime` Update the user interface realtime _default true_
+21. `UseDiskWatcher` Watch the disk for changes and update the database _default true_
+22. `CheckForUpdates` Check if there are updates on github and notify the user _default true_
+23. `SyncIgnore` Ignore pattern to not include disk items while running sync, uses always unix style
     and startsWith _default list with: /lost+found_
-23. `ImportIgnore` ImportIgnore filter  _default list with: "lost+found" ".Trashes"_
-24. `MaxDegreesOfParallelism` Number of jobs running in background _default 6_
-25. `MetaThumbnailOnImport` Create small thumbnails after import, is very fast _default true_
-26. `EnablePackageTelemetry` Telemetry is send for service improvement _default true_
-27. `EnablePackageTelemetryDebug` Debug Telemetry _default false_
-28. `AddSwaggerExportExitAfter` Quit application after exporting swagger files, should
+24. `ImportIgnore` ImportIgnore filter  _default list with: "lost+found" ".Trashes"_
+25. `MaxDegreesOfParallelism` Number of jobs running in background _default 6_
+26. `MetaThumbnailOnImport` Create small thumbnails after import, is very fast _default true_
+27. `EnablePackageTelemetry` Telemetry is send for service improvement _default true_
+28. `EnablePackageTelemetryDebug` Debug Telemetry _default false_
+29. `AddSwaggerExportExitAfter` Quit application after exporting swagger files, should
     have `AddSwagger` and `AddSwaggerExport` enabled _default false_
-29. `NoAccountLocalhost` No login needed when on localhost, used in Desktop App
-30. `VideoUseLocalTime` Use localtime by Camera make and model instead of UTC
-31. `SyncOnStartup` Sync Database on changes since latest start _default true_
-32. `ThumbnailGenerationIntervalInMinutes` Interval to generate thumbnails, to disable use value
+30. `NoAccountLocalhost` No login needed when on localhost, used in Desktop App
+31. `VideoUseLocalTime` Use localtime by Camera make and model instead of UTC
+32. `SyncOnStartup` Sync Database on changes since latest start _default true_
+33. `ThumbnailGenerationIntervalInMinutes` Interval to generate thumbnails, to disable use value
     lower than 3 _default 15_
-33. `GeoFilesSkipDownloadOnStartup` Skip download of GeoFiles on startup, _recommend to keep this
+34. `GeoFilesSkipDownloadOnStartup` Skip download of GeoFiles on startup, _recommend to keep this
     false or null_ - _default false_
-34. `ExiftoolSkipDownloadOnStartup` Skip download of Exiftool on startup, _recommend to keep this
+35. `ExiftoolSkipDownloadOnStartup` Skip download of Exiftool on startup, _recommend to keep this
     false or null_ - _default false_
-35. `AccountRolesByEmailRegisterOverwrite` Overwrite the default role for a user by email address,
+36. `AccountRolesByEmailRegisterOverwrite` Overwrite the default role for a user by email address,
     _default empty list_
-36. `OpenTelemetry` See logging in an external service, _default no enabled_
+37. `OpenTelemetry` See logging in an external service, _default no enabled_
     see [OpenTelemetry](https://docs.qdraw.nl/docs/developer-guide/logging/opentelemetry/)
-37. `UseLocalDesktop` Enable local desktop features (hide trash in Ui / Open in Application)
+38. `UseLocalDesktop` Enable local desktop features (hide trash in Ui / Open in Application)
     _default false_ _in app true_
-38. `DefaultDesktopEditor` List of Properties that contain the default editor by imageFormat
+39. `DefaultDesktopEditor` List of Properties that contain the default editor by imageFormat
     _default none_
-39. `ThumbnailCleanupSkipOnStartup` Skip the cleanup of the thumbnail folder on startup
+40. `ThumbnailCleanupSkipOnStartup` Skip the cleanup of the thumbnail folder on startup
     _default false_
 
 ### Appsettings.json example

--- a/starsky/starskytest/starsky.foundation.platform/Helpers/SetupAppSettingsTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Helpers/SetupAppSettingsTest.cs
@@ -25,12 +25,14 @@ public sealed class SetupAppSettingsTest
 	}
 
 
-	[TestMethod]
-	public async Task SetLocalAppData_ShouldRead()
+	[DataTestMethod]
+	[DataRow("app__appsettingspath")]
+	[DataRow("app__appsettingslocalpath")]
+	public async Task SetLocalAppData_ShouldRead(string envName)
 	{
 		var appDataFolderFullPath =
 			Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location)!,
-				"setup_app_settings_test");
+				$"setup_app_settings_test_{envName}");
 
 		_hostStorage.CreateDirectory(appDataFolderFullPath);
 		var path = Path.Combine(appDataFolderFullPath, "appsettings.json");
@@ -50,7 +52,7 @@ public sealed class SetupAppSettingsTest
 		Assert.AreEqual(path, appSettings.AppSettingsPath);
 
 		_hostStorage.FolderDelete(appDataFolderFullPath);
-		Environment.SetEnvironmentVariable("app__appsettingspath", null);
+		Environment.SetEnvironmentVariable(envName, null);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/starsky.foundation.platform/Helpers/SetupAppSettingsTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Helpers/SetupAppSettingsTest.cs
@@ -12,164 +12,164 @@ using starskytest.FakeMocks;
 
 [assembly: Parallelize(Workers = 1, Scope = ExecutionScope.MethodLevel)]
 
-namespace starskytest.starsky.foundation.platform.Helpers
+namespace starskytest.starsky.foundation.platform.Helpers;
+
+[TestClass]
+public sealed class SetupAppSettingsTest
 {
-	[TestClass]
-	public sealed class SetupAppSettingsTest
+	private readonly StorageHostFullPathFilesystem _hostStorage;
+
+	public SetupAppSettingsTest()
 	{
-		private readonly StorageHostFullPathFilesystem _hostStorage;
+		_hostStorage = new StorageHostFullPathFilesystem(new FakeIWebLogger());
+	}
 
-		public SetupAppSettingsTest()
+
+	[TestMethod]
+	public async Task SetLocalAppData_ShouldRead()
+	{
+		var appDataFolderFullPath =
+			Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location)!,
+				"setup_app_settings_test");
+
+		_hostStorage.CreateDirectory(appDataFolderFullPath);
+		var path = Path.Combine(appDataFolderFullPath, "appsettings.json");
+
+		var example =
+			StringToStreamHelper.StringToStream(
+				"{\n \"app\" :{\n   \"isAccountRegisterOpen\": \"true\"\n }\n}\n");
+
+		await _hostStorage.WriteStreamAsync(example, path);
+		Environment.SetEnvironmentVariable("app__appsettingspath", path);
+		var builder = await SetupAppSettings.AppSettingsToBuilder();
+		var services = new ServiceCollection();
+		var appSettings = SetupAppSettings.ConfigurePoCoAppSettings(services, builder);
+
+		Assert.IsFalse(string.IsNullOrEmpty(appSettings.AppSettingsPath));
+		Assert.IsTrue(appSettings.IsAccountRegisterOpen);
+		Assert.AreEqual(path, appSettings.AppSettingsPath);
+
+		_hostStorage.FolderDelete(appDataFolderFullPath);
+		Environment.SetEnvironmentVariable("app__appsettingspath", null);
+	}
+
+	[TestMethod]
+	public async Task SetLocalAppData_ShouldTakeDefault()
+	{
+		Environment.SetEnvironmentVariable("app__appsettingspath", null);
+
+		var builder = await SetupAppSettings.AppSettingsToBuilder();
+		var services = new ServiceCollection();
+		var appSettings = SetupAppSettings.ConfigurePoCoAppSettings(services, builder);
+
+		var expectedPath =
+			Path.Combine(appSettings.BaseDirectoryProject, "appsettings.patch.json");
+		Assert.AreEqual(expectedPath, appSettings.AppSettingsPath);
+		Assert.IsFalse(appSettings.IsAccountRegisterOpen);
+	}
+
+	[TestMethod]
+	public async Task MergeJsonFiles_DefaultFile()
+	{
+		var testDir = Path.Combine(new AppSettings().BaseDirectoryProject, "_test");
+		if ( _hostStorage.ExistFolder(testDir) )
 		{
-			_hostStorage = new StorageHostFullPathFilesystem(new FakeIWebLogger());
-		}
-
-		[TestMethod]
-		public async Task SetLocalAppData_ShouldRead()
-		{
-			var appDataFolderFullPath =
-				Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location)!,
-					"setup_app_settings_test");
-
-			_hostStorage.CreateDirectory(appDataFolderFullPath);
-			var path = Path.Combine(appDataFolderFullPath, "appsettings.json");
-
-			var example =
-				StringToStreamHelper.StringToStream(
-					"{\n \"app\" :{\n   \"isAccountRegisterOpen\": \"true\"\n }\n}\n");
-
-			await _hostStorage.WriteStreamAsync(example, path);
-			Environment.SetEnvironmentVariable("app__appsettingspath", path);
-			var builder = await SetupAppSettings.AppSettingsToBuilder();
-			var services = new ServiceCollection();
-			var appSettings = SetupAppSettings.ConfigurePoCoAppSettings(services, builder);
-
-			Assert.IsFalse(string.IsNullOrEmpty(appSettings.AppSettingsPath));
-			Assert.IsTrue(appSettings.IsAccountRegisterOpen);
-			Assert.AreEqual(path, appSettings.AppSettingsPath);
-
-			_hostStorage.FolderDelete(appDataFolderFullPath);
-			Environment.SetEnvironmentVariable("app__appsettingspath", null);
-		}
-
-		[TestMethod]
-		public async Task SetLocalAppData_ShouldTakeDefault()
-		{
-			Environment.SetEnvironmentVariable("app__appsettingspath", null);
-
-			var builder = await SetupAppSettings.AppSettingsToBuilder();
-			var services = new ServiceCollection();
-			var appSettings = SetupAppSettings.ConfigurePoCoAppSettings(services, builder);
-
-			var expectedPath =
-				Path.Combine(appSettings.BaseDirectoryProject, "appsettings.patch.json");
-			Assert.AreEqual(expectedPath, appSettings.AppSettingsPath);
-			Assert.IsFalse(appSettings.IsAccountRegisterOpen);
-		}
-
-		[TestMethod]
-		public async Task MergeJsonFiles_DefaultFile()
-		{
-			var testDir = Path.Combine(new AppSettings().BaseDirectoryProject, "_test");
-			if ( _hostStorage.ExistFolder(testDir) )
-			{
-				_hostStorage.FolderDelete(testDir);
-			}
-
-			_hostStorage.CreateDirectory(testDir);
-
-			await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
-				"{\n  \"app\": {\n   " +
-				" \"StorageFolder\": \"/data/test\"\n " +
-				" }\n}\n"), Path.Combine(testDir, "appsettings.json"));
-
-			var result = await SetupAppSettings.MergeJsonFiles(testDir);
-			Assert.AreEqual(PathHelper.AddBackslash("/data/test"), result.StorageFolder);
-		}
-
-		[TestMethod]
-		public async Task MergeJsonFiles_NoFileFound()
-		{
-			var testDir = Path.Combine(new AppSettings().BaseDirectoryProject, "_not_found");
-			var result = await SetupAppSettings.MergeJsonFiles(testDir);
-			Assert.AreEqual(result.Verbose, new AppSettings().Verbose);
-		}
-
-		[TestMethod]
-		public async Task MergeJsonFiles_StackPatchFile()
-		{
-			var testDir = Path.Combine(new AppSettings().BaseDirectoryProject, "_test");
-			if ( _hostStorage.ExistFolder(testDir) )
-			{
-				_hostStorage.FolderDelete(testDir);
-			}
-
-			_hostStorage.CreateDirectory(testDir);
-
-			await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
-				"{\n  \"app\": {\n   " +
-				" \"StorageFolder\": \"/data/test\",\n \"addSwagger\": \"true\" " +
-				" }\n}\n"), Path.Combine(testDir, "appsettings.json"));
-
-			await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
-				"{\n  \"app\": {\n  \"addSwagger\": \"false\" " +
-				" }\n}\n"), Path.Combine(testDir, "appsettings.patch.json"));
-
-			var result = await SetupAppSettings.MergeJsonFiles(testDir);
-			Assert.AreEqual(PathHelper.AddBackslash("/data/test"), result.StorageFolder);
-			Assert.IsFalse(result.AddSwagger);
-		}
-
-		[TestMethod]
-		public async Task MergeJsonFiles_StackMachineNamePatchFile()
-		{
-			var testDir = Path.Combine(new AppSettings().BaseDirectoryProject, "_test");
-			if ( _hostStorage.ExistFolder(testDir) )
-			{
-				_hostStorage.FolderDelete(testDir);
-			}
-
-			_hostStorage.CreateDirectory(testDir);
-
-			await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
-				"{\n  \"app\": {\n   " +
-				" \"StorageFolder\": \"/data/test\",\n \"addSwagger\": \"true\" " +
-				" }\n}\n"), Path.Combine(testDir, "appsettings.json"));
-
-			await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
-					"{\n  \"app\": {\n  \"addSwagger\": \"false\" " +
-					" }\n}\n"),
-				Path.Combine(testDir, $"{SetupAppSettings.AppSettingsMachineNameWithDot()}json"));
-
-			var result = await SetupAppSettings.MergeJsonFiles(testDir);
-			Assert.AreEqual(PathHelper.AddBackslash("/data/test"), result.StorageFolder);
-			Assert.IsFalse(result.AddSwagger);
-		}
-
-		[TestMethod]
-		public async Task MergeJsonFiles_StackFromEnv()
-		{
-			var testDir = Path.Combine(new AppSettings().BaseDirectoryProject, "_test");
 			_hostStorage.FolderDelete(testDir);
-			_hostStorage.CreateDirectory(testDir);
-
-			await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
-				"{\n  \"app\": {\n   " +
-				" \"StorageFolder\": \"/data/test\",\n \"addSwagger\": \"true\" " +
-				" }\n}\n"), Path.Combine(testDir, "appsettings.json"));
-
-			await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
-				"{\n  \"app\": {\n  \"addSwagger\": \"false\" " +
-				" }\n}\n"), Path.Combine(testDir, "appsettings_ref_patch.json"));
-
-			Environment.SetEnvironmentVariable("app__appsettingspath",
-				Path.Combine(testDir, "appsettings_ref_patch.json"));
-
-			var result = await SetupAppSettings.MergeJsonFiles(testDir);
-			Assert.AreEqual(PathHelper.AddBackslash("/data/test"), result.StorageFolder);
-			Assert.IsFalse(result.AddSwagger);
-
-			Environment.SetEnvironmentVariable("app__appsettingspath", null);
 		}
+
+		_hostStorage.CreateDirectory(testDir);
+
+		await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
+			"{\n  \"app\": {\n   " +
+			" \"StorageFolder\": \"/data/test\"\n " +
+			" }\n}\n"), Path.Combine(testDir, "appsettings.json"));
+
+		var result = await SetupAppSettings.MergeJsonFiles(testDir);
+		Assert.AreEqual(PathHelper.AddBackslash("/data/test"), result.StorageFolder);
+	}
+
+	[TestMethod]
+	public async Task MergeJsonFiles_NoFileFound()
+	{
+		var testDir = Path.Combine(new AppSettings().BaseDirectoryProject, "_not_found");
+		var result = await SetupAppSettings.MergeJsonFiles(testDir);
+		Assert.AreEqual(result.Verbose, new AppSettings().Verbose);
+	}
+
+	[TestMethod]
+	public async Task MergeJsonFiles_StackPatchFile()
+	{
+		var testDir = Path.Combine(new AppSettings().BaseDirectoryProject, "_test");
+		if ( _hostStorage.ExistFolder(testDir) )
+		{
+			_hostStorage.FolderDelete(testDir);
+		}
+
+		_hostStorage.CreateDirectory(testDir);
+
+		await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
+			"{\n  \"app\": {\n   " +
+			" \"StorageFolder\": \"/data/test\",\n \"addSwagger\": \"true\" " +
+			" }\n}\n"), Path.Combine(testDir, "appsettings.json"));
+
+		await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
+			"{\n  \"app\": {\n  \"addSwagger\": \"false\" " +
+			" }\n}\n"), Path.Combine(testDir, "appsettings.patch.json"));
+
+		var result = await SetupAppSettings.MergeJsonFiles(testDir);
+		Assert.AreEqual(PathHelper.AddBackslash("/data/test"), result.StorageFolder);
+		Assert.IsFalse(result.AddSwagger);
+	}
+
+	[TestMethod]
+	public async Task MergeJsonFiles_StackMachineNamePatchFile()
+	{
+		var testDir = Path.Combine(new AppSettings().BaseDirectoryProject, "_test");
+		if ( _hostStorage.ExistFolder(testDir) )
+		{
+			_hostStorage.FolderDelete(testDir);
+		}
+
+		_hostStorage.CreateDirectory(testDir);
+
+		await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
+			"{\n  \"app\": {\n   " +
+			" \"StorageFolder\": \"/data/test\",\n \"addSwagger\": \"true\" " +
+			" }\n}\n"), Path.Combine(testDir, "appsettings.json"));
+
+		await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
+				"{\n  \"app\": {\n  \"addSwagger\": \"false\" " +
+				" }\n}\n"),
+			Path.Combine(testDir, $"{SetupAppSettings.AppSettingsMachineNameWithDot()}json"));
+
+		var result = await SetupAppSettings.MergeJsonFiles(testDir);
+		Assert.AreEqual(PathHelper.AddBackslash("/data/test"), result.StorageFolder);
+		Assert.IsFalse(result.AddSwagger);
+	}
+
+	[TestMethod]
+	public async Task MergeJsonFiles_StackFromEnv()
+	{
+		var testDir = Path.Combine(new AppSettings().BaseDirectoryProject, "_test");
+		_hostStorage.FolderDelete(testDir);
+		_hostStorage.CreateDirectory(testDir);
+
+		await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
+			"{\n  \"app\": {\n   " +
+			" \"StorageFolder\": \"/data/test\",\n \"addSwagger\": \"true\" " +
+			" }\n}\n"), Path.Combine(testDir, "appsettings.json"));
+
+		await _hostStorage.WriteStreamAsync(StringToStreamHelper.StringToStream(
+			"{\n  \"app\": {\n  \"addSwagger\": \"false\" " +
+			" }\n}\n"), Path.Combine(testDir, "appsettings_ref_patch.json"));
+
+		Environment.SetEnvironmentVariable("app__appsettingspath",
+			Path.Combine(testDir, "appsettings_ref_patch.json"));
+
+		var result = await SetupAppSettings.MergeJsonFiles(testDir);
+		Assert.AreEqual(PathHelper.AddBackslash("/data/test"), result.StorageFolder);
+		Assert.IsFalse(result.AddSwagger);
+
+		Environment.SetEnvironmentVariable("app__appsettingspath", null);
 	}
 }

--- a/starsky/starskytest/starsky.foundation.platform/Models/AppSettingsTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Models/AppSettingsTest.cs
@@ -550,4 +550,21 @@ public sealed class AppSettingsTest
 		Assert.AreEqual(source.StorageFolder, destination.StorageFolder);
 		Assert.AreEqual(source.Verbose, destination.Verbose);
 	}
+
+	[TestMethod]
+	public void AppSettings_AppSettingsLocalPath_Null()
+	{
+		var appSettings = new AppSettings { AppSettingsLocalPath = null! };
+		Assert.AreEqual(string.Empty, appSettings.AppSettingsLocalPath);
+	}
+	
+	[TestMethod]
+	public void AppSettings_AppSettingsLocalPath_AssemblyDirectory()
+	{
+		var appSettings = new AppSettings { AppSettingsLocalPath = "/test/{AssemblyDirectory}" };
+
+		var expectedResult = $"/test/{appSettings.BaseDirectoryProject}";
+		
+		Assert.AreEqual(expectedResult, appSettings.AppSettingsLocalPath);
+	}
 }

--- a/starskydesktop/src/app/child-process/setup-child-process.ts
+++ b/starskydesktop/src/app/child-process/setup-child-process.ts
@@ -52,6 +52,7 @@ function CreateTempThumbnailFolders() {
 function EnvHelper(appPort: number) {
   const databaseConnection = `Data Source=${path.join(electronCacheLocation(), "starsky.db")}`;
   const appSettingsPath = path.join(electronCacheLocation(), "appsettings.json");
+  const appSettingsLocalPath = path.join(electronCacheLocation(), "appsettings.local.json");
   const createTempThumbnailFolderResult = CreateTempThumbnailFolders();
 
   return {
@@ -59,6 +60,7 @@ function EnvHelper(appPort: number) {
     app__thumbnailTempFolder: createTempThumbnailFolderResult.thumbnailTempFolder,
     app__tempFolder: createTempThumbnailFolderResult.tempFolder,
     app__appsettingspath: appSettingsPath,
+    app__appsettingslocalpath: appSettingsLocalPath,
     app__NoAccountLocalhost: "true",
     app__UseLocalDesktop: "true",
     app__databaseConnection: databaseConnection,
@@ -70,11 +72,13 @@ function EnvHelper(appPort: number) {
 
 export async function setupChildProcess() {
   const appSettingsPath = path.join(electronCacheLocation(), "appsettings.json");
+  const appSettingsLocalPath = path.join(electronCacheLocation(), "appsettings.local.json");
 
   (global.shared as SharedSettings).port = await GetFreePort();
 
   logger.info(`next: port: ${(global.shared as SharedSettings).port}`);
   logger.info(`-appSettingsPath > ${appSettingsPath}`);
+  logger.info(`-appSettingsLocalPath > ${appSettingsLocalPath}`);
 
   const env = EnvHelper((global.shared as SharedSettings).port);
   process.env = { ...process.env, ...env };


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request introduces support for a new configuration option, `appsettingsLocalPath`, which allows storing manual settings in the AppData folder. The changes span across multiple files to integrate this new feature, update documentation, and enhance testing.

### New Configuration Option: `appsettingsLocalPath`

#### Core Functionality:
* Added a new property, `AppSettingsLocalPath`, to the `AppSettings` class to store manual settings. This includes a private backing field, getter, and setter, along with integration into the constructor for default initialization (`appsettings.local.json`). (`[[1]](diffhunk://#diff-0e27e057ba40e882bc1e16d9a077ffce5a26cc87d8c758c7b59a2e9a351ba360R99-R103)`, `[[2]](diffhunk://#diff-0e27e057ba40e882bc1e16d9a077ffce5a26cc87d8c758c7b59a2e9a351ba360R173)`, `[[3]](diffhunk://#diff-0e27e057ba40e882bc1e16d9a077ffce5a26cc87d8c758c7b59a2e9a351ba360R398-R409)`)
* Modified the `Order` method in `SetupAppSettings` to include `appsettingsLocalPath` in the list of configuration paths. (`[starsky/starsky.foundation.platform/Helpers/SetupAppSettings.csR68-R78](diffhunk://#diff-c7a5afbcc7dcc33cb4c7986c50beab27296da0f364a4b3a55eea2b9fb12bbc4aR68-R78)`)

#### Updates to Help and Documentation:
* Updated the `NeedHelpShowDialog` method to display the new environment variable `app__appsettingslocalpath`. (`[starsky/starsky.foundation.platform/Helpers/ArgsHelper.csL485-R487](diffhunk://#diff-81b5c4e0fd7713ac12ea83edb9621d7b33ffbd04704e888f06e189706f6e1668L485-R487)`)
* Added `appsettingsLocalPath` to the README file, describing its purpose and default value. (`[starsky/starsky/readme.mdL100-R140](diffhunk://#diff-4e8444e7216976e2c2b00ee2e59961727b6e4bb1f7a32869e1935c165e4b97bdL100-R140)`)

#### Testing Enhancements:
* Refactored `SetupAppSettingsTest` to include a parameterized test for both `app__appsettingspath` and `app__appsettingslocalpath`, ensuring the new configuration option is tested. (`[[1]](diffhunk://#diff-af4590b13bb877a5a4e56885b64fa5437dbadab4bc7a44113cf3ddc2c2156318L27-R35)`, `[[2]](diffhunk://#diff-af4590b13bb877a5a4e56885b64fa5437dbadab4bc7a44113cf3ddc2c2156318L52-R55)`)

#### Integration with Desktop App:
* Updated the `EnvHelper` function in the desktop app setup to include `appsettingsLocalPath` in the environment variables. (`[[1]](diffhunk://#diff-8097dd458935062e89e51e55eb7b5609cb6c1969e2cb401cdddc98c4d19911d1R55-R63)`, `[[2]](diffhunk://#diff-8097dd458935062e89e51e55eb7b5609cb6c1969e2cb401cdddc98c4d19911d1R75-R81)`)
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
