### PR TITLE
Potential fix for code scanning alert no. 1134: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webapp-build-net-ubuntu.yml
+++ b/.github/workflows/webapp-build-net-ubuntu.yml
@@ -1,4 +1,6 @@
 name: Ubuntu .NET build
+permissions:
+  contents: read
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -74,7 +76,10 @@ jobs:
           bash build.sh --Target TestNetCore --no-dependencies --no-publish --no-logo
 
   trigger_pipe_release_desktop:
-  
+    permissions:
+      contents: read
+      actions: write
+    
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1134](https://github.com/qdraw/starsky/security/code-scanning/1134)

To address this issue, add an explicit `permissions:` block at the root of the workflow, granting only the minimum permissions required for all jobs. Alternatively, set the root block to minimal permissions (such as `contents: read`) and override as needed in specific jobs. The build job requires only read access to repository contents, so the root can be set to `contents: read`. The trigger_pipe_release_desktop job dispatches another workflow via the API, which requires `actions: write` (and possibly still needs `contents: read`). 

Edit the `.github/workflows/webapp-build-net-ubuntu.yml` file as follows:
- Add a `permissions:` block after the `name:` key at the top of the workflow, setting `contents: read`.
- Add a job-level `permissions:` block to `trigger_pipe_release_desktop` specifying `contents: read` and `actions: write`.
This will follow the principle of least privilege and address the CodeQL-reported issue.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
