### PR TITLE
Potential fix for code scanning alert no. 1132: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webapp-sonarqube-clientapp-netcore.yml
+++ b/.github/workflows/webapp-sonarqube-clientapp-netcore.yml
@@ -1,4 +1,6 @@
 name: SonarQube ClientApp .NET Analyze
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1132](https://github.com/qdraw/starsky/security/code-scanning/1132)

To fix the problem, an explicit `permissions` key should be added to the workflow or the `build` job to limit the GITHUB_TOKEN's permissions to the minimum required. Since the workflow does not seem to need write access to repository contents, issues, or pull requests, the best practice is to set `contents: read`. This can be achieved by adding the following block after the workflow name and before the `on:` section at the root level of the workflow YAML file: 

```yaml
permissions:
  contents: read
```

This will restrict the GITHUB_TOKEN permissions for all jobs in the workflow to read-only access unless further overridden. No imports or method definitions are needed. This change is entirely contained in the .github/workflows/webapp-sonarqube-clientapp-netcore.yml file and does not modify any functional code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
