### PR TITLE
AppSettingsCompareHelper AppSettingsImportTransformationModel AppSettingsStructureModel

### DIFF
--- a/starsky/starsky.feature.packagetelemetry/Services/PackageTelemetry.cs
+++ b/starsky/starsky.feature.packagetelemetry/Services/PackageTelemetry.cs
@@ -193,7 +193,8 @@ public class PackageTelemetry : IPackageTelemetry
 			     typeof(Dictionary<string, List<AppSettingsPublishProfiles>>) ||
 			     propValue?.GetType() == typeof(List<CameraMakeModel>) ||
 			     propValue?.GetType() == typeof(List<AppSettingsDefaultEditorApplication>) ||
-			     propValue?.GetType() == typeof(AppSettingsImportTransformationModel) )
+			     propValue?.GetType() == typeof(AppSettingsImportTransformationModel) ||
+			     propValue?.GetType() == typeof(AppSettingsStructureModel))
 			{
 				value = ParseContentToJson(propValue);
 			}

--- a/starsky/starsky.foundation.platform/Helpers/AppSettingsCompareHelper.cs
+++ b/starsky/starsky.foundation.platform/Helpers/AppSettingsCompareHelper.cs
@@ -76,6 +76,19 @@ public static class AppSettingsCompareHelper
 				newStructure, differenceList);
 		}
 
+		if ( propertyB.PropertyType == typeof(AppSettingsImportTransformationModel) )
+		{
+			var oldImportTransformation =
+				( AppSettingsImportTransformationModel? ) propertyInfoFromA.GetValue(
+					sourceIndexItem,
+					null);
+			var newImportTransformation =
+				( AppSettingsImportTransformationModel? ) propertyB.GetValue(updateObject, null);
+			CompareAppSettingsImportTransformationModel(propertyB.Name, sourceIndexItem,
+				oldImportTransformation,
+				newImportTransformation, differenceList);
+		}
+
 		if ( propertyInfoFromA.PropertyType ==
 		     typeof(List<AppSettingsDefaultEditorApplication>) &&
 		     propertyB.PropertyType == typeof(List<AppSettingsDefaultEditorApplication>) )
@@ -209,6 +222,27 @@ public static class AppSettingsCompareHelper
 
 		sourceIndexItem.GetType().GetProperty(propertyBName)!.SetValue(sourceIndexItem,
 			newStructure, null);
+		differenceList.Add(propertyBName.ToLowerInvariant());
+	}
+
+	private static void CompareAppSettingsImportTransformationModel(string propertyBName,
+		AppSettings sourceIndexItem, AppSettingsImportTransformationModel? oldImportTransformation,
+		AppSettingsImportTransformationModel? newImportTransformation, List<string> differenceList)
+	{
+		if ( oldImportTransformation == null ||
+		     newImportTransformation == null ||
+		     // compare lists
+		     JsonSerializer.Serialize(oldImportTransformation) ==
+		     JsonSerializer.Serialize(newImportTransformation) ||
+		     // default options
+		     JsonSerializer.Serialize(newImportTransformation) ==
+		     JsonSerializer.Serialize(new AppSettingsImportTransformationModel()) )
+		{
+			return;
+		}
+
+		sourceIndexItem.GetType().GetProperty(propertyBName)!.SetValue(sourceIndexItem,
+			newImportTransformation, null);
 		differenceList.Add(propertyBName.ToLowerInvariant());
 	}
 

--- a/starsky/starskytest/starsky.feature.packagetelemetry/Helpers/PackageTelemetryTest.cs
+++ b/starsky/starskytest/starsky.feature.packagetelemetry/Helpers/PackageTelemetryTest.cs
@@ -308,6 +308,10 @@ public sealed class PackageTelemetryTest
 		DisplayName = "Type is List<AppSettingsDefaultEditorApplication>")]
 	[DataRow(typeof(string), false, DisplayName = "Type is string")]
 	[DataRow(typeof(int), false, DisplayName = "Type is int")]
+	[DataRow(typeof(AppSettingsImportTransformationModel), true,
+		DisplayName = "Type is AppSettingsImportTransformationModel")]
+	[DataRow(typeof(AppSettingsStructureModel), true,
+		DisplayName = "Type is AppSettingsStructureModel")]
 	public void TestPropValueTypeCheck(Type type, bool expected)
 	{
 		// Arrange
@@ -328,6 +332,14 @@ public sealed class PackageTelemetryTest
 		{
 			propValue = new List<AppSettingsDefaultEditorApplication>();
 		}
+		else if ( type == typeof(AppSettingsImportTransformationModel) )
+		{
+			propValue = new AppSettingsImportTransformationModel();
+		}
+		else if ( type == typeof(AppSettingsStructureModel) )
+		{
+			propValue = new AppSettingsStructureModel();
+		}
 		else if ( type == typeof(string) )
 		{
 			propValue = "test";
@@ -342,6 +354,8 @@ public sealed class PackageTelemetryTest
 		             propValue.GetType() ==
 		             typeof(Dictionary<string, List<AppSettingsPublishProfiles>>) ||
 		             propValue.GetType() == typeof(List<CameraMakeModel>) ||
+		             propValue.GetType() == typeof(AppSettingsImportTransformationModel) ||
+		             propValue.GetType() == typeof(AppSettingsStructureModel) ||
 		             propValue.GetType() == typeof(List<AppSettingsDefaultEditorApplication>);
 
 		// check for json

--- a/starsky/starskytest/starsky.foundation.platform/Helpers/AppSettingsCompareHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Helpers/AppSettingsCompareHelperTest.cs
@@ -101,6 +101,95 @@ public sealed class AppSettingsCompareHelperTest
 			source.Structure.Rules[0].Pattern);
 	}
 
