### PR TITLE
Potential fix for code scanning alert no. 1125: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/desktop-release-on-tag-net-electron.yml
+++ b/.github/workflows/desktop-release-on-tag-net-electron.yml
@@ -176,6 +176,8 @@ jobs:
     name: Build Windows Desktop app
     runs-on: windows-latest
     needs: [build_net]
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@c2d88d3ecc89a9ef08eebf45d9637801dcee7eb5


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1125](https://github.com/qdraw/starsky/security/code-scanning/1125)

To address the issue, we should add a `permissions` block to the `build_win` job to restrict the GITHUB_TOKEN permissions according to the principle of least privilege. Since the steps in `build_win` only require reading the contents of the repository (for actions/checkout, actions/download-artifact, etc.), we should set `contents: read`. This change is limited to inserting a single block in the `build_win` job definition, after its initial job fields and before its steps. No changes are needed elsewhere, no imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
