### PR TITLE
Potential fix for code scanning alert no. 1142: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/desktop-release-on-tag-net-electron.yml
+++ b/.github/workflows/desktop-release-on-tag-net-electron.yml
@@ -1,4 +1,6 @@
 name: Desktop Release on tag (.NET & Electron)
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1142](https://github.com/qdraw/starsky/security/code-scanning/1142)

To fix the problem, we should explicitly add a `permissions` key to the workflow file. The best practice is to add this block at the top level (under the workflow `name` or directly after the `on:` block), so that all jobs inherit minimal permissions, unless they require more. For the provided workflow, most jobs only need to upload or download artifacts and check out code, which typically only require `contents: read`. The release job may need `contents: write` (to create releases/tags), but unless jobs specifically push code, we keep `contents: read` as the base.

The change:  
- Insert the following block at the workflow root, just after `name:` and before or after `on:` (either correct, but typically after `name:`):  
  ```yaml
  permissions:
    contents: read
  ```

No additional imports or methods are required. If any job requires elevated permissions (e.g., for creating releases), that job should have a job-level `permissions` block, but that change is not strictly required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
