### PR TITLE
log exception http client && expose buffer size && set bigger buffer …

### DIFF
--- a/starsky/starsky.feature.webhtmlpublish/Services/WebHtmlPublishService.cs
+++ b/starsky/starsky.feature.webhtmlpublish/Services/WebHtmlPublishService.cs
@@ -331,12 +331,13 @@ public class WebHtmlPublishService : IWebHtmlPublishService
 			}
 			catch ( AggregateException e )
 			{
-				_logger.LogError(
-					$"[ResizerLocal] Skip due errors: (catch-ed exception) {item.FilePath} {item.FileHash}");
-				foreach ( var exception in e.InnerExceptions )
-				{
-					_logger.LogError("[ResizerLocal] " + exception.Message, exception);
-				}
+				var errorMessage =
+					$"[WebHtmlPublishService/ResizerLocal] Skip due errors: (catch-ed exception) {item.FilePath} {item.FileHash} - ";
+				errorMessage = e.InnerExceptions.Aggregate(errorMessage,
+					(current, exception) =>
+						current +
+						$" {exception.Message} {exception.InnerException?.Message} {exception.GetType().Name}");
+				_logger.LogError(errorMessage);
 			}
 		}
 

--- a/starsky/starsky.foundation.http/Services/HttpClientHelper.cs
+++ b/starsky/starsky.foundation.http/Services/HttpClientHelper.cs
@@ -106,7 +106,8 @@ public sealed class HttpClientHelper : IHttpClientHelper
 		}
 		catch ( Exception exception )
 		{
-			_logger.LogError("[ReadString] HttpClientHelper > Exception ", exception);
+			_logger.LogError($"[ReadString] HttpClientHelper > Exception {exception.Message}",
+				exception);
 			return new KeyValuePair<bool, string>(false, exception.Message);
 		}
 	}

--- a/starsky/starsky.foundation.sync/WatcherInterfaces/IFileSystemWatcherWrapper.cs
+++ b/starsky/starsky.foundation.sync/WatcherInterfaces/IFileSystemWatcherWrapper.cs
@@ -1,27 +1,27 @@
 using System;
 using System.IO;
 
-namespace starsky.foundation.sync.WatcherInterfaces
+namespace starsky.foundation.sync.WatcherInterfaces;
+
+/// <summary>
+///     A wrapper around FileSystemWatcher
+///     @see:
+///     https://docs.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher.notifyfilter?view=netcore-3.1
+///     @see: https://stackoverflow.com/a/50948255/8613589
+/// </summary>
+public interface IFileSystemWatcherWrapper : IDisposable
 {
-	/// <summary>
-	/// A wrapper around FileSystemWatcher
-	/// @see: https://docs.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher.notifyfilter?view=netcore-3.1
-	/// @see: https://stackoverflow.com/a/50948255/8613589
-	/// </summary>
-	public interface IFileSystemWatcherWrapper : IDisposable
-	{
-		event FileSystemEventHandler Created;
-		event FileSystemEventHandler Deleted;
-		event RenamedEventHandler Renamed;
-		event FileSystemEventHandler Changed;
-		event ErrorEventHandler Error;
+	bool EnableRaisingEvents { get; set; }
 
-		bool EnableRaisingEvents { get; set; }
+	bool IncludeSubdirectories { get; set; }
 
-		bool IncludeSubdirectories { get; set; }
-
-		string Path { get; set; }
-		string Filter { get; set; }
-		public NotifyFilters NotifyFilter { get; set; }
-	}
+	string Path { get; set; }
+	string Filter { get; set; }
+	public NotifyFilters NotifyFilter { get; set; }
+	int InternalBufferSize { get; set; }
+	event FileSystemEventHandler Created;
+	event FileSystemEventHandler Deleted;
+	event RenamedEventHandler Renamed;
+	event FileSystemEventHandler Changed;
+	event ErrorEventHandler Error;
 }

