### PR TITLE
code smells 12

### DIFF
--- a/starsky/starskytest/Architecture/ArchitectureTest.cs
+++ b/starsky/starskytest/Architecture/ArchitectureTest.cs
@@ -227,12 +227,13 @@ public partial class TheSolutionShould
 	private static void AssertLayerReferences(IReadOnlyCollection<string> invalidReferences,
 		string layer)
 	{
-		Assert.AreEqual(0, invalidReferences.Count,
+		Assert.IsEmpty(invalidReferences,
 			$"There should be no Helix incompatible references in the {layer} layer. " +
 			$"{invalidReferences.Count} invalid reference{( invalidReferences.Count == 1 ? " was" : "s were" )} " +
 			$"found: {string.Join(", ", invalidReferences)}. Expected 0");
 	}
 
-	[GeneratedRegex("Project\\(\"\\{[\\w-]*\\}\"\\) = \"([\\w _]*.*)\", \"(.*\\.(cs|vcx|vb)proj)\"", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+	[GeneratedRegex("Project\\(\"\\{[\\w-]*\\}\"\\) = \"([\\w _]*.*)\", \"(.*\\.(cs|vcx|vb)proj)\"",
+		RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
 	private static partial Regex ProjectFileNameRegex();
 }

--- a/starsky/starskytest/Controllers/AppSettingsControllerTest.cs
+++ b/starsky/starskytest/Controllers/AppSettingsControllerTest.cs
@@ -138,8 +138,8 @@ public sealed class AppSettingsControllerTest
 		var jsonContent = await StreamToStringHelper.StreamToStringAsync(
 			storage.ReadStream(appSettings.AppSettingsPath));
 
-		Assert.IsTrue(jsonContent.Contains("app\": {"));
-		Assert.IsTrue(jsonContent.Contains("\"StorageFolder\": \""));
+		Assert.Contains("app\": {", jsonContent);
+		Assert.Contains("\"StorageFolder\": \"", jsonContent);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/Controllers/DiskControllerTest.cs
+++ b/starsky/starskytest/Controllers/DiskControllerTest.cs
@@ -243,7 +243,7 @@ public sealed class DiskControllerTest
 		await controller.Rename(_createAnImage.DbPath, "/test.jpg");
 
 		Assert.AreEqual(1, socket.FakeSendToAllAsync.Count(p => !p.Contains("[system]")));
-		Assert.IsTrue(socket.FakeSendToAllAsync[0].Contains("/test.jpg"));
+		Assert.Contains("/test.jpg", socket.FakeSendToAllAsync[0]);
 
 		await _query.RemoveItemAsync(( await _query.GetObjectByFilePathAsync("/test.jpg") )!);
 	}
@@ -309,7 +309,7 @@ public sealed class DiskControllerTest
 			!p.StartsWith("[system]"));
 
 		Assert.IsNotNull(value);
-		Assert.IsTrue(value.Contains("/test_dir"));
+		Assert.Contains("/test_dir", value);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/Controllers/ExportControllerTest.cs
+++ b/starsky/starskytest/Controllers/ExportControllerTest.cs
@@ -105,6 +105,8 @@ public sealed class ExportControllerTest
 		_bgTaskQueue = new UpdateBackgroundTaskQueue(scopeFactory);
 	}
 
+	public TestContext TestContext { get; set; }
+
 	[TestMethod]
 	public async Task ExportController_CreateZipNotFound()
 	{
@@ -205,11 +207,12 @@ public sealed class ExportControllerTest
 		var actionResult = await controller.CreateZip(_createAnImage.DbPath) as JsonResult;
 
 		Assert.IsNotNull(actionResult);
-		var zipHash = actionResult!.Value as string;
+		var zipHash = actionResult.Value as string;
 
-		Assert.IsTrue(zipHash!.Contains("SR"));
+		Assert.IsNotNull(zipHash);
+		Assert.Contains("SR", zipHash);
 
-		await Task.Delay(150);
+		await Task.Delay(150, TestContext.CancellationTokenSource.Token);
 
 		// Get from real fs in to fake memory
 		var sourceFullPath = Path.Join(appSettings.TempFolder, zipHash) + ".zip";
@@ -281,7 +284,7 @@ public sealed class ExportControllerTest
 
 		var filePaths = await export.CreateListToExport(fileIndexResultsList, true);
 
-		Assert.AreEqual(0, filePaths.Count);
+		Assert.IsEmpty(filePaths);
 	}
 
 
@@ -305,7 +308,7 @@ public sealed class ExportControllerTest
 
 		var filePaths = await export.CreateListToExport(fileIndexResultsList, true);
 
-		Assert.AreEqual(0, filePaths.Count);
+		Assert.IsEmpty(filePaths);
 	}
 
 	[TestMethod]
@@ -340,8 +343,8 @@ public sealed class ExportControllerTest
 
 		var filePaths = await export.CreateListToExport(fileIndexResultsList, false);
 
-		Assert.IsTrue(filePaths[0].Contains("test.dng"));
-		Assert.IsTrue(filePaths[1].Contains("test.xmp"));
+		Assert.Contains("test.dng", filePaths[0]);
+		Assert.Contains("test.xmp", filePaths[1]);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/Controllers/ImportControllerTest.cs
+++ b/starsky/starskytest/Controllers/ImportControllerTest.cs
@@ -130,7 +130,7 @@ public sealed class ImportControllerTest
 		var result = await importController.ImportPostBackgroundTask(
 			new List<string> { "/test" }, new ImportSettingsModel());
 
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 		Assert.AreEqual(ImportStatus.NotFound, result[0].Status);
 	}
 
@@ -166,7 +166,7 @@ public sealed class ImportControllerTest
 		await importController.ImportPostBackgroundTask(
 			new List<string> { "/test" }, new ImportSettingsModel(), true);
 
-		Assert.AreEqual(1, logger.TrackedInformation.Count);
+		Assert.HasCount(1, logger.TrackedInformation);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/Controllers/UploadControllerTest.cs
+++ b/starsky/starskytest/Controllers/UploadControllerTest.cs
@@ -228,7 +228,7 @@ public sealed class UploadControllerTest
 		var getAllFiles = await _query.GetAllFilesAsync(toPlaceFolder);
 
 		// Should not duplicate
-		Assert.AreEqual(1, getAllFiles.Count);
+		Assert.HasCount(1, getAllFiles);
 
 		var queryResult = _query.SingleItem(toPlaceSubPath);
 		Assert.AreEqual("Sony", queryResult?.FileIndexItem?.Make);

--- a/starsky/starskytest/Helpers/CompressionMimeTests.cs
+++ b/starsky/starskytest/Helpers/CompressionMimeTests.cs
@@ -14,9 +14,8 @@ public class CompressionMimeTests
 		var result = CompressionMime.GetCompressionMimeTypes().ToList();
 
 		// Assert
-		Assert.IsTrue(result.Contains("application/xhtml+xml"));
-		Assert.IsTrue(result.Contains("image/svg+xml"));
-		Assert.IsTrue(
-			result.Contains("text/plain")); // Example from ResponseCompressionDefaults.MimeTypes
+		Assert.Contains("application/xhtml+xml", result);
+		Assert.Contains("image/svg+xml", result);
+		Assert.Contains("text/plain", result); // Example from ResponseCompressionDefaults.MimeTypes
 	}
 }

--- a/starsky/starskytest/Helpers/FileIndexCompareHelperTest.cs
+++ b/starsky/starskytest/Helpers/FileIndexCompareHelperTest.cs
@@ -16,7 +16,7 @@ namespace starskytest.Helpers
 		{
 			var source = new FileIndexItem { Tags = "hi" };
 			var changes = FileIndexCompareHelper.Compare(source);
-			Assert.AreEqual(0, changes.Count);
+			Assert.IsEmpty(changes);
 		}
 
 		[TestMethod]
