### PR TITLE
Potential fix for code scanning alert no. 1143: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/documentation-update-dependencies-create-docusaurus.yml
+++ b/.github/workflows/documentation-update-dependencies-create-docusaurus.yml
@@ -1,4 +1,7 @@
 name: Documentation update dependencies create docusaurus
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1143](https://github.com/qdraw/starsky/security/code-scanning/1143)

To fix this issue, add a `permissions` block at the top-level of the workflow file (recommended), or per job if varying permissions are needed. You should assign only the required permissions for the workflow tasks. In this workflow, actions such as making commits, creating pull requests, and merging branches require specific permissions: `contents: write` (for pushing commits and creating branches), `pull-requests: write` (for creating pull requests), and optionally `issues: write` (if issue interactions are later added). For minimal privilege, only add permissions that the steps actually need.

The change should be made at the root of `.github/workflows/documentation-update-dependencies-create-docusaurus.yml`, directly below the `name` field and before the `on:` key. No new imports or external definitions are needed for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
