### PR TITLE
Potential fix for code scanning alert no. 1141: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clientapp-react-windows-ci.yml
+++ b/.github/workflows/clientapp-react-windows-ci.yml
@@ -1,5 +1,7 @@
 name: ClientApp React Windows CI
 # see also Linux CI
+permissions:
+  contents: read
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1141](https://github.com/qdraw/starsky/security/code-scanning/1141)

To fix this problem, add a `permissions` block to the workflow file, restricting the GITHUB_TOKEN to only the least privileges required for the jobs. In this specific workflow (.github/workflows/clientapp-react-windows-ci.yml), the jobs only need read access to the repository to check out the code and perform builds and tests. Therefore, add `permissions: contents: read` at the root level of the workflow, immediately after the `name:` and any comments. No imports or additional changes are needed. Only the YAML workflow file itself needs to be edited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
