### PR TITLE
Feature/202505 logging findings2

### DIFF
--- a/starsky/starsky.foundation.native/PreviewImageNative/Helpers/QuicklookMacOs.cs
+++ b/starsky/starsky.foundation.native/PreviewImageNative/Helpers/QuicklookMacOs.cs
@@ -52,7 +52,8 @@ public class QuicklookMacOs(IWebLogger logger)
 			return SaveCGImageAsFile(thumbnailRef, outputPath);
 		}
 
-		logger.LogInformation("[QuicklookMacOs] Failed to generate thumbnail");
+		logger.LogInformation("[QuicklookMacOs] Failed to generate thumbnail" +
+		                      $" for F: {filePath} O: {outputPath}");
 		return false;
 	}
 
@@ -96,12 +97,13 @@ public class QuicklookMacOs(IWebLogger logger)
 
 		if ( destination == IntPtr.Zero )
 		{
-			logger.LogInformation("[QuicklookMacOs] Failed to create image destination");
+			logger.LogInformation("[QuicklookMacOs] Failed to create image destination"
+			                      + $" for F: {outputPath} U: {uniformTypeIdentifier}");
 			return false;
 		}
 
 		// Add image and finalize
-		ImageDestinationAddImageFinalize(destination, cgImage);
+		ImageDestinationAddImageFinalize(destination, cgImage, outputPath);
 
 		// Cleanup
 		CFRelease(destination);
@@ -111,12 +113,14 @@ public class QuicklookMacOs(IWebLogger logger)
 		return true;
 	}
 
-	internal void ImageDestinationAddImageFinalize(IntPtr destination, IntPtr cgImage)
+	internal void ImageDestinationAddImageFinalize(IntPtr destination, IntPtr cgImage,
+		string? reference = "")
 	{
 		CGImageDestinationAddImage(destination, cgImage, IntPtr.Zero);
 		if ( !CGImageDestinationFinalize(destination) )
 		{
-			logger.LogInformation("[QuicklookMacOs] Failed to finalize image");
+			logger.LogInformation("[QuicklookMacOs] Failed to finalize image" +
+			                      $" destination for R: {reference}");
 		}
 	}
 
@@ -171,15 +175,9 @@ public class QuicklookMacOs(IWebLogger logger)
 
 	// Define a structure for CGSize (used for image size)
 	[StructLayout(LayoutKind.Sequential)]
-	internal struct CGSize
+	internal struct CGSize(double width, double height)
 	{
-		public double Width;
-		public double Height;
-
-		public CGSize(double width, double height)
-		{
-			Width = width;
-			Height = height;
-		}
+		public double Width = width;
+		public double Height = height;
 	}
 }

--- a/starsky/starsky.foundation.video/Process/FfmpegRunner.cs
+++ b/starsky/starsky.foundation.video/Process/FfmpegRunner.cs
@@ -38,8 +38,8 @@ public class FfmpegRunner(string ffMpegPath, IWebLogger logger)
 		{
 			throw new ArgumentException("Error when trying to start the ffmpeg process.  " +
 			                            "Please make sure ffmpeg is installed, and its path is properly " +
-			                            "specified in the options. " +
-			                            argumentsWithPipeEnd, exception);
+			                            "specified in the options. - " +
+			                            $" {ffMpegPath} {argumentsWithPipeEnd}", exception);
 		}
 	}
 

--- a/starsky/starsky.foundation.video/Process/FfmpegRunner.cs
+++ b/starsky/starsky.foundation.video/Process/FfmpegRunner.cs
@@ -12,7 +12,8 @@ public class FfmpegRunner(string ffMpegPath, IWebLogger logger)
 	{
 		ArgumentNullException.ThrowIfNull(fullFilePath);
 
-		var argumentsWithPipeEnd = $"-i \"{fullFilePath}\" {ffmpegInputArguments} -f {format} pipe:1";
+		var argumentsWithPipeEnd =
+			$"-i \"{fullFilePath}\" {ffmpegInputArguments} -f {format} pipe:1";
 
 		var memoryStream = new MemoryStream();
 
@@ -37,7 +38,8 @@ public class FfmpegRunner(string ffMpegPath, IWebLogger logger)
 		{
 			throw new ArgumentException("Error when trying to start the ffmpeg process.  " +
 			                            "Please make sure ffmpeg is installed, and its path is properly " +
-			                            "specified in the options.", exception);
+			                            "specified in the options. " +
+			                            argumentsWithPipeEnd, exception);
 		}
 	}
 


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context
This pull request includes updates to improve logging clarity, enhance method functionality, and simplify code structures in the `QuicklookMacOs` and `FfmpegRunner` classes. The key changes focus on providing more detailed log messages, modifying method signatures for better flexibility, and simplifying a struct definition.

### Logging Improvements:
* Enhanced log messages in `GenerateThumbnail` and `SaveCGImageAsFile` to include file paths and identifiers, providing more context for debugging. (`starsky/starsky.foundation.native/PreviewImageNative/Helpers/QuicklookMacOs.cs`, [[1]](diffhunk://#diff-33716b5eef14b2a21f59f15af52e1b53485fcbf0552d26326ed298f1bec0b4a7L55-R56) [[2]](diffhunk://#diff-33716b5eef14b2a21f59f15af52e1b53485fcbf0552d26326ed298f1bec0b4a7L99-R106)
* Updated `ImageDestinationAddImageFinalize` to include an optional reference parameter in log messages for additional context. (`starsky/starsky.foundation.native/PreviewImageNative/Helpers/QuicklookMacOs.cs`, [starsky/starsky.foundation.native/PreviewImageNative/Helpers/QuicklookMacOs.csL114-R123](diffhunk://#diff-33716b5eef14b2a21f59f15af52e1b53485fcbf0552d26326ed298f1bec0b4a7L114-R123))
* Improved error logging in `FfmpegRunner` to include the `ffMpegPath` and command arguments when the process fails to start. (`starsky/starsky.foundation.video/Process/FfmpegRunner.cs`, [starsky/starsky.foundation.video/Process/FfmpegRunner.csL40-R42](diffhunk://#diff-78e9a80c57ecc1fcc9743ba4bc00a70e32b3ff988338e867d3d268b604a4a40cL40-R42))

### Code Simplification:
* Refactored the `CGSize` struct to use a more concise syntax, reducing boilerplate code. (`starsky/starsky.foundation.native/PreviewImageNative/Helpers/QuicklookMacOs.cs`, [starsky/starsky.foundation.native/PreviewImageNative/Helpers/QuicklookMacOs.csL174-R181](diffhunk://#diff-33716b5eef14b2a21f59f15af52e1b53485fcbf0552d26326ed298f1bec0b4a7L174-R181))

### Minor Formatting:
* Adjusted line breaks for better readability in the `FfmpegRunner` class. (`starsky/starsky.foundation.video/Process/FfmpegRunner.cs`, [starsky/starsky.foundation.video/Process/FfmpegRunner.csL15-R16](diffhunk://#diff-78e9a80c57ecc1fcc9743ba4bc00a70e32b3ff988338e867d3d268b604a4a40cL15-R16))
<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