+	[TestMethod]
+	public void AppSettingsImportTransformationModel()
+	{
+		var source = new AppSettings
+		{
+			ImportTransformation =
+				new AppSettingsImportTransformationModel
+				{
+					Rules =
+					[
+						new TransformationRule
+						{
+							ColorClass = ColorClassParser.Color.Superior,
+							Conditions = new TransformationConditions
+							{
+								ImageFormats = [ExtensionRolesHelper.ImageFormat.png],
+								Origin = "test-1"
+							}
+						}
+					]
+				}
+		};
+
+		var to = new AppSettings
+		{
+			ImportTransformation =
+				new AppSettingsImportTransformationModel
+				{
+					Rules =
+					[
+						new TransformationRule
+						{
+							ColorClass = ColorClassParser.Color.Extras,
+							Conditions = new TransformationConditions
+							{
+								ImageFormats = [ExtensionRolesHelper.ImageFormat.jpg],
+								Origin = "test"
+							}
+						}
+					]
+				}
+		};
+
+		AppSettingsCompareHelper.Compare(source, to);
+
+		Assert.AreEqual(source.ImportTransformation.Rules[0].ColorClass,
+			to.ImportTransformation.Rules[0].ColorClass);
+		Assert.AreEqual(source.ImportTransformation.Rules[0].Conditions.Origin,
+			to.ImportTransformation.Rules[0].Conditions.Origin);
+		Assert.AreEqual(source.ImportTransformation.Rules[0].Conditions.ImageFormats[0],
+			to.ImportTransformation.Rules[0].Conditions.ImageFormats[0]);
+	}
+
+	[TestMethod]
+	public void AppSettingsImportTransformationModel_Ignore_DefaultOption()
+	{
+		var source = new AppSettings
+		{
+			ImportTransformation = new AppSettingsImportTransformationModel
+			{
+				Rules =
+				[
+					new TransformationRule
+					{
+						ColorClass = ColorClassParser.Color.Superior,
+						Conditions = new TransformationConditions
+						{
+							ImageFormats = [ExtensionRolesHelper.ImageFormat.png],
+							Origin = "test-1"
+						}
+					}
+				]
+			}
+		};
+
+		var to = new AppSettings
+		{
+			ImportTransformation = new AppSettingsImportTransformationModel()
+		};
+
+		AppSettingsCompareHelper.Compare(source, to);
+
+		Assert.AreEqual(ColorClassParser.Color.Superior,
+			source.ImportTransformation.Rules[0].ColorClass);
+		Assert.AreEqual("test-1",
+			source.ImportTransformation.Rules[0].Conditions.Origin);
+		Assert.AreEqual(ExtensionRolesHelper.ImageFormat.png,
+			source.ImportTransformation.Rules[0].Conditions.ImageFormats[0]);
+	}
 
 	[TestMethod]
 	public void StringCompare()


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request introduces support for the `AppSettingsImportTransformationModel` and `AppSettingsStructureModel` types across the codebase. The changes include updates to existing logic for handling these types, enhancements to comparison functionality, and the addition of new unit tests to ensure proper behavior.

### Support for new types (`AppSettingsImportTransformationModel` and `AppSettingsStructureModel`):

* [`starsky/starsky.feature.packagetelemetry/Services/PackageTelemetry.cs`](diffhunk://#diff-f990af3b54390f4ee888386c2fbb594abc475fae062448cf30b655e3ed9b32e5L196-R197): Added handling for `AppSettingsStructureModel` in the `AddAppSettingsData` method to parse its content into JSON.

### Enhancements to comparison functionality:

* [`starsky/starsky.foundation.platform/Helpers/AppSettingsCompareHelper.cs`](diffhunk://#diff-32e70689ab2e456e214d4d5e9d62ad63274b4e99246d58fed99a6ca6845098adR79-R91): Introduced a new method `CompareAppSettingsImportTransformationModel` to compare `AppSettingsImportTransformationModel` objects and update differences. Added logic to handle this type in `CompareListMultipleObjects`. [[1]](diffhunk://#diff-32e70689ab2e456e214d4d5e9d62ad63274b4e99246d58fed99a6ca6845098adR79-R91) [[2]](diffhunk://#diff-32e70689ab2e456e214d4d5e9d62ad63274b4e99246d58fed99a6ca6845098adR228-R248)

### Unit tests for new functionality:

* [`starsky/starskytest/starsky.feature.packagetelemetry/Helpers/PackageTelemetryTest.cs`](diffhunk://#diff-2f8767c5bf6d0cb415d22ca9432f7242d3956be6994fccaec6558b41ac45aac5R311-R314): Added test cases for `AppSettingsImportTransformationModel` and `AppSettingsStructureModel` in the `TestPropValueTypeCheck` method to verify type handling. [[1]](diffhunk://#diff-2f8767c5bf6d0cb415d22ca9432f7242d3956be6994fccaec6558b41ac45aac5R311-R314) [[2]](diffhunk://#diff-2f8767c5bf6d0cb415d22ca9432f7242d3956be6994fccaec6558b41ac45aac5R335-R342) [[3]](diffhunk://#diff-2f8767c5bf6d0cb415d22ca9432f7242d3956be6994fccaec6558b41ac45aac5R357-R358)
* [`starsky/starskytest/starsky.foundation.platform/Helpers/AppSettingsCompareHelperTest.cs`](diffhunk://#diff-8e81a2e89857983fa65ca47a240f172d4af9ab85efdb12fe194499bdc8a2af9bR104-R192): Added tests for `AppSettingsImportTransformationModel` to ensure proper comparison and handling of default options.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
