### PR TITLE
Potential fix for code scanning alert no. 1144: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/global-clean-untagged-ghcr-images.yml
+++ b/.github/workflows/global-clean-untagged-ghcr-images.yml
@@ -1,5 +1,8 @@
 name: Clean untagged and nightly ghcr images
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1144](https://github.com/qdraw/starsky/security/code-scanning/1144)

To fix this problem, add an explicit `permissions` block to the workflow to restrict the GITHUB_TOKEN's permissions to the minimum required for deleting package versions on the GHCR registry. The minimum necessary permission for this purpose is `packages: write`. The `permissions` block should be placed at the job level (adjacent to `runs-on`) or at the workflow root (above `jobs:`). Since only the `delete_versions` job exists in this workflow, adding it at the job level will suffice, but for single-job workflows, adding it at the workflow root is also common and will apply to all jobs. No change to functionality is required—simply introduce the `permissions` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
