### PR TITLE
Potential fix for code scanning alert no. 1145: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/global-snyk-analysis.yml
+++ b/.github/workflows/global-snyk-analysis.yml
@@ -1,4 +1,6 @@
 name: Snyk analysis
+permissions:
+  contents: read
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1145](https://github.com/qdraw/starsky/security/code-scanning/1145)

To fix the problem, add a `permissions` block to the workflow. The most secure and generally safe way is to add it at the root level (just below the workflow name or before the `jobs:` block), so that it applies to all jobs unless overridden. Since the workflow does not appear to create or update repository contents or manage issues/pull requests, it only requires minimal permissions. Set `contents: read` to enable basic actions such as checkout, but disallow modification of repository content.

Steps to implement:
- In `.github/workflows/global-snyk-analysis.yml`, insert a `permissions:` block with `contents: read` following the `name: Snyk analysis` line, before any `concurrency`, `on`, or `jobs` keys.
- No changes to imports, definitions, or logic are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
