### PR TITLE
Potential fix for code scanning alert no. 1149: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webapp-build-net-windows.yml
+++ b/.github/workflows/webapp-build-net-windows.yml
@@ -1,5 +1,8 @@
 name: Windows .NET build
 
+permissions:
+  contents: read
+
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1149](https://github.com/qdraw/starsky/security/code-scanning/1149)

To fix the problem, we should explicitly define the permissions of the GITHUB_TOKEN for this workflow, as recommended by GitHub security guidance. This limits the GITHUB_TOKEN used by all steps in the workflow to the minimal necessary permissions, reducing risk of accidental token overuse or abuse. The best way is to add a `permissions` block at the root of the workflow (after the `name:` and before `jobs:`), as the example shows, so that all jobs get these restricted permissions unless overridden. The safest minimal setting is:

```yaml
permissions:
  contents: read
```

This should be placed after the `name:` field, and before `on:` or `jobs:`. No additional imports, methods, or definitions are needed; this is a pure YAML-structure change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
