### PR TITLE
Potential fix for code scanning alert no. 1148: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tools-smoke-test-node.yml
+++ b/.github/workflows/tools-smoke-test-node.yml
@@ -1,4 +1,6 @@
 name: Tools smoke test node
+permissions:
+  contents: read
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1148](https://github.com/qdraw/starsky/security/code-scanning/1148)

The best way to fix this problem is to add a `permissions` block specifying the minimum required permissions for the workflow. Since this job appears only to be running local builds and tests (checking out code and running npm scripts), `contents: read` is sufficient – this allows workflows to checkout code but not, for example, create commits or releases. The change should be added at the root of the workflow YAML file, directly below the workflow name and above the first top-level key (`concurrency:`). No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