--- a/starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs
+++ b/starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using starsky.foundation.injection;
 using starsky.foundation.platform.Helpers;
@@ -11,231 +12,232 @@ using starsky.foundation.sync.WatcherInterfaces;
 
 [assembly: InternalsVisibleTo("starskytest")]
 
-namespace starsky.foundation.sync.WatcherServices
+namespace starsky.foundation.sync.WatcherServices;
+
+/// <summary>
+///     Service is created only once, and used everywhere
+/// </summary>
+[Service(typeof(IDiskWatcher), InjectionLifetime = InjectionLifetime.Singleton)]
+public sealed class DiskWatcher : IDiskWatcher, IDisposable
 {
-	/// <summary>
-	/// Service is created only once, and used everywhere
-	/// </summary>
-	[Service(typeof(IDiskWatcher), InjectionLifetime = InjectionLifetime.Singleton)]
-	public sealed class DiskWatcher : IDiskWatcher, IDisposable
+	private readonly IQueueProcessor _queueProcessor;
+	private readonly IWebLogger _webLogger;
+	private IFileSystemWatcherWrapper _fileSystemWatcherWrapper;
+
+	public DiskWatcher(IFileSystemWatcherWrapper fileSystemWatcherWrapper,
+		IServiceScopeFactory scopeFactory)
 	{
-		private IFileSystemWatcherWrapper _fileSystemWatcherWrapper;
-		private readonly IWebLogger _webLogger;
-		private readonly IQueueProcessor _queueProcessor;
+		_fileSystemWatcherWrapper = fileSystemWatcherWrapper;
+		var serviceProvider = scopeFactory.CreateScope().ServiceProvider;
+		_webLogger = serviceProvider.GetRequiredService<IWebLogger>();
+		_queueProcessor =
+			new QueueProcessor(scopeFactory, new SyncWatcherConnector(scopeFactory).Sync);
+	}
 
-		public DiskWatcher(IFileSystemWatcherWrapper fileSystemWatcherWrapper,
-			IServiceScopeFactory scopeFactory)
+	internal DiskWatcher(
+		IFileSystemWatcherWrapper fileSystemWatcherWrapper,
+		IWebLogger logger, IQueueProcessor queueProcessor)
+	{
+		_fileSystemWatcherWrapper = fileSystemWatcherWrapper;
+		_webLogger = logger;
+		_queueProcessor = queueProcessor;
+	}
+
+	/// <summary>
+	///     @see: https://docs.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher?view=netcore-3.1
+	/// </summary>
+	public void Watcher(string fullFilePath)
+	{
+		if ( !Directory.Exists(fullFilePath) )
 		{
-			_fileSystemWatcherWrapper = fileSystemWatcherWrapper;
-			var serviceProvider = scopeFactory.CreateScope().ServiceProvider;
-			_webLogger = serviceProvider.GetRequiredService<IWebLogger>();
-			_queueProcessor =
-				new QueueProcessor(scopeFactory, new SyncWatcherConnector(scopeFactory).Sync);
+			_webLogger.LogError(
+				$"[DiskWatcher] FAIL can't find directory: {fullFilePath} so watcher is not started");
+			return;
 		}
 
-		internal DiskWatcher(
-			IFileSystemWatcherWrapper fileSystemWatcherWrapper,
-			IWebLogger logger, IQueueProcessor queueProcessor)
+		_webLogger.LogInformation($"[DiskWatcher] started {fullFilePath}" +
+		                          $"{DateTimeDebug()}");
+
+		// Create a new FileSystemWatcher and set its properties.
+
+		_fileSystemWatcherWrapper.Path = fullFilePath;
+		_fileSystemWatcherWrapper.Filter = "*";
+		_fileSystemWatcherWrapper.IncludeSubdirectories = true;
+		_fileSystemWatcherWrapper.NotifyFilter = NotifyFilters.FileName
+		                                         | NotifyFilters.DirectoryName
+		                                         | NotifyFilters.Attributes
+		                                         | NotifyFilters.Size
+		                                         | NotifyFilters.LastWrite
+		                                         | NotifyFilters.CreationTime
+		                                         | NotifyFilters.Security;
+
+		// Watch for changes in LastAccess and LastWrite times, and
+		// the renaming of files or directories.
+
+		// handle many file system events quickly
+		_fileSystemWatcherWrapper.InternalBufferSize = 10 * 1024; // 10 KB - default = 4096 / 4 KB
+
+		// Add event handlers.
+		_fileSystemWatcherWrapper.Created += OnChanged;
+		_fileSystemWatcherWrapper.Changed += OnChanged;
+		_fileSystemWatcherWrapper.Deleted += OnChanged;
+		_fileSystemWatcherWrapper.Renamed += OnRenamed;
+		_fileSystemWatcherWrapper.Error += OnError;
+
+		// Begin watching.
+		_fileSystemWatcherWrapper.EnableRaisingEvents = true;
+	}
+
+	public void Dispose()
+	{
+		_fileSystemWatcherWrapper.EnableRaisingEvents = false;
+		_fileSystemWatcherWrapper.Dispose();
+	}
+
+	private void OnError(object source, ErrorEventArgs e)
+	{
+		//  Show that an error has been detected.
+		_webLogger.LogError(e.GetException(),
+			"[DiskWatcher] The FileSystemWatcher has an error (catch-ed) - next: retry " +
+			$"{DateTimeDebug()}");
+		_webLogger.LogError("[DiskWatcher] (catch-ed) " + e.GetException().Message);
+
+		//  Give more information if the error is due to an internal buffer overflow.
+		if ( e.GetException().GetType() == typeof(InternalBufferOverflowException) )
 		{
-			_fileSystemWatcherWrapper = fileSystemWatcherWrapper;
-			_webLogger = logger;
-			_queueProcessor = queueProcessor;
-		}
-
-		/// <summary>
-		/// @see: https://docs.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher?view=netcore-3.1
-		/// </summary>
-		public void Watcher(string fullFilePath)
-		{
-			if ( !Directory.Exists(fullFilePath) )
-			{
-				_webLogger.LogError(
-					$"[DiskWatcher] FAIL can't find directory: {fullFilePath} so watcher is not started");
-				return;
-			}
-
-			_webLogger.LogInformation($"[DiskWatcher] started {fullFilePath}" +
-									  $"{DateTimeDebug()}");
-
-			// Create a new FileSystemWatcher and set its properties.
-
-			_fileSystemWatcherWrapper.Path = fullFilePath;
-			_fileSystemWatcherWrapper.Filter = "*";
-			_fileSystemWatcherWrapper.IncludeSubdirectories = true;
-			_fileSystemWatcherWrapper.NotifyFilter = NotifyFilters.FileName
-													 | NotifyFilters.DirectoryName
-													 | NotifyFilters.Attributes
-													 | NotifyFilters.Size
-													 | NotifyFilters.LastWrite
-													 | NotifyFilters.CreationTime
-													 | NotifyFilters.Security;
-
-			// Watch for changes in LastAccess and LastWrite times, and
-			// the renaming of files or directories.
-
-			// Add event handlers.
-
-			_fileSystemWatcherWrapper.Created += OnChanged;
-			_fileSystemWatcherWrapper.Changed += OnChanged;
-			_fileSystemWatcherWrapper.Deleted += OnChanged;
-			_fileSystemWatcherWrapper.Renamed += OnRenamed;
-			_fileSystemWatcherWrapper.Error += OnError;
-
-			// Begin watching.
-			_fileSystemWatcherWrapper.EnableRaisingEvents = true;
-		}
-
-		private void OnError(object source, ErrorEventArgs e)
-		{
-			//  Show that an error has been detected.
+			//  This can happen if Windows is reporting many file system events quickly 
+			//  and internal buffer of the  FileSystemWatcher is not large enough to handle this
+			//  rate of events. The InternalBufferOverflowException error informs the application
+			//  that some of the file system events are being lost.
 			_webLogger.LogError(e.GetException(),
-				"[DiskWatcher] The FileSystemWatcher has an error (catch-ed) - next: retry " +
-				$"{DateTimeDebug()}");
-			_webLogger.LogError("[DiskWatcher] (catch-ed) " + e.GetException().Message);
-
-			//  Give more information if the error is due to an internal buffer overflow.
-			if ( e.GetException().GetType() == typeof(InternalBufferOverflowException) )
-			{
-				//  This can happen if Windows is reporting many file system events quickly 
-				//  and internal buffer of the  FileSystemWatcher is not large enough to handle this
-				//  rate of events. The InternalBufferOverflowException error informs the application
-				//  that some of the file system events are being lost.
-				_webLogger.LogError(e.GetException(),
-					"[DiskWatcher] The file system watcher experienced an internal buffer overflow ");
-			}
-
-			// when test dont retry
-			if ( e.GetException().Message == "test" )
-			{
-				return;
-			}
-
-			// When fail it should try it again
-			Retry(new BufferingFileSystemWatcher(_fileSystemWatcherWrapper.Path));
+				"[DiskWatcher] The file system watcher experienced an internal buffer overflow ");
 		}
 
-		/// <summary>
-		/// @see: https://www.codeguru.com/dotnet/filesystemwatcher%EF%BF%BDwhy-does-it-stop-working/
-		/// </summary>
-		internal bool Retry(IFileSystemWatcherWrapper fileSystemWatcherWrapper,
-			int numberOfTries = 20, int milliSecondsTimeout = 5000)
+		// when test dont retry
+		if ( e.GetException().Message == "test" )
 		{
-			_webLogger.LogInformation("[DiskWatcher] next retry " +
-									  $"{DateTimeDebug()}");
-			var path = _fileSystemWatcherWrapper.Path;
-
-			_fileSystemWatcherWrapper.Dispose();
-			_fileSystemWatcherWrapper = fileSystemWatcherWrapper;
-
-			var i = 0;
-			while ( !_fileSystemWatcherWrapper.EnableRaisingEvents && i < numberOfTries )
-			{
-				try
-				{
-					// This will throw an error at the
-					// watcher.NotifyFilter line if it can't get the path.
-					Watcher(path);
-					if ( _fileSystemWatcherWrapper.EnableRaisingEvents )
-					{
-						_webLogger.LogInformation("[DiskWatcher] I'm Back!");
-					}
-
-					return true;
-				}
-				catch
-				{
-					_webLogger.LogInformation(
-						$"[DiskWatcher] next retry {i} - wait for {milliSecondsTimeout}ms");
-					// Sleep for a bit; otherwise, it takes a bit of
-					// processor time
-					System.Threading.Thread.Sleep(milliSecondsTimeout);
-					i++;
-				}
-			}
-
-			_webLogger.LogError($"[DiskWatcher] Failed after {i} times - so stop trying");
-			return false;
+			return;
 		}
 
-		private static string DateTimeDebug()
-		{
-			return ": " + DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss",
-				CultureInfo.InvariantCulture);
-		}
+		// When fail it should try it again
+		Retry(new BufferingFileSystemWatcher(_fileSystemWatcherWrapper.Path));
+	}
 
