### PR TITLE
.NET SDK Upgrade to 8.0.410

### DIFF
--- a/.github/workflows/desktop-release-on-tag-net-electron.yml
+++ b/.github/workflows/desktop-release-on-tag-net-electron.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.409
+          dotnet-version: 8.0.410
 
       - name: Build --no-unit-test linux-arm,linux-arm64,win-x64,osx-x64,linux-x64,osx-arm64 --ready-to-run
         shell: bash

--- a/.github/workflows/webapp-build-net-macos.yml
+++ b/.github/workflows/webapp-build-net-macos.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.409
+        dotnet-version: 8.0.410
         
     - name: "BuildNetCore (MacOS)"
       shell: bash

--- a/.github/workflows/webapp-build-net-ubuntu.yml
+++ b/.github/workflows/webapp-build-net-ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.409
+        dotnet-version: 8.0.410
 
     - name: Cache nuget packages (*nix)
       uses: actions/cache@v4

--- a/.github/workflows/webapp-build-net-windows.yml
+++ b/.github/workflows/webapp-build-net-windows.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.409
+        dotnet-version: 8.0.410
         
     - name: Build (Windows)
       shell: pwsh

--- a/.github/workflows/webapp-codecov-clientapp-netcore.yml
+++ b/.github/workflows/webapp-codecov-clientapp-netcore.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.409
+          dotnet-version: 8.0.410
  
       - name: Cache node modules clientapp (*nix)
         uses: actions/cache@v4

--- a/.github/workflows/webapp-sonarqube-clientapp-netcore.yml
+++ b/.github/workflows/webapp-sonarqube-clientapp-netcore.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.409
+          dotnet-version: 8.0.410
         
       - name: Use Java 17   
         uses: actions/setup-java@v4

--- a/.github/workflows/webapp-update-swagger-dotnet.yml
+++ b/.github/workflows/webapp-update-swagger-dotnet.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.409
+        dotnet-version: 8.0.410
 
     - name: Cache nuget packages (*nix)
       uses: actions/cache@v4

--- a/pipelines/azure/steps/use_dotnet_version.yml
+++ b/pipelines/azure/steps/use_dotnet_version.yml
@@ -1,9 +1,9 @@
 steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET SDK 8.0.409'
+    displayName: 'Use .NET SDK 8.0.410'
     enabled: true
     inputs:
       packageType: sdk
-      version: 8.0.409
+      version: 8.0.410
       installationPath: $(Agent.ToolsDirectory)/dotnet
       performMultiLevelLookup: true

--- a/starsky/global.json
+++ b/starsky/global.json
@@ -1,7 +1,7 @@
 {
     "strictVersion": true,
     "sdk": {
-        "version": "8.0.409",
+        "version": "8.0.410",
         "rollForward": "disable",
         "allowPrerelease": false
     }

--- a/starsky/nuget-packages-list.json
+++ b/starsky/nuget-packages-list.json
@@ -53,8 +53,8 @@
   "Microsoft.AspNetCore.Identity.EntityFrameworkCore 8.0.16",
   "Microsoft.Extensions.Hosting 8.0.1",
   "Microsoft.NET.Test.Sdk 17.14.0",
-  "MSTest.TestAdapter 3.9.0",
-  "MSTest.TestFramework 3.9.0",
+  "MSTest.TestAdapter 3.9.1",
+  "MSTest.TestFramework 3.9.1",
   "coverlet.collector 6.0.4",
   "Microsoft.AspNetCore.Mvc.Formatters.Json 2.3.0",
   "Microsoft.AspNetCore.Identity 2.3.1"

--- a/starsky/starskytest/starskytest.csproj
+++ b/starsky/starskytest/starskytest.csproj
@@ -21,10 +21,10 @@
     <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'"/>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'"/>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.16"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1"/>
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.16" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.9.1"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.9.1"/>


### PR DESCRIPTION
## Upgrade of .NET with newer SDK Version
- Install SDK version 8.0.410 on your development machine https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.16/8.0.16.md
- First test on linux-arm test envs before approve
- update azure runtime on test https://demostarsky.scm.azurewebsites.net/
- update docs with minimal version https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.410/starsky/readme.md
- update changelog https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.410/history.md

## When upgrading a major version
- when upgrading to newer major release check docker