### PR TITLE
#2106 align upload

### DIFF
--- a/history.md
+++ b/history.md
@@ -44,7 +44,8 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 ## version 0.7.0 - _(Unreleased)_ - 2025-05-? {#v0.7.0}
 
 - [x] (Fixed) _Back-end_ Fix for when images are white on macOS, thumbnail generation (PR #2176)
-- [x] (Fixed) _Back-end_ Quote handeling for tags, description and title (Issue #1510 & PR #2177)
+- [x] (Fixed) _Back-end_ Quote handling for tags, description and title (Issue #1510 & PR #2177)
+- [x] (Fixed) _Front-end_ Upload button when readonly (Issue #2106 & PR #2178)
 
 ## version 0.7.0-beta.1 - 2025-05-20 {#v0.7.0-beta.1}
 

--- a/starsky/starsky/clientapp/src/components/organisms/menu-archive/internal/upload-menu-item.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/menu-archive/internal/upload-menu-item.tsx
@@ -21,7 +21,7 @@ export const UploadMenuItem: React.FunctionComponent<IUploadMenuItemProps> = ({
   if (readOnly)
     return (
       <li data-test="upload" className="menu-option disabled">
-        Upload
+        <button>Upload</button>
       </li>
     );
   return (

--- a/starsky/starsky/clientapp/src/shared/url/url-query.ts
+++ b/starsky/starsky/clientapp/src/shared/url/url-query.ts
@@ -1,6 +1,6 @@
-import {IUrl, newIUrl} from "../../interfaces/IUrl.ts";
-import {URLPath} from "./url-path";
-import {IsRelativeUrl} from "./url.ts";
+import { IUrl, newIUrl } from "../../interfaces/IUrl.ts";
+import { URLPath } from "./url-path";
+import { IsRelativeUrl } from "./url.ts";
 
 import packageJson from "../../../package.json";
 


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request makes a small change to the `UploadMenuItem` component to improve accessibility by replacing plain text with a `<button>` element for the "Upload" option when the menu is in a read-only state.

* [`starsky/starsky/clientapp/src/components/organisms/menu-archive/internal/upload-menu-item.tsx`](diffhunk://#diff-363d2d5a5dd0461801172abffa7384b6b89d77cf5dd4bbf1d7fdfa6a6b4bb600L24-R24): Replaced the plain text "Upload" with a `<button>` element inside the read-only menu option to enhance accessibility.
<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