@@ -157,7 +157,7 @@ namespace starskytest.Helpers
 			var update = new FileIndexItem { LastChanged = new List<string> { "test" } };
 			FileIndexCompareHelper.Compare(source,
 				update); // it element is updated, but the list not
-			Assert.AreEqual(1, source.LastChanged.Count);
+			Assert.HasCount(1, source.LastChanged);
 		}
 
 		[TestMethod]
@@ -166,7 +166,7 @@ namespace starskytest.Helpers
 			var source = new FileIndexItem { LastChanged = new List<string>() };
 			var update = new FileIndexItem { LastChanged = new List<string> { "test" } };
 			var result = FileIndexCompareHelper.Compare(source, update);
-			Assert.AreEqual(0, result.Count);
+			Assert.IsEmpty(result);
 		}
 
 		[TestMethod]

--- a/starsky/starskytest/Helpers/FileStreamingHelperTest.cs
+++ b/starsky/starskytest/Helpers/FileStreamingHelperTest.cs
@@ -176,7 +176,7 @@ public sealed class FileStreamingHelperTest
 
 		var tempPath = storage.GetAllFilesInDirectoryRecursive(_appSettings.TempFolder).ToList()[0];
 
-		Assert.IsTrue(tempPath.EndsWith("a.txt"));
+		Assert.EndsWith("a.txt", tempPath);
 
 		CleanParentFolder(tempPath);
 	}

--- a/starsky/starskytest/Helpers/ReplaceReDirectorHelperTest.cs
+++ b/starsky/starskytest/Helpers/ReplaceReDirectorHelperTest.cs
@@ -30,7 +30,7 @@ public class ReplaceReDirectorHelperTest
 		);
 	}
 	
-	[DataTestMethod]
+	[TestMethod]
 	[DataRow("/api/test", "{\"errors\": [{\"status\": \"401\" }]}", 
 		HttpStatusCode.Unauthorized, "application/json")]
 	[DataRow("/test", "", HttpStatusCode.OK, null)]

--- a/starsky/starskytest/Helpers/SwaggerHelperTest.cs
+++ b/starsky/starskytest/Helpers/SwaggerHelperTest.cs
@@ -102,7 +102,7 @@ namespace starskytest.Helpers
 
 			System.Console.WriteLine("swaggerFileContent " + swaggerFileContent);
 
-			Assert.IsTrue(swaggerFileContent.Contains($"\"title\": \"{_appSettings.Name}\""));
+			Assert.Contains($"\"title\": \"{_appSettings.Name}\"", swaggerFileContent);
 		}
 	}
 }

--- a/starsky/starskytest/Helpers/TimeApplicationRunningTests.cs
+++ b/starsky/starskytest/Helpers/TimeApplicationRunningTests.cs
@@ -43,8 +43,8 @@ public class TimeApplicationRunningTests
 
 		Console.WriteLine(time);
 
-		Assert.IsTrue(time > 0.00000000001);
-		Assert.IsTrue(time < 1000);
+		Assert.IsGreaterThan(0.00000000001, time);
+		Assert.IsLessThan(1000, time);
 	}
 
 	private sealed class FakeHostApplicationLifetime(CancellationToken applicationStopping)

--- a/starsky/starskytest/starsky.feature.desktop/Service/OpenEditorPreflightTests.cs
+++ b/starsky/starskytest/starsky.feature.desktop/Service/OpenEditorPreflightTests.cs
@@ -30,11 +30,11 @@ public class OpenEditorPreflightTests
 
 		var result = await openEditorPreflight.PreflightAsync(inputFilePaths, collections);
 
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 		Assert.AreEqual("/test.jpg", result[0].SubPath);
 		Assert.AreEqual(FileIndexItem.ExifStatus.Ok, result[0].Status);
 		Assert.AreEqual(ExtensionRolesHelper.ImageFormat.unknown, result[0].ImageFormat);
-		Assert.IsTrue(result[0].FullFilePath.EndsWith("test.jpg"));
+		Assert.EndsWith("test.jpg", result[0].FullFilePath);
 		Assert.AreEqual(string.Empty, result[0].AppPath);
 	}
 
@@ -74,11 +74,11 @@ public class OpenEditorPreflightTests
 
 		var result = await openEditorPreflight.PreflightAsync(inputFilePaths, collections);
 
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 		Assert.AreEqual("/test.jpg", result[0].SubPath);
 		Assert.AreEqual(FileIndexItem.ExifStatus.Ok, result[0].Status);
 		Assert.AreEqual(ExtensionRolesHelper.ImageFormat.jpg, result[0].ImageFormat);
-		Assert.IsTrue(result[0].FullFilePath.EndsWith("test.jpg"));
+		Assert.EndsWith("test.jpg", result[0].FullFilePath);
 		Assert.AreEqual(string.Empty, result[0].AppPath);
 	}
 
@@ -120,11 +120,11 @@ public class OpenEditorPreflightTests
 
 		var result = await openEditorPreflight.PreflightAsync(inputFilePaths, collections);
 
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 		Assert.AreEqual("/test.jpg", result[0].SubPath);
 		Assert.AreEqual(FileIndexItem.ExifStatus.Ok, result[0].Status);
 		Assert.AreEqual(ExtensionRolesHelper.ImageFormat.jpg, result[0].ImageFormat);
-		Assert.IsTrue(result[0].FullFilePath.EndsWith("test.jpg"));
+		Assert.EndsWith("test.jpg", result[0].FullFilePath);
 		Assert.AreEqual("/app/test", result[0].AppPath);
 	}
 
@@ -148,7 +148,7 @@ public class OpenEditorPreflightTests
 		var result =
 			await openEditorPreflight.GetObjectsToOpenFromDatabase(inputFilePaths, collections);
 
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 		Assert.AreEqual("/test.jpg", result[0].FilePath);
 		Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundSourceMissing, result[0].Status);
 	}
@@ -178,7 +178,7 @@ public class OpenEditorPreflightTests
 		var result =
 			await openEditorPreflight.GetObjectsToOpenFromDatabase(inputFilePaths, collections);
 
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 		Assert.AreEqual("/readonly/test.jpg", result[0].FilePath);
 		Assert.AreEqual(FileIndexItem.ExifStatus.ReadOnly, result[0].Status);
 	}
@@ -209,7 +209,7 @@ public class OpenEditorPreflightTests
 		var result =
 			await openEditorPreflight.GetObjectsToOpenFromDatabase(inputFilePaths, collections);
 
-		Assert.AreEqual(0, result.Count);
+		Assert.IsEmpty(result);
 	}
 
 	[TestMethod]
@@ -240,7 +240,7 @@ public class OpenEditorPreflightTests
 			await openEditorPreflight.GetObjectsToOpenFromDatabase(inputFilePaths, collections);
 
 		// Change the status to Ok
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 		Assert.AreEqual("/test.mp4", result[0].FilePath);
 		Assert.AreEqual(FileIndexItem.ExifStatus.Ok, result[0].Status);
 	}
@@ -278,7 +278,7 @@ public class OpenEditorPreflightTests
 			await openEditorPreflight.GetObjectsToOpenFromDatabase(inputFilePaths, collections);
 
 		// removed duplicates
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 		Assert.AreEqual("/test.mp4", result[0].FilePath);
 		Assert.AreEqual(FileIndexItem.ExifStatus.Ok, result[0].Status);
 	}
@@ -311,7 +311,7 @@ public class OpenEditorPreflightTests
 			await openEditorPreflight.GetObjectsToOpenFromDatabase(inputFilePaths, collections);
 
 		// Change the status to Ok
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 		Assert.AreEqual("/test.mp4", result[0].FilePath);
 		Assert.AreEqual(FileIndexItem.ExifStatus.Ok, result[0].Status);
 	}
@@ -346,7 +346,7 @@ public class OpenEditorPreflightTests
 		var result = preflight.GroupByFileCollectionName(fileIndexList);
 
 		// Assert
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 
 		var collection1 = result.Find(p => p.FileCollectionName == "collection1");
 