-		// Define the event handlers.
+	/// <summary>
+	///     @see: https://www.codeguru.com/dotnet/filesystemwatcher%EF%BF%BDwhy-does-it-stop-working/
+	/// </summary>
+	internal bool Retry(IFileSystemWatcherWrapper fileSystemWatcherWrapper,
+		int numberOfTries = 20, int milliSecondsTimeout = 5000)
+	{
+		_webLogger.LogInformation("[DiskWatcher] next retry " +
+		                          $"{DateTimeDebug()}");
+		var path = _fileSystemWatcherWrapper.Path;
 
-		/// <summary>
-		/// Specify what is done when a file is changed. e.FullPath
-		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="e"></param>
-		internal void OnChanged(object source, FileSystemEventArgs e)
-		{
-			if ( e.FullPath.EndsWith(".tmp") ||
-				 !ExtensionRolesHelper.IsExtensionSyncSupported(e.FullPath) )
-			{
-				return;
-			}
+		_fileSystemWatcherWrapper.Dispose();
+		_fileSystemWatcherWrapper = fileSystemWatcherWrapper;
 
-			_webLogger.LogDebug($"[DiskWatcher] " +
-								$"{e.FullPath} OnChanged ChangeType is: {e.ChangeType} " +
-								DateTimeDebug());
-
-			_queueProcessor.QueueInput(e.FullPath, null, e.ChangeType).ConfigureAwait(false);
-			// Specify what is done when a file is changed, created, or deleted.
-		}
-
-		private static FileAttributes? GetFileAttributes(string fullPath)
+		var i = 0;
+		while ( !_fileSystemWatcherWrapper.EnableRaisingEvents && i < numberOfTries )
 		{
 			try
 			{
-				return File.GetAttributes(fullPath);
+				// This will throw an error at the
+				// watcher.NotifyFilter line if it can't get the path.
+				Watcher(path);
+				if ( _fileSystemWatcherWrapper.EnableRaisingEvents )
+				{
+					_webLogger.LogInformation("[DiskWatcher] I'm Back!");
+				}
+
+				return true;
 			}
-			catch ( Exception )
+			catch
 			{
-				return null;
+				_webLogger.LogInformation(
+					$"[DiskWatcher] next retry {i} - wait for {milliSecondsTimeout}ms");
+				// Sleep for a bit; otherwise, it takes a bit of
+				// processor time
+				Thread.Sleep(milliSecondsTimeout);
+				i++;
 			}
 		}
 
-		/// <summary>
-		/// Specify what is done when a file is renamed. e.OldFullPath to e.FullPath
-		/// </summary>
-		/// <param name="source">object source (ignored)</param>
-		/// <param name="e">arguments</param>
-		internal void OnRenamed(object source, RenamedEventArgs e)
+		_webLogger.LogError($"[DiskWatcher] Failed after {i} times - so stop trying");
+		return false;
+	}
+
+	private static string DateTimeDebug()
+	{
+		return ": " + DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss",
+			CultureInfo.InvariantCulture);
+	}
+
+	// Define the event handlers.
+
+	/// <summary>
+	///     Specify what is done when a file is changed. e.FullPath
+	/// </summary>
+	/// <param name="source"></param>
+	/// <param name="e"></param>
+	internal void OnChanged(object source, FileSystemEventArgs e)
+	{
+		if ( e.FullPath.EndsWith(".tmp") ||
+		     !ExtensionRolesHelper.IsExtensionSyncSupported(e.FullPath) )
 		{
-			_webLogger.LogInformation($"[DiskWatcher] {e.OldFullPath} OnRenamed to: {e.FullPath}" +
-									  DateTimeDebug());
+			return;
+		}
 
-			var fileAttributes = GetFileAttributes(e.FullPath);
-			var isDirectory = fileAttributes == FileAttributes.Directory;
+		_webLogger.LogDebug($"[DiskWatcher] " +
+		                    $"{e.FullPath} OnChanged ChangeType is: {e.ChangeType} " +
+		                    DateTimeDebug());
 
-			var isOldFullPathTempFile =
-				e.OldFullPath.Contains(Path.DirectorySeparatorChar + "tmp.{")
-				|| e.OldFullPath.EndsWith(".tmp");
-			var isNewFullPathTempFile = e.FullPath.Contains(Path.DirectorySeparatorChar + "tmp.{")
-										|| e.FullPath.EndsWith(".tmp");
-			if ( !isDirectory && isOldFullPathTempFile )
-			{
-				_queueProcessor.QueueInput(e.FullPath, null, WatcherChangeTypes.Created)
-					.ConfigureAwait(false);
-				return;
-			}
+		_queueProcessor.QueueInput(e.FullPath, null, e.ChangeType).ConfigureAwait(false);
+		// Specify what is done when a file is changed, created, or deleted.
+	}
 
