### PR TITLE
Potential fix for code scanning alert no. 1131: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webapp-codecov-clientapp-netcore.yml
+++ b/.github/workflows/webapp-codecov-clientapp-netcore.yml
@@ -1,4 +1,6 @@
 name: Starsky Codecov ClientApp NetCore
+permissions:
+  contents: read
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1131](https://github.com/qdraw/starsky/security/code-scanning/1131)

The best way to fix this issue is to explicitly add a `permissions` block at the root level of the workflow (directly beneath the `name` field, before `on:`), to control and reduce privileges for all jobs in the workflow unless overridden. Based on the workflow contents (building, caching, checking out code, uploading to Codecov with a specific token), only read access to the code repository contents is required; `contents: read` is sufficient and standard. No `write` permissions to contents, issues, or pull-requests should be granted unless specifically needed, which does not appear to be the case here.

To implement the change, insert the following at line 2 in `.github/workflows/webapp-codecov-clientapp-netcore.yml`:
```yaml
permissions:
  contents: read
```
No other block in the current snippet needs changing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