@@ -393,7 +393,7 @@ public class OpenEditorPreflightTests
 		var result = preflight.GroupByFileCollectionName(fileIndexList);
 
 		// Assert
-		Assert.AreEqual(3, result.Count);
+		Assert.HasCount(3, result);
 
 		var collection1 = result.Find(p => p.FileCollectionName == "collection1");
 		var collection2 = result.Find(p => p.FileCollectionName == "collection2");
@@ -434,7 +434,7 @@ public class OpenEditorPreflightTests
 		var result = preflight.GroupByFileCollectionName(fileIndexList);
 
 		// Assert
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 
 		var collection1 = result.Find(p => p.FileCollectionName == "collection1");
 
@@ -471,7 +471,7 @@ public class OpenEditorPreflightTests
 		var result = preflight.GroupByFileCollectionName(fileIndexList);
 
 		// Assert
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 
 		var collection1 = result.Find(p => p.FileCollectionName == "collection1");
 
@@ -509,7 +509,7 @@ public class OpenEditorPreflightTests
 		var result = preflight.GroupByFileCollectionName(fileIndexList, false);
 
 		// Assert
-		Assert.AreEqual(2, result.Count);
+		Assert.HasCount(2, result);
 
 		var collection1Xmp = result.Find(p => p.FileName == "collection1.xmp");
 		var collection1Jpg = result.Find(p => p.FileName == "collection1.jpg");
@@ -548,7 +548,7 @@ public class OpenEditorPreflightTests
 		var result = preflight.GroupByFileCollectionName(fileIndexList);
 
 		// Assert
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 
 		var collection1 = result.Find(p => p.FileCollectionName == "collection1");
 

--- a/starsky/starskytest/starsky.feature.export/Services/ExportServiceTest.cs
+++ b/starsky/starskytest/starsky.feature.export/Services/ExportServiceTest.cs
@@ -28,7 +28,7 @@ public class ExportServiceTest
 		var (_, fileIndexResultsList) =
 			await exportService.PreflightAsync(new List<string> { "/test" }.ToArray());
 
-		Assert.AreEqual(1, fileIndexResultsList.Count);
+		Assert.HasCount(1, fileIndexResultsList);
 	}
 
 	[TestMethod]
@@ -48,7 +48,7 @@ public class ExportServiceTest
 		var (_, fileIndexResultsList) =
 			await exportService.PreflightAsync(new List<string> { "/test/test.jpg" }.ToArray());
 
-		Assert.AreEqual(3, fileIndexResultsList.Count);
+		Assert.HasCount(3, fileIndexResultsList);
 		Assert.AreEqual(1, fileIndexResultsList.Count(p => p.FilePath == "/test/test.jpg"));
 		Assert.AreEqual(1, fileIndexResultsList.Count(p => p.FilePath == "/test/test.dng"));
 	}
@@ -72,7 +72,7 @@ public class ExportServiceTest
 			await exportService.PreflightAsync(new List<string> { "/test/test.jpg" }.ToArray(),
 				false);
 
-		Assert.AreEqual(1, fileIndexResultsList.Count);
+		Assert.HasCount(1, fileIndexResultsList);
 		Assert.AreEqual(1, fileIndexResultsList.Count(p => p.FilePath == "/test/test.jpg"));
 		Assert.AreEqual(0, fileIndexResultsList.Count(p => p.FilePath == "/test/test.dng"));
 	}
@@ -94,7 +94,7 @@ public class ExportServiceTest
 		var (_, fileIndexResultsList) =
 			await exportService.PreflightAsync(new List<string> { "/test" }.ToArray());
 
-		Assert.AreEqual(0, fileIndexResultsList.Count);
+		Assert.IsEmpty(fileIndexResultsList);
 	}
 
 	[TestMethod]
@@ -128,7 +128,7 @@ public class ExportServiceTest
 			new FakeSelectorStorage(), new FakeIWebLogger(), new FakeIThumbnailService());
 		var (_, fileIndexResultsList) =
 			await exportService.PreflightAsync(new List<string> { "/test" }.ToArray());
-		Assert.AreEqual(1, fileIndexResultsList.Count);
+		Assert.HasCount(1, fileIndexResultsList);
 		Assert.AreEqual(FileIndexItem.ExifStatus.NotFoundNotInIndex,
 			fileIndexResultsList[0].Status);
 	}
@@ -141,7 +141,7 @@ public class ExportServiceTest
 		var (zipHash, _) =
 			await exportService.PreflightAsync(new List<string> { "/test" }.ToArray(), false, true);
 
-		Assert.IsTrue(zipHash.StartsWith("TN"));
+		Assert.StartsWith("TN", zipHash);
 	}
 
 	[TestMethod]
@@ -152,7 +152,7 @@ public class ExportServiceTest
 		var (zipHash, _) =
 			await exportService.PreflightAsync(new List<string> { "/test" }.ToArray(), false);
 
-		Assert.IsTrue(zipHash.StartsWith("SR"));
+		Assert.StartsWith("SR", zipHash);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/starsky.feature.webhtmlpublish/ViewModels/WebHtmlViewModelTest.cs
+++ b/starsky/starskytest/starsky.feature.webhtmlpublish/ViewModels/WebHtmlViewModelTest.cs
@@ -23,8 +23,8 @@ public sealed class WebHtmlViewModelTest
 		Assert.AreEqual("test", model.ItemName);
 		Assert.AreEqual("Starsky", model.AppSettings.Name);
 		Assert.AreEqual(TemplateContentType.None, model.CurrentProfile.ContentType);
-		Assert.AreEqual(0, model.Profiles.Count);
+		Assert.IsEmpty(model.Profiles);
 		Assert.AreEqual(0, model.Base64ImageArray.Length);
-		Assert.AreEqual(0, model.FileIndexItems.Count);
+		Assert.IsEmpty(model.FileIndexItems);
 	}
 }

--- a/starsky/starskytest/starsky.foundation.accountmanagement/Helpers/Pbkdf2HasherTests.cs
+++ b/starsky/starskytest/starsky.foundation.accountmanagement/Helpers/Pbkdf2HasherTests.cs
@@ -21,7 +21,7 @@ public class Pbkdf2HasherTests
 
 		// Assert
 		Assert.IsNotNull(hash);
-		Assert.IsTrue(hash.Length > 0);
+		Assert.IsGreaterThan(0, hash.Length);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/starsky.foundation.accountmanagement/Services/UserManagerTest.cs
+++ b/starsky/starskytest/starsky.foundation.accountmanagement/Services/UserManagerTest.cs
@@ -212,7 +212,7 @@ public sealed class UserManagerTest
 		Assert.AreEqual(ValidateResultError.UserNotFound, result.Error);
 	}
 
-	[DataTestMethod] // [Theory]
+	[TestMethod] // [Theory]
 	[DataRow(true)]
 	[DataRow(false)]
 	public async Task ValidateAsync_Transform_To_Iterate100K(bool cacheEnabled)
@@ -585,7 +585,7 @@ public sealed class UserManagerTest
 			new AppSettings(), logger, new FakeMemoryCache());
 		var users = ( await userManager.AllUsersAsync() ).Users;
 
-		Assert.AreEqual(0, users.Count);
+		Assert.IsEmpty(users);
 		Assert.IsTrue(logger.TrackedExceptions.LastOrDefault().Item2
 			?.Contains("RetryLimitExceededException"));
 	}
@@ -893,7 +893,7 @@ public sealed class UserManagerTest
 			_memoryCache);
 		var result = userManager.GetUserPermissionClaims(new Role { Id = 99 }).ToList();
 
-		Assert.AreEqual(1, result.Count);
+		Assert.HasCount(1, result);
 		Assert.AreEqual("test", result[0].Value);
 	}
 

