### PR TITLE
Potential fix for code scanning alert no. 1140: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clientapp-storybook-netlify.yml
+++ b/.github/workflows/clientapp-storybook-netlify.yml
@@ -14,6 +14,8 @@ on:
   workflow_dispatch:
     
 name: storybook clientapp netlify
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1140](https://github.com/qdraw/starsky/security/code-scanning/1140)

We should add a top-level `permissions` block to the workflow file, using `contents: read` as the minimal and recommended setting. This is best placed directly under the `name:` key (line 16), before the `jobs:` key. This ensures all jobs in the workflow inherit these minimal permissions unless overridden, adhering to the principle of least privilege. No changes to existing workflow steps or functionality are required. No third-party imports, method, or variable definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