-			if ( !isDirectory && isNewFullPathTempFile )
-			{
-				return;
-			}
+	private static FileAttributes? GetFileAttributes(string fullPath)
+	{
+		try
+		{
+			return File.GetAttributes(fullPath);
+		}
+		catch ( Exception )
+		{
+			return null;
+		}
+	}
 
-			_queueProcessor.QueueInput(e.OldFullPath, e.FullPath, WatcherChangeTypes.Renamed)
+	/// <summary>
+	///     Specify what is done when a file is renamed. e.OldFullPath to e.FullPath
+	/// </summary>
+	/// <param name="source">object source (ignored)</param>
+	/// <param name="e">arguments</param>
+	internal void OnRenamed(object source, RenamedEventArgs e)
+	{
+		_webLogger.LogInformation($"[DiskWatcher] {e.OldFullPath} OnRenamed to: {e.FullPath}" +
+		                          DateTimeDebug());
+
+		var fileAttributes = GetFileAttributes(e.FullPath);
+		var isDirectory = fileAttributes == FileAttributes.Directory;
+
+		var isOldFullPathTempFile =
+			e.OldFullPath.Contains(Path.DirectorySeparatorChar + "tmp.{")
+			|| e.OldFullPath.EndsWith(".tmp");
+		var isNewFullPathTempFile = e.FullPath.Contains(Path.DirectorySeparatorChar + "tmp.{")
+		                            || e.FullPath.EndsWith(".tmp");
+		if ( !isDirectory && isOldFullPathTempFile )
+		{
+			_queueProcessor.QueueInput(e.FullPath, null, WatcherChangeTypes.Created)
 				.ConfigureAwait(false);
+			return;
 		}
 
-		public void Dispose()
+		if ( !isDirectory && isNewFullPathTempFile )
 		{
-			_fileSystemWatcherWrapper.EnableRaisingEvents = false;
-			_fileSystemWatcherWrapper.Dispose();
+			return;
 		}
+
+		_queueProcessor.QueueInput(e.OldFullPath, e.FullPath, WatcherChangeTypes.Renamed)
+			.ConfigureAwait(false);
 	}
 }