--- a/starsky/starskytest/starsky.foundation.database/DataProtection/SqlXmlRepositoryTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/DataProtection/SqlXmlRepositoryTest.cs
@@ -51,7 +51,7 @@ public class SqlXmlRepositoryTest
 
 		var result = _repository.GetAllElements().ToList();
 
-		Assert.AreEqual(0, result.Count);
+		Assert.IsEmpty(result);
 	}
 
 	[TestMethod]
@@ -108,7 +108,7 @@ public class SqlXmlRepositoryTest
 			new SqlXmlRepository(new GetAllElementsAppDbMySqlException2(options), null!,
 					new FakeIWebLogger())
 				.GetAllElements();
-		Assert.AreEqual(0, readOnlyCollection.Count);
+		Assert.IsEmpty(readOnlyCollection);
 	}
 
 

--- a/starsky/starskytest/starsky.foundation.database/Thumbnails/ThumbnailQueryTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/Thumbnails/ThumbnailQueryTest.cs
@@ -56,7 +56,7 @@ public class ThumbnailQueryTest
 
 		// Assert
 		Assert.IsNotNull(result);
-		Assert.AreEqual(2, result.Count);
+		Assert.HasCount(2, result);
 		Assert.IsTrue(result.Where(p => p.FileHash is "00123" or "00456")
 			.All(x => x.Small == true));
 		Assert.IsTrue(result.Where(p => p.FileHash is "00123" or "00456")
@@ -99,7 +99,7 @@ public class ThumbnailQueryTest
 
 		// Assert
 		Assert.IsNotNull(result);
-		Assert.AreEqual(2, result.Count);
+		Assert.HasCount(2, result);
 		Assert.IsTrue(result.Where(p => p.FileHash is "627445" or "8127445")
 			.All(x => x.Large == true));
 		Assert.IsTrue(result.Where(p => p.FileHash is "627445" or "8127445")

--- a/starsky/starskytest/starsky.foundation.injection/ServiceCollectionExtensionsTest.cs
+++ b/starsky/starskytest/starsky.foundation.injection/ServiceCollectionExtensionsTest.cs
@@ -168,7 +168,7 @@ public class ServiceCollectionExtensionsTest
 		var result =
 			ServiceCollectionExtensions.GetExportedTypes(typeof(TestInjectionClass).Assembly);
 		var count = result.Count();
-		Assert.IsTrue(count >= 100);
+		Assert.IsGreaterThanOrEqualTo(100, count);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/starsky.foundation.metaupdate/Services/MetaPreflightTest.cs
+++ b/starsky/starskytest/starsky.foundation.metaupdate/Services/MetaPreflightTest.cs
@@ -34,7 +34,7 @@ public sealed class MetaPreflightTest
 			new FileIndexItem("/test.jpg"),
 			TestJpgArray.ToList(), true, true, 0);
 
-		Assert.AreEqual(2, result.fileIndexResultsList.Count);
+		Assert.HasCount(2, result.fileIndexResultsList);
 		Assert.AreEqual(FileIndexItem.ExifStatus.Ok,
 			result.fileIndexResultsList[0].Status);
 		Assert.AreEqual(FileIndexItem.ExifStatus.Ok,
@@ -56,7 +56,7 @@ public sealed class MetaPreflightTest
 			new FileIndexItem("/test.jpg"),
 			TestJpgArray.ToList(), true, false, 0);
 
-		Assert.AreEqual(1, result.fileIndexResultsList.Count);
+		Assert.HasCount(1, result.fileIndexResultsList);
 		Assert.AreEqual(FileIndexItem.ExifStatus.Ok,
 			result.fileIndexResultsList[0].Status);
 	}
@@ -79,7 +79,7 @@ public sealed class MetaPreflightTest
 			new FileIndexItem("/test.jpg"),
 			TestJpgArray.ToList(), true, true, 0);
 
-		Assert.AreEqual(1, result.fileIndexResultsList.Count);
+		Assert.HasCount(1, result.fileIndexResultsList);
 		Assert.AreEqual(FileIndexItem.ExifStatus.OperationNotSupported,
 			result.fileIndexResultsList[0].Status);
 	}
@@ -104,7 +104,7 @@ public sealed class MetaPreflightTest
 			new FileIndexItem("/test.jpg"),
 			TestJpgArray.ToList(), true, true, 0);
 
-		Assert.AreEqual(1, result.fileIndexResultsList.Count);
+		Assert.HasCount(1, result.fileIndexResultsList);
 		Assert.AreEqual(FileIndexItem.ExifStatus.Ok,
 			result.fileIndexResultsList[0].Status);
 	}
@@ -149,7 +149,7 @@ public sealed class MetaPreflightTest
 				statusModel, false, 0);
 
 		// Check how that changedFileIndexItemName works
-		Assert.AreEqual(1, changedFileIndexItemName["/test.jpg"].Count);
+		Assert.HasCount(1, changedFileIndexItemName["/test.jpg"]);
 		Assert.AreEqual("tags", changedFileIndexItemName["/test.jpg"].FirstOrDefault());
 
 		// Check for value
@@ -192,7 +192,7 @@ public sealed class MetaPreflightTest
 				collectionsDetailView.FileIndexItem,
 				statusModel, false, 0);
 
-		Assert.AreEqual(0, changedFileIndexItemName["/test.jpg"].Count);
+		Assert.IsEmpty(changedFileIndexItemName["/test.jpg"]);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/starsky.foundation.native/Trash/Helpers/WindowsShellTrashBindingHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.native/Trash/Helpers/WindowsShellTrashBindingHelperTest.cs
@@ -44,7 +44,7 @@ public class WindowsShellTrashBindingHelperTest
 		var result = WindowsShellTrashBindingHelper.Trash("destPath", OSPlatform.Linux);
 
 		Assert.IsNull(result.Item1);
-		Assert.IsTrue(result.Item2.Contains("Not supported"));
+		Assert.Contains("Not supported", result.Item2);
 	}
 
 	[TestMethod]
@@ -54,7 +54,7 @@ public class WindowsShellTrashBindingHelperTest
 			WindowsShellTrashBindingHelper.Trash(new List<string> { "destPath" }, OSPlatform.Linux);
 
 		Assert.IsNull(result.Item1);
-		Assert.IsTrue(result.Item2.Contains("Not supported"));
+		Assert.Contains("Not supported", result.Item2);
 	}
 
 	[TestMethod]
@@ -187,7 +187,7 @@ public class WindowsShellTrashBindingHelperTest
 		info ??= WindowsShellTrashBindingHelper.SHQueryRecycleBinInfo(hResult, "ZZ:\\",
 			pShQueryRbInfo);
 
-		Assert.IsTrue(info.Contains("Fail! Drive ZZ:\\ contains 0 item(s) in 0 bytes"));
+		Assert.Contains("Fail! Drive ZZ:\\ contains 0 item(s) in 0 bytes", info);
 		Assert.AreEqual(0, pShQueryRbInfo.i64NumItems);
 	}
 
@@ -220,12 +220,12 @@ public class WindowsShellTrashBindingHelperTest
 		if ( !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) )
 		{
 			Assert.IsFalse(driveHasBin);
-			Assert.IsTrue(info.Contains("Unable to load shared library"));
+			Assert.Contains("Unable to load shared library", info);
 			return;
 		}
 
 		Assert.IsFalse(driveHasBin);
-		Assert.IsTrue(info.Contains("Fail! Drive ZZ:\\ contains 0 item(s) in 0 bytes"));
+		Assert.Contains("Fail! Drive ZZ:\\ contains 0 item(s) in 0 bytes", info);
 	}
 
 	[TestMethod]
@@ -239,12 +239,12 @@ public class WindowsShellTrashBindingHelperTest
 		{
 			Assert.AreEqual(0, items);
 			Assert.IsFalse(driveHasBin);
-			Assert.IsTrue(info.Contains("Unable to load shared library"));
+			Assert.Contains("Unable to load shared library", info);
 			Assert.Inconclusive("Shell32.dll is not available on Linux or Mac OS");
 			return;
 		}
 
