### PR TITLE
Potential fix for code scanning alert no. 1150: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webapp-build-net-ubuntu.yml
+++ b/.github/workflows/webapp-build-net-ubuntu.yml
@@ -1,4 +1,6 @@
 name: Ubuntu .NET build
+permissions:
+  contents: read
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1150](https://github.com/qdraw/starsky/security/code-scanning/1150)

To remediate the issue, we should add a `permissions` block to the root of the workflow, specifying only the minimal required permission: `contents: read`. This ensures that all jobs run with only read access to repository contents via GITHUB_TOKEN unless specifically overridden per-job. The change should be placed immediately after the workflow name (line 1)—the typical location for root-level workflow configuration keys.

No additional imports or method changes are necessary. Only a single configuration addition is needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