--- a/starsky/starskytest/FakeMocks/FakeIFileSystemWatcherWrapper.cs
+++ b/starsky/starskytest/FakeMocks/FakeIFileSystemWatcherWrapper.cs
@@ -2,78 +2,79 @@ using System;
 using System.IO;
 using starsky.foundation.sync.WatcherInterfaces;
 
-namespace starskytest.FakeMocks
+namespace starskytest.FakeMocks;
+
+public class FakeIFileSystemWatcherWrapper : IFileSystemWatcherWrapper
 {
-	public class FakeIFileSystemWatcherWrapper : IFileSystemWatcherWrapper
+	public bool CrashOnEnableRaisingEvents { get; set; } = false;
+
+	public bool EnableRaisingEventsPrivate { get; set; }
+
+	public bool IsDisposed { get; set; }
+
+	public event FileSystemEventHandler? Created;
+
+	public event FileSystemEventHandler? Deleted;
+
+	public event RenamedEventHandler? Renamed;
+
+	public event FileSystemEventHandler? Changed;
+	public event ErrorEventHandler? Error;
+
+	public bool EnableRaisingEvents
 	{
-		public void TriggerOnChanged(FileSystemEventArgs args)
+		get => EnableRaisingEventsPrivate;
+		set
 		{
-			Changed?.Invoke(this, args);
-		}
-		
-		public event FileSystemEventHandler? Created;
-		
-		public void TriggerOnCreated(FileSystemEventArgs args)
-	    {
-	        Created?.Invoke(this, args);
-	    }
-        		
-		public void TriggerOnDeleted(RenamedEventArgs args)
-		{
-			Deleted?.Invoke(this, args);
-		}
-		
-		public event FileSystemEventHandler? Deleted;
-		
-		public void TriggerOnRename(RenamedEventArgs args)
-		{
-			Renamed?.Invoke(this, args);
-		}
-		
-		public event RenamedEventHandler? Renamed;
-		
-		public event FileSystemEventHandler? Changed;
-		public event ErrorEventHandler? Error;
-		
-		public void TriggerOnError(ErrorEventArgs args)
-		{
-			Error?.Invoke(this, args);
-		}
-
-		public bool CrashOnEnableRaisingEvents { get; set; } = false;
-
-		public bool EnableRaisingEventsPrivate { get; set; }
-
-		public bool EnableRaisingEvents
-		{
-			get => EnableRaisingEventsPrivate;
-			set
+			if ( CrashOnEnableRaisingEvents && value )
 			{
-				if ( CrashOnEnableRaisingEvents && value )
-				{
-					throw new Exception("test");
-				}
-				
-				EnableRaisingEventsPrivate = value;
+				throw new Exception("test");
 			}
-		}
 
-		public bool IncludeSubdirectories { get; set; }
-		public string Path { get; set; } = string.Empty;
-		public string Filter { get; set; } = string.Empty;
-		public NotifyFilters NotifyFilter { get; set; }
+			EnableRaisingEventsPrivate = value;
+		}
+	}
 