-		Assert.IsTrue(items >= 0);
+		Assert.IsGreaterThanOrEqualTo(0, items);
 		Assert.IsTrue(driveHasBin);
 	}
 }

--- a/starsky/starskytest/starsky.foundation.readmeta/Helpers/GeoParserTest.cs
+++ b/starsky/starskytest/starsky.foundation.readmeta/Helpers/GeoParserTest.cs
@@ -2,253 +2,246 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using starsky.foundation.readmeta.Helpers;
 using starsky.foundation.readmeta.Models;
 
-namespace starskytest.starsky.foundation.readmeta.Helpers
+namespace starskytest.starsky.foundation.readmeta.Helpers;
+
+[TestClass]
+public sealed class GeoParserTest // GeoParserTests
 {
-	[TestClass]
-	public sealed class GeoParserTest // GeoParserTests
+	[TestMethod]
+	public void GeoParser_ExifRead_ParseGpsTest()
 	{
-		
-		[TestMethod]
-		public void GeoParser_ExifRead_ParseGpsTest()
-		{
-			var latitude = GeoParser.ConvertDegreeMinutesSecondsToDouble("52° 18' 29.54\"", "N");
-			Assert.AreEqual(52.308205555500003, latitude, 0.000001);
-             
-			var longitude = GeoParser.ConvertDegreeMinutesSecondsToDouble("6° 11' 36.8\"", "E");
-			Assert.AreEqual(6.1935555554999997, longitude,0.000001);
-		}
-	    
-		[TestMethod]
-		public void GeoParser_ExifRead_ConvertDegreeMinutesToDouble_ConvertLongLat()
-		{
-			var input = "52,20.708N";
-			string refGps = input.Substring(input.Length-1, 1);
-			var data = GeoParser.ConvertDegreeMinutesToDouble(input, refGps);
-			Assert.AreEqual(52.3451333333,data,0.001);
+		var latitude = GeoParser.ConvertDegreeMinutesSecondsToDouble("52° 18' 29.54\"", "N");
+		Assert.AreEqual(52.308205555500003, latitude, 0.000001);
 
-			var input1 = "5,55.840E";
-			string refGps1 = input1.Substring(input1.Length-1, 1);
-			var data1 = GeoParser.ConvertDegreeMinutesToDouble(input1, refGps1);
-			Assert.AreEqual(5.930,data1,0.001);
-		}
-		
-		[TestMethod]
-		public void ConvertDegreeMinutesToDouble_WithNorthOrEast_ReturnsPositiveValue()
-		{
-			// Arrange
-			string point = "5,55.840";
-			string refGps = "N";
+		var longitude = GeoParser.ConvertDegreeMinutesSecondsToDouble("6° 11' 36.8\"", "E");
+		Assert.AreEqual(6.1935555554999997, longitude, 0.000001);
+	}
 
-			// Act
-			double result = GeoParser.ConvertDegreeMinutesToDouble(point, refGps);
+	[TestMethod]
+	public void GeoParser_ExifRead_ConvertDegreeMinutesToDouble_ConvertLongLat()
+	{
+		const string input = "52,20.708N";
+		var refGps = input.Substring(input.Length - 1, 1);
+		var data = GeoParser.ConvertDegreeMinutesToDouble(input, refGps);
+		Assert.AreEqual(52.3451333333, data, 0.001);
 
-			// Assert
-			Assert.IsTrue(result > 0);
-		}
+		const string input1 = "5,55.840E";
+		var refGps1 = input1.Substring(input1.Length - 1, 1);
+		var data1 = GeoParser.ConvertDegreeMinutesToDouble(input1, refGps1);
+		Assert.AreEqual(5.930, data1, 0.001);
+	}
 
-		[TestMethod]
-		public void ConvertDegreeMinutesToDouble_WithSouthOrWest_ReturnsNegativeValue()
-		{
-			// Arrange
-			string point = "5,55.840";
-			string refGps = "W";
+	[TestMethod]
+	public void ConvertDegreeMinutesToDouble_WithNorthOrEast_ReturnsPositiveValue()
+	{
+		// Arrange
+		const string point = "5,55.840";
+		const string refGps = "N";
 
-			// Act
-			double result = GeoParser.ConvertDegreeMinutesToDouble(point, refGps);
+		// Act
+		var result = GeoParser.ConvertDegreeMinutesToDouble(point, refGps);
 
-			// Assert
-			Assert.IsTrue(result < 0);
-		}
+		// Assert
+		Assert.IsGreaterThan(0, result);
+	}
 
-		[TestMethod]
-		public void GeoParser_ParseIsoString_DoesNotEndOnSlash()
-		{
-			var result = GeoParser.ParseIsoString("-05.2169-080.6303"); // no slash here
-			Assert.AreEqual(0,result.Latitude,0.001);
-		}
-		
-		[TestMethod]
-		public void GeoParser_ParseIsoString_WrongPlusFormat()
-		{
-			var result = GeoParser.ParseIsoString("0-05"); 
-			Assert.AreEqual(0,result.Latitude,0.001);
-		}
-		
-		[TestMethod]
-		public void GeoParser_ParseIsoString_LotsOfMinus()
-		{
-			var result = GeoParser.ParseIsoString("0-05-0-0-0-0-0-0-0-0"); 
-			Assert.AreEqual(0,result.Latitude,0.001);
-		}
-		
-		[TestMethod]
-		public void GeoParser_ParseIsoString_Peru()
-		{
-			var result = GeoParser.ParseIsoString("-05.2169-080.6303/");
-			Assert.AreEqual(-5.2168999565972225,result.Latitude,0.001);
-			Assert.AreEqual(-80.63030381944445,result.Longitude,0.001);
-			Assert.AreEqual(0,result.Altitude,0.001);
-		}
+	[TestMethod]
+	public void ConvertDegreeMinutesToDouble_WithSouthOrWest_ReturnsNegativeValue()
+	{
+		// Arrange
+		const string point = "5,55.840";
+		const string refGps = "W";
 
-		[TestMethod]
-		public void GeoParser_ParseIsoString_NotSupported()
-		{
-			var result = GeoParser.ParseIsoString("+40.20361-75.00417CRSxxxx/");
-			Assert.AreEqual(0,result.Latitude,0.001);
-			Assert.AreEqual(0,result.Longitude,0.001);
-			Assert.AreEqual(0,result.Altitude,0.001);
-		}
-		
-		[TestMethod]
-		public void ParseIsoString_InvalidLength_ReturnsEmptyGeoListItem()
-		{
-			// Arrange
-			// Doesn't has seperators so that's why its invalid
-			const string isoStr = "InvalidString123456/"; 
+		// Act
+		var result = GeoParser.ConvertDegreeMinutesToDouble(point, refGps);
 
-			// Act
-			var result = GeoParser.ParseIsoString(isoStr);
+		// Assert
+		Assert.IsLessThan(0, result);
+	}
 
-			// Assert
-			Assert.IsNotNull(result);
-			Assert.AreEqual(0, result.Latitude);
-			Assert.AreEqual(0, result.Longitude);
-		}
+	[TestMethod]
+	public void GeoParser_ParseIsoString_DoesNotEndOnSlash()
+	{
+		var result = GeoParser.ParseIsoString("-05.2169-080.6303"); // no slash here
+		Assert.AreEqual(0, result.Latitude, 0.001);
+	}
 
-		[TestMethod]
-		public void ParseIsoString_InvalidLength2_ReturnsEmptyGeoListItem()
-		{
-			// Arrange
-			// First part is not dash or plus
-			const string isoStr = "Invalid-test-String123456/"; // Replace with your invalid string
+	[TestMethod]
+	public void GeoParser_ParseIsoString_WrongPlusFormat()
+	{
+		var result = GeoParser.ParseIsoString("0-05");
+		Assert.AreEqual(0, result.Latitude, 0.001);
+	}
 
-			// Act
-			var result = GeoParser.ParseIsoString(isoStr);
+	[TestMethod]
+	public void GeoParser_ParseIsoString_LotsOfMinus()
+	{
+		var result = GeoParser.ParseIsoString("0-05-0-0-0-0-0-0-0-0");
+		Assert.AreEqual(0, result.Latitude, 0.001);
+	}
 
-			// Assert
-			Assert.IsNotNull(result);
-			Assert.AreEqual(0, result.Latitude);
-			Assert.AreEqual(0, result.Longitude);
-		}
-		
-		[TestMethod]
-		public void ParseIsoString_InvalidLength1_ReturnsEmptyGeoListItem()
-		{
-			// Arrange
-			const string isoStr = "-Invalid-test-String123456/"; 
+	[TestMethod]
+	public void GeoParser_ParseIsoString_Peru()
+	{
+		var result = GeoParser.ParseIsoString("-05.2169-080.6303/");
+		Assert.AreEqual(-5.2168999565972225, result.Latitude, 0.001);
+		Assert.AreEqual(-80.63030381944445, result.Longitude, 0.001);
+		Assert.AreEqual(0, result.Altitude, 0.001);
+	}
 
-			// Act
-			var result = GeoParser.ParseIsoString(isoStr);
+	[TestMethod]
+	public void GeoParser_ParseIsoString_NotSupported()
+	{
+		var result = GeoParser.ParseIsoString("+40.20361-75.00417CRSxxxx/");
+		Assert.AreEqual(0, result.Latitude, 0.001);
+		Assert.AreEqual(0, result.Longitude, 0.001);
+		Assert.AreEqual(0, result.Altitude, 0.001);
+	}
 
-			// Assert
-			Assert.IsNotNull(result);
-			Assert.AreEqual(0, result.Latitude);
-			Assert.AreEqual(0, result.Longitude);
-		}
-		
-		[TestMethod]
-		public void ParseIsoString_InvalidLength3_ReturnsEmptyGeoListItem()
-		{
-			// Arrange
-			const string isoStr = "-In.valid-test-String123456/"; 
+	[TestMethod]
+	public void ParseIsoString_InvalidLength_ReturnsEmptyGeoListItem()
+	{
+		// Arrange
+		// Doesn't has seperators so that's why its invalid
+		const string isoStr = "InvalidString123456/";
 
-			// Act
-			var result = GeoParser.ParseIsoString(isoStr);
+		// Act
+		var result = GeoParser.ParseIsoString(isoStr);
 
-			// Assert
-			Assert.IsNotNull(result);
-			Assert.AreEqual(0, result.Latitude);
-			Assert.AreEqual(0, result.Longitude);
-		}
-		
-		[TestMethod]
-		public void GeoParser_ParseIsoString_Italy()
-		{
-			var result = GeoParser.ParseIsoString("+40.8516+014.2480+083.241/");
-			Assert.AreEqual(40.8516015625,result.Latitude,0.001);
-			Assert.AreEqual(14.248000217013889,result.Longitude,0.001);
-			Assert.AreEqual(0,result.Altitude,0.001);
-		}
-	
-		[TestMethod]
-		public void ParseIsoString_ValidInput_ReturnsCorrectCoordinates()
-		{
-			// Arrange
-			const string input = "+1234.56-09854.321/";
+		// Assert
+		Assert.IsNotNull(result);
+		Assert.AreEqual(0, result.Latitude);
+		Assert.AreEqual(0, result.Longitude);
+	}
 
-			// Act
-			var result = GeoParser.ParseIsoString(input);
+	[TestMethod]
+	public void ParseIsoString_InvalidLength2_ReturnsEmptyGeoListItem()
+	{
+		// Arrange
+		// First part is not dash or plus
+		const string isoStr = "Invalid-test-String123456/"; // Replace with your invalid string
 
-			// Assert
-			Assert.AreEqual(12.576, result.Latitude, 0.001);
-			Assert.AreEqual(-98.90535, result.Longitude, 0.00001);
-		}
-		
-		[TestMethod]
-		public void ParseIsoString_InvalidInput_ReturnsEmptyGeoListItem()
-		{
-			// Arrange
-			const string input = "+12.34/";
-			var expected = new GeoListItem();
+		// Act
+		var result = GeoParser.ParseIsoString(isoStr);
 
-			// Act
-			var actual = GeoParser.ParseIsoString(input);
+		// Assert
+		Assert.IsNotNull(result);
+		Assert.AreEqual(0, result.Latitude);
+		Assert.AreEqual(0, result.Longitude);
+	}
 
-			// Assert
-			Assert.AreEqual(expected.Latitude, actual.Latitude, 0.001f);
-			Assert.AreEqual(expected.Longitude, actual.Longitude, 0.001f);
-			Assert.AreEqual(expected.Altitude, actual.Altitude, 0.001f);
-		}
-		
-		[TestMethod]
-		public void ParseIsoString_WhenPointIs4_ReturnsCorrectGeoListItem()
-		{
-			// Arrange
-			const string isoStr = "+1234.56-09854.321/";
-			var expected = new GeoListItem
-			{
-				Latitude = 12.576f,
-				Longitude = -98.90535f
-			};
-        
-			// Act
-			var actual = GeoParser.ParseIsoString(isoStr);
-        
-			// Assert
-			Assert.AreEqual(expected.Latitude, actual.Latitude, 0.001f);
-			Assert.AreEqual(expected.Longitude, actual.Longitude, 0.001f);
-		}
-		
-		[TestMethod]
-		public void TestParseIsoString_PointIs6()
-		{
-			// Arrange
-			const string input = "+123456.7-0985432.1+15.9/";
-			var expectedOutput = new GeoListItem { Latitude = 12.5824167f, Longitude = -98.9089167f };
+	[TestMethod]
+	public void ParseIsoString_InvalidLength1_ReturnsEmptyGeoListItem()
+	{
+		// Arrange
+		const string isoStr = "-Invalid-test-String123456/";
 
-			// Act
-			var output = GeoParser.ParseIsoString(input);
+		// Act
+		var result = GeoParser.ParseIsoString(isoStr);
 
-			// Assert
-			Assert.AreEqual(expectedOutput.Latitude, output.Latitude, 0.0001f);
-			Assert.AreEqual(expectedOutput.Longitude, output.Longitude, 0.0001f);
-		}
-		
-		[TestMethod]
-		public void TestParseIsoStringInvalidAltitude()
-		{
-			// Arrange
-			const string isoStr = "+1234.56-09854.321+abc/";
-			var expectedOutput = new GeoListItem { Latitude = 45273.6015625, Longitude = 356059.25 };
+		// Assert
+		Assert.IsNotNull(result);
+		Assert.AreEqual(0, result.Latitude);
+		Assert.AreEqual(0, result.Longitude);
+	}
 
-			// Act
-			var output = GeoParser.ParseIsoString(isoStr);
+	[TestMethod]
+	public void ParseIsoString_InvalidLength3_ReturnsEmptyGeoListItem()
+	{
+		// Arrange
+		const string isoStr = "-In.valid-test-String123456/";
 
-			// Assert
-			Assert.AreEqual(expectedOutput.Latitude, output.Latitude, 0.000001f);
-			Assert.AreEqual(expectedOutput.Longitude, output.Longitude, 0.000001f);
-			Assert.AreEqual(expectedOutput.Altitude, output.Altitude, 0.000001f);
-		}
+		// Act
+		var result = GeoParser.ParseIsoString(isoStr);
 
+		// Assert
+		Assert.IsNotNull(result);
+		Assert.AreEqual(0, result.Latitude);
+		Assert.AreEqual(0, result.Longitude);
+	}
+
+	[TestMethod]
+	public void GeoParser_ParseIsoString_Italy()
+	{
+		var result = GeoParser.ParseIsoString("+40.8516+014.2480+083.241/");
+		Assert.AreEqual(40.8516015625, result.Latitude, 0.001);
+		Assert.AreEqual(14.248000217013889, result.Longitude, 0.001);
+		Assert.AreEqual(0, result.Altitude, 0.001);
+	}
+
+	[TestMethod]
+	public void ParseIsoString_ValidInput_ReturnsCorrectCoordinates()
+	{
+		// Arrange
+		const string input = "+1234.56-09854.321/";
+
+		// Act
+		var result = GeoParser.ParseIsoString(input);
+
+		// Assert
+		Assert.AreEqual(12.576, result.Latitude, 0.001);
+		Assert.AreEqual(-98.90535, result.Longitude, 0.00001);
+	}
+
+	[TestMethod]
+	public void ParseIsoString_InvalidInput_ReturnsEmptyGeoListItem()
+	{
+		// Arrange
+		const string input = "+12.34/";
+		var expected = new GeoListItem();
+
+		// Act
+		var actual = GeoParser.ParseIsoString(input);
+
+		// Assert
+		Assert.AreEqual(expected.Latitude, actual.Latitude, 0.001f);
+		Assert.AreEqual(expected.Longitude, actual.Longitude, 0.001f);
+		Assert.AreEqual(expected.Altitude, actual.Altitude, 0.001f);
+	}
+
+	[TestMethod]
+	public void ParseIsoString_WhenPointIs4_ReturnsCorrectGeoListItem()
+	{
+		// Arrange
+		const string isoStr = "+1234.56-09854.321/";
+		var expected = new GeoListItem { Latitude = 12.576f, Longitude = -98.90535f };
+
+		// Act
+		var actual = GeoParser.ParseIsoString(isoStr);
+
+		// Assert
+		Assert.AreEqual(expected.Latitude, actual.Latitude, 0.001f);
+		Assert.AreEqual(expected.Longitude, actual.Longitude, 0.001f);
+	}
+
+	[TestMethod]
+	public void TestParseIsoString_PointIs6()
+	{
+		// Arrange
+		const string input = "+123456.7-0985432.1+15.9/";
+		var expectedOutput = new GeoListItem { Latitude = 12.5824167f, Longitude = -98.9089167f };
+
+		// Act
+		var output = GeoParser.ParseIsoString(input);
+
+		// Assert
+		Assert.AreEqual(expectedOutput.Latitude, output.Latitude, 0.0001f);
+		Assert.AreEqual(expectedOutput.Longitude, output.Longitude, 0.0001f);
+	}
+
+	[TestMethod]
+	public void TestParseIsoStringInvalidAltitude()
+	{
+		// Arrange
+		const string isoStr = "+1234.56-09854.321+abc/";
+		var expectedOutput = new GeoListItem { Latitude = 45273.6015625, Longitude = 356059.25 };
+
+		// Act
+		var output = GeoParser.ParseIsoString(isoStr);
+
+		// Assert
+		Assert.AreEqual(expectedOutput.Latitude, output.Latitude, 0.000001f);
+		Assert.AreEqual(expectedOutput.Longitude, output.Longitude, 0.000001f);
+		Assert.AreEqual(expectedOutput.Altitude, output.Altitude, 0.000001f);
 	}
 }

