### PR TITLE
Potential fix for code scanning alert no. 1126: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/global-update-application-version-auto.yml
+++ b/.github/workflows/global-update-application-version-auto.yml
@@ -8,6 +8,7 @@ on:
       - release/*
     paths: 
       - 'starsky-tools/build-tools/app-version-update.js'
+      - '.github/workflows/global-update-application-version-auto.yml'      
   workflow_dispatch:
 
 jobs: 


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1126](https://github.com/qdraw/starsky/security/code-scanning/1126)

To fix the problem, add a `permissions` block to the workflow YAML file. The block should request only the minimal set of permissions required for the workflow's jobs. The workflow uses `actions/checkout`, runs a script, and commits changes back to the repository with EndBug/add-and-commit, which requires write access to the repository contents. Thus, `contents: write` is needed. Optionally, if pull request updates are performed (not indicated in this workflow), `pull-requests: write` could be added, but here only repository contents are updated. The best fix is to add a root-level `permissions:` block with `contents: write`, immediately after the workflow `name` and before the `on:` section for maximum clarity and coverage.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