-		public bool IsDisposed { get; set; }
-		void IDisposable.Dispose()
-		{
-			GC.SuppressFinalize(this);
-			IsDisposed = true;
-			Dispose(true);
-		}
-		
-		protected virtual void Dispose(bool disposing)
-		{
-			IsDisposed = true;
-		}
+	public bool IncludeSubdirectories { get; set; }
+	public string Path { get; set; } = string.Empty;
+	public string Filter { get; set; } = string.Empty;
+	public NotifyFilters NotifyFilter { get; set; }
+	public int InternalBufferSize { get; set; }
+
+	void IDisposable.Dispose()
+	{
+		GC.SuppressFinalize(this);
+		IsDisposed = true;
+		Dispose(true);
+	}
+
+	public void TriggerOnChanged(FileSystemEventArgs args)
+	{
+		Changed?.Invoke(this, args);
+	}
+
+	public void TriggerOnCreated(FileSystemEventArgs args)
+	{
+		Created?.Invoke(this, args);
+	}
+
+	public void TriggerOnDeleted(RenamedEventArgs args)
+	{
+		Deleted?.Invoke(this, args);
+	}
+
+	public void TriggerOnRename(RenamedEventArgs args)
+	{
+		Renamed?.Invoke(this, args);
+	}
+
+	public void TriggerOnError(ErrorEventArgs args)
+	{
+		Error?.Invoke(this, args);
+	}
+
+	protected virtual void Dispose(bool disposing)
+	{
+		IsDisposed = true;
 	}
 }