--- a/starsky/starskytest/starsky.foundation.realtime/Helpers/WebSocketConnectionTest.cs
+++ b/starsky/starskytest/starsky.foundation.realtime/Helpers/WebSocketConnectionTest.cs
@@ -57,11 +57,11 @@ public sealed class WebSocketConnectionTest
 		// when this unit test keeps hanging the end signal has not passed correctly
 		await socketConnection.ReceiveMessagesUntilCloseAsync();
 
-		Assert.IsTrue(message.StartsWith("message"));
+		Assert.StartsWith("message", message);
 	}
 
 	[TestMethod]
-	[Timeout(2000)]
+	[Timeout(2000, CooperativeCancellation = true)]
 	public async Task ReceiveMessagesUntil_ConnectionClosedPrematurely_And_Exit()
 	{
 		var fakeSocket = new FakeWebSocket
@@ -71,11 +71,11 @@ public sealed class WebSocketConnectionTest
 		var socketConnection = new WebSocketConnection(fakeSocket, new FakeIWebLogger());
 
 		var message = "";
-		socketConnection.ReceiveText += (sender, s) => { message = s; };
+		socketConnection.ReceiveText += (_, s) => { message = s; };
 
 		// when this unit test keeps hanging the end signal has not passed correctly
 		await socketConnection.ReceiveMessagesUntilCloseAsync();
 
-		Assert.IsTrue(message.StartsWith("message"));
+		Assert.StartsWith("message", message);
 	}
 }

