### PR TITLE
Potential fix for code scanning alert no. 1147: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webapp-build-net-macos.yml
+++ b/.github/workflows/webapp-build-net-macos.yml
@@ -1,5 +1,8 @@
 name: MacOS Webapp .NET only build
 
+permissions:
+  contents: read
+
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1147](https://github.com/qdraw/starsky/security/code-scanning/1147)

To fix this problem, explicitly set the `permissions` key at the root of the workflow (recommended for single-job workflows) or directly under the specific job (`build:`). This restricts the GITHUB_TOKEN permissions for all jobs/steps to the minimal required set. For a build/test job that only checks out code and does not push, merge, or modify repository contents, `contents: read` is generally sufficient and recommended. The change should be inserted after the workflow name and before concurrency or job definitions. No new methods or imports are required for this YAML change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
