### PR TITLE
.NET SDK Upgrade to 8.0.411

### DIFF
--- a/starsky/nuget-packages-list.json
+++ b/starsky/nuget-packages-list.json
@@ -53,8 +53,8 @@
   "Microsoft.AspNetCore.Identity.EntityFrameworkCore 8.0.17",
   "Microsoft.Extensions.Hosting 8.0.1",
   "Microsoft.NET.Test.Sdk 17.14.1",
-  "MSTest.TestAdapter 3.9.1",
-  "MSTest.TestFramework 3.9.1",
+  "MSTest.TestAdapter 3.9.3",
+  "MSTest.TestFramework 3.9.3",
   "coverlet.collector 6.0.4",
   "Microsoft.AspNetCore.Mvc.Formatters.Json 2.3.0",
   "Microsoft.AspNetCore.Identity 2.3.1"


### PR DESCRIPTION
## Upgrade of .NET with newer SDK Version
- Install SDK version 8.0.411 on your development machine https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.17/8.0.17.md
- First test on linux-arm test envs before approve
- update azure runtime on test https://demostarsky.scm.azurewebsites.net/
- update docs with minimal version https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.411/starsky/readme.md
- update changelog https://github.com/qdraw/starsky/blob/feature/auto_dotnet_sdk_version_upgrade_8.0.411/history.md

## When upgrading a major version
- when upgrading to newer major release check docker