--- a/starsky/starskytest/starsky.foundation.realtime/Services/HeartbeatServiceTest.cs
+++ b/starsky/starskytest/starsky.foundation.realtime/Services/HeartbeatServiceTest.cs
@@ -5,59 +5,57 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using starsky.foundation.realtime.Services;
 using starskytest.FakeMocks;
 
-namespace starskytest.starsky.foundation.realtime.Services
+namespace starskytest.starsky.foundation.realtime.Services;
+
+[TestClass]
+public sealed class HeartbeatServiceTest
 {
-	[TestClass]
-	public sealed class HeartbeatServiceTest 
+	[TestMethod]
+	public async Task StartAsync()
 	{
-		[TestMethod]
-		public async Task StartAsync()
-		{
-			var connectionService = new FakeIWebSocketConnectionsService();
-			var service = new HeartbeatService(connectionService);
-			
-			CancellationTokenSource source = new CancellationTokenSource();
-			CancellationToken token = source.Token;
-			
-			await service.StartAsync(token);
-			Assert.IsTrue(connectionService.FakeSendToAllAsync.LastOrDefault()?.Contains("dateTime"));
-			Assert.IsTrue(connectionService.FakeSendToAllAsync.LastOrDefault()?.Contains("dateTime"));
+		var connectionService = new FakeIWebSocketConnectionsService();
+		var service = new HeartbeatService(connectionService);
 
-			source.Cancel();
-			source.Dispose();
-		}
-		
-		[TestMethod]
-		public async Task StartAsync_CancelBeforeStart()
-		{
-			var connectionService = new FakeIWebSocketConnectionsService();
-			var service = new HeartbeatService(connectionService);
-			
-			CancellationTokenSource source = new CancellationTokenSource();
-			CancellationToken token = source.Token;
-			
-			source.Cancel();
-			await service.StartAsync(token);
-			
-			Assert.AreEqual(0,connectionService.FakeSendToAllAsync.Count);
-			source.Dispose();
-		}
-		
-		[TestMethod]
-		public async Task StartAsyncStop()
-		{
-			var connectionService = new FakeIWebSocketConnectionsService();
-			var service = new HeartbeatService(connectionService);
-			
-			CancellationTokenSource source = new CancellationTokenSource();
-			CancellationToken token = source.Token;
-			
-			await service.StartAsync(token);
-			await service.StopAsync(token);
+		var source = new CancellationTokenSource();
+		var token = source.Token;
 
-			Assert.IsTrue(connectionService.FakeSendToAllAsync.LastOrDefault()?.Contains("dateTime"));
-			source.Dispose();
+		await service.StartAsync(token);
+		Assert.IsTrue(connectionService.FakeSendToAllAsync.LastOrDefault()?.Contains("dateTime"));
+		Assert.IsTrue(connectionService.FakeSendToAllAsync.LastOrDefault()?.Contains("dateTime"));
 
-		}
+		await source.CancelAsync();
+		source.Dispose();
+	}
+
+	[TestMethod]
+	public async Task StartAsync_CancelBeforeStart()
+	{
+		var connectionService = new FakeIWebSocketConnectionsService();
+		var service = new HeartbeatService(connectionService);
+
+		var source = new CancellationTokenSource();
+		var token = source.Token;
+
+		await source.CancelAsync();
+		await service.StartAsync(token);
+
+		Assert.IsEmpty(connectionService.FakeSendToAllAsync);
+		source.Dispose();
+	}
+
+	[TestMethod]
+	public async Task StartAsyncStop()
+	{
+		var connectionService = new FakeIWebSocketConnectionsService();
+		var service = new HeartbeatService(connectionService);
+
+		var source = new CancellationTokenSource();
+		var token = source.Token;
+
+		await service.StartAsync(token);
+		await service.StopAsync(token);
+
+		Assert.IsTrue(connectionService.FakeSendToAllAsync.LastOrDefault()?.Contains("dateTime"));
+		source.Dispose();
 	}
 }