### PR DESCRIPTION
…size && reformat DiskWatcher && only change here is: 		_fileSystemWatcherWrapper.InternalBufferSize = 10 * 1024; // 10 KB - default = 4096 / 4 KB

&& reformat fake system watcher wrapper && change logging WebHtmlPublishService/ResizerLocal

This pull request introduces several improvements and refactorings across multiple files, focusing on logging enhancements, namespace simplification, and updates to the file system watcher functionality. The key changes include improving error logging, adopting file-scoped namespaces, and enhancing the `DiskWatcher` service with additional features like buffer size configuration and proper disposal handling.

### Logging Improvements:
* Enhanced error logging in `ResizerLocal` to include detailed exception messages, inner exceptions, and exception types for better debugging. (`starsky/starsky.feature.webhtmlpublish/Services/WebHtmlPublishService.cs`, [starsky/starsky.feature.webhtmlpublish/Services/WebHtmlPublishService.csL334-R340](diffhunk://#diff-0a57c94d1d89e123600d5791107eb9e3183e07cb8f59b8563b0372e1b9dbe069L334-R340))
* Improved exception logging in `ReadString` to include exception messages in the log output for better clarity. (`starsky/starsky.foundation.http/Services/HttpClientHelper.cs`, [starsky/starsky.foundation.http/Services/HttpClientHelper.csL109-R110](diffhunk://#diff-aeaaa20f750fb966d40aa323f860ec773d6a1a9d082372edb18edc63d72989d0L109-R110))

### Namespace Simplification:
* Transitioned to file-scoped namespaces in `IFileSystemWatcherWrapper`, `DiskWatcher`, and `FakeIFileSystemWatcherWrapper` for cleaner and more modern code structure. (`starsky/starsky.foundation.sync/WatcherInterfaces/IFileSystemWatcherWrapper.cs`, [[1]](diffhunk://#diff-4e702986d3a5f326eb37eb2da4f8f76286b621666b7bc224d31ab2b22bbe19bdL4-R26); `starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs`, [[2]](diffhunk://#diff-83b7ce6726311ccc80dd83a5ddb6953ee89ac1256cb22a63b8bdbeaca436bddfL14-R25); `starsky/starskytest/FakeMocks/FakeIFileSystemWatcherWrapper.cs`, [[3]](diffhunk://#diff-1c1455b3025488d82388fa0d68a7935f84072b9780dc95e7a4893cbc11453d8fL5-L46)

### File System Watcher Enhancements:
* Added `InternalBufferSize` property to `IFileSystemWatcherWrapper` and configured it in `DiskWatcher` to handle a larger number of file system events efficiently. (`starsky/starsky.foundation.sync/WatcherInterfaces/IFileSystemWatcherWrapper.cs`, [[1]](diffhunk://#diff-4e702986d3a5f326eb37eb2da4f8f76286b621666b7bc224d31ab2b22bbe19bdL4-R26); `starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs`, [[2]](diffhunk://#diff-83b7ce6726311ccc80dd83a5ddb6953ee89ac1256cb22a63b8bdbeaca436bddfL76-R80)
* Implemented proper disposal of `DiskWatcher` to ensure resources are released and event handling is disabled when no longer needed. (`starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs`, [[1]](diffhunk://#diff-83b7ce6726311ccc80dd83a5ddb6953ee89ac1256cb22a63b8bdbeaca436bddfR91-R96) [[2]](diffhunk://#diff-83b7ce6726311ccc80dd83a5ddb6953ee89ac1256cb22a63b8bdbeaca436bddfL234-L240)

### Miscellaneous Updates:
* Updated `FakeIFileSystemWatcherWrapper` to include methods for triggering events and added the `InternalBufferSize` property for testing purposes. (`starsky/starskytest/FakeMocks/FakeIFileSystemWatcherWrapper.cs`, [starsky/starskytest/FakeMocks/FakeIFileSystemWatcherWrapper.csR42-L79](diffhunk://#diff-1c1455b3025488d82388fa0d68a7935f84072b9780dc95e7a4893cbc11453d8fR42-L79))
* Replaced fully qualified `System.Threading.Thread.Sleep` with a simpler `Thread.Sleep` in `DiskWatcher` for consistency. (`starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.cs`, [starsky/starsky.foundation.sync/WatcherServices/DiskWatcher.csL151-R160](diffhunk://#diff-83b7ce6726311ccc80dd83a5ddb6953ee89ac1256cb22a63b8bdbeaca436bddfL151-R160))
# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
