### PR TITLE
Potential fix for code scanning alert no. 1146: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tools-dependencies-mirror-netlify.yml
+++ b/.github/workflows/tools-dependencies-mirror-netlify.yml
@@ -19,6 +19,8 @@ on:
     
 name: Tools dependencies mirror netlify
 # for: starsky-dependencies
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1146](https://github.com/qdraw/starsky/security/code-scanning/1146)

To remediate this issue, add a `permissions` block to the workflow. The ideal place is at the top level, so all jobs inherit minimal permissions, unless broader ones need to be set for specific jobs. The safest minimal permission is `contents: read`, which allows read-only access to repository contents. Review of the workflow indicates that read access should be sufficient: code is checked out (which requires `contents: read`), and no other steps need write access (Netlify uses its own token and artifact upload doesn’t interact with repository contents).  
Edit the `.github/workflows/tools-dependencies-mirror-netlify.yml` file and add the following directly after the `name:` field (line 20) and before jobs (line 23):
```yaml
permissions:
  contents: read
```
No imports, method definitions, or further edits are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