--- a/starsky/starskytest/starsky.foundation.realtime/Services/WebSocketConnectionsServiceTest.cs
+++ b/starsky/starskytest/starsky.foundation.realtime/Services/WebSocketConnectionsServiceTest.cs
@@ -36,7 +36,7 @@ public sealed class WebSocketConnectionsServiceTest
 		service.AddConnection(new WebSocketConnection(fakeSocket, logger));
 
 		await service.SendToAllAsync(null!, CancellationToken.None);
-		Assert.AreEqual(1, logger.TrackedInformation.Count);
+		Assert.HasCount(1, logger.TrackedInformation);
 	}
 
 	[TestMethod]
@@ -52,9 +52,9 @@ public sealed class WebSocketConnectionsServiceTest
 		await service.SendToAllAsync("test", CancellationToken.None);
 
 		// One of Two fails
-		Assert.AreEqual(1, fakeSocket.FakeSendItems.Count);
+		Assert.HasCount(1, fakeSocket.FakeSendItems);
 		Assert.IsTrue(fakeSocket.FakeSendItems.LastOrDefault()?.StartsWith("test"));
-		Assert.AreEqual(1, logger.TrackedInformation.Count);
+		Assert.HasCount(1, logger.TrackedInformation);
 		Assert.IsTrue(logger.TrackedInformation.LastOrDefault().Item2
 			?.Contains("WebSocketException"));
 	}
@@ -69,7 +69,7 @@ public sealed class WebSocketConnectionsServiceTest
 
 		const string message = "💥"; // magic string to trigger exception
 		await service.SendToAllAsync(message, CancellationToken.None);
-		Assert.AreEqual(1, logger.TrackedExceptions.Count);
+		Assert.HasCount(1, logger.TrackedExceptions);
 	}
 
 	[TestMethod]


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request refactors unit tests across several files to use more expressive and specific assertion methods. The main focus is on replacing generic assertions like `Assert.AreEqual` and `Assert.IsTrue` with more intent-revealing methods such as `Assert.Contains`, `Assert.IsEmpty`, `Assert.HasCount`, `Assert.EndsWith`, `Assert.IsGreaterThan`, and `Assert.IsLessThan`. These changes improve test readability and clarity, making it easier to understand the purpose of each assertion. Additionally, some minor code style and test infrastructure improvements were made.

Key changes include:

**Assertion improvements for clarity and intent:**

- Replaced assertions checking collection counts (e.g., `Assert.AreEqual(0, ...)`, `Assert.AreEqual(1, ...)`) with `Assert.IsEmpty` and `Assert.HasCount` in multiple test files, such as `ExportControllerTest.cs`, `ImportControllerTest.cs`, `UploadControllerTest.cs`, `FileIndexCompareHelperTest.cs`, and `OpenEditorPreflightTests.cs`. [[1]](diffhunk://#diff-4fb361552a39f9c0d6f25677282ab74073b25741ee56947d1aafeb1f2c1e7c4bL284-R287) [[2]](diffhunk://#diff-4fb361552a39f9c0d6f25677282ab74073b25741ee56947d1aafeb1f2c1e7c4bL308-R311) [[3]](diffhunk://#diff-b463e27347e91a8cfe089f840d5362b95f150e560942cf8f631333bea97f4bf8L133-R133) [[4]](diffhunk://#diff-b463e27347e91a8cfe089f840d5362b95f150e560942cf8f631333bea97f4bf8L169-R169) [[5]](diffhunk://#diff-ad0310492f5915a9630f68d718f0e856b6c88f81477221cdfc55b050bf0c7489L231-R231) [[6]](diffhunk://#diff-88c9c5989ef30a3dc1ef4e741a011d2ef8753dbbdc521cd0868d463894986d46L19-R19) [[7]](diffhunk://#diff-88c9c5989ef30a3dc1ef4e741a011d2ef8753dbbdc521cd0868d463894986d46L169-R169) [[8]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL33-R37) [[9]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL77-R81) [[10]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL123-R127) [[11]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL151-R151) [[12]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL243-R243) [[13]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL281-R281) [[14]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL314-R314) [[15]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL349-R349) [[16]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL396-R396) [[17]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL437-R437)

- Replaced string containment assertions (e.g., `Assert.IsTrue(str.Contains(...))`) with `Assert.Contains` for better readability in test files like `AppSettingsControllerTest.cs`, `DiskControllerTest.cs`, `ExportControllerTest.cs`, `CompressionMimeTests.cs`, `SwaggerHelperTest.cs`, and others. [[1]](diffhunk://#diff-a2746f11c9acd2f0ab4bd6883ce7b80fcc0fa45fcc5d72cf9d2879666a10070aL141-R142) [[2]](diffhunk://#diff-e83b1e22ac6f2e654821d889c5c66f71cde03d542a1ea16e9f6f9924382c00d5L246-R246) [[3]](diffhunk://#diff-e83b1e22ac6f2e654821d889c5c66f71cde03d542a1ea16e9f6f9924382c00d5L312-R312) [[4]](diffhunk://#diff-4fb361552a39f9c0d6f25677282ab74073b25741ee56947d1aafeb1f2c1e7c4bL343-R347) [[5]](diffhunk://#diff-e89edad129f1633b4c31363a01cf26d1dc618382fe939f77cec92b72abd691a2L17-R19) [[6]](diffhunk://#diff-ceced811b09961bec85f3ac3caf00b44a5646abb461f67098dfee14c9cf127fcL105-R105)

- Updated assertions for string endings and numeric ranges to use `Assert.EndsWith`, `Assert.IsGreaterThan`, and `Assert.IsLessThan` where appropriate, improving semantic clarity. [[1]](diffhunk://#diff-2e1b0069b5018cb020640ba4e9d5fa83020e0924959d2f04ac56b2e8fa33e726L179-R179) [[2]](diffhunk://#diff-f41498c8d3e4b050c51fb1fc0f17c13519f2815a6cc666ea44affea059840101L46-R47) [[3]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL33-R37) [[4]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL77-R81) [[5]](diffhunk://#diff-98938df4ab17568bdf87487d4353490c35c5af1ff301c45955e04281717c32deL123-R127)

**Test infrastructure and style improvements:**

- Added a `TestContext` property to `ExportControllerTest` to support cancellation tokens in async tests, and updated a `Task.Delay` call to use this token. [[1]](diffhunk://#diff-4fb361552a39f9c0d6f25677282ab74073b25741ee56947d1aafeb1f2c1e7c4bR108-R109) [[2]](diffhunk://#diff-4fb361552a39f9c0d6f25677282ab74073b25741ee56947d1aafeb1f2c1e7c4bL208-R215)

- Minor code style changes, such as formatting of attributes and method signatures, and updating a `[DataTestMethod]` to `[TestMethod]` for consistency. [[1]](diffhunk://#diff-b199229e102e79a0c7ed2aeb9c987da3c04cdd4a47e0ac59da13c58a710e7978L230-R237) [[2]](diffhunk://#diff-0fa0ff4f17fbe75995dc80a74b5263be04ae1e872476de62167023ea48173861L33-R33)

These updates collectively make the test suite more expressive, maintainable, and easier to reason about.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
