### PR TITLE
timezone issue

### DIFF
--- a/starsky/starskytest/starsky.foundation.settings/Services/SettingsServiceTest.cs
+++ b/starsky/starskytest/starsky.foundation.settings/Services/SettingsServiceTest.cs
@@ -110,7 +110,7 @@ public class SettingsServiceTest
 
 		DateTime defaultDatetime = default;
 		Assert.AreEqual(defaultDatetime.ToString(CultureInfo.InvariantCulture),
-			item.ToUniversalTime().ToString(CultureInfo.InvariantCulture));
+			item.ToString(CultureInfo.InvariantCulture));
 		await RemoveAsync(dbContext, SettingsType
 			.LastSyncBackgroundDateTime);
 	}


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request makes a minor adjustment to a unit test in `SettingsServiceTest.cs` to improve the accuracy of the `DateTime` comparison. The test now compares the string representation of the default `DateTime` directly, rather than converting the test value to universal time before comparison.

([starsky/starskytest/starsky.foundation.settings/Services/SettingsServiceTest.csL113-R113](diffhunk://#diff-f11caff6a4f951ed9505aec311206b1f3100bb3706b2e935c126ee1def898610L113-R113))

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
