### PR TITLE
Potential fix for code scanning alert no. 1151: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webapp-update-dotnet-sdk-version-upgrade.yml
+++ b/.github/workflows/webapp-update-dotnet-sdk-version-upgrade.yml
@@ -1,5 +1,9 @@
 name: Dotnet sdk version auto upgrade
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1151](https://github.com/qdraw/starsky/security/code-scanning/1151)

The best way to fix this problem is to explicitly add a `permissions` block to the workflow, either at the top level or within the specific job (`run`). Considering there is only one job (`run`), you can add the `permissions` block at the workflow level (above `jobs:`), which will apply to all jobs inside the workflow, or you can add it specifically to the `run` job. The minimal starting point recommended by CodeQL is `contents: read`, but since this workflow creates and merges pull requests, additional permissions such as `pull-requests: write` may be needed for the steps that interact with PRs (e.g., the actions creating and merging pull requests). However, unless you know the exact required permissions for each step, it's safe to begin with the least possible privilege and add what is necessary if a step fails due to lack of permission.

Therefore, you should add (above `jobs:`) or inside the `run` job:

```yaml
permissions:
  contents: read
  pull-requests: write
```

If any step requires more (or fewer) permissions, you can later update that block accordingly. In this case, add the `permissions` block to the root of the workflow file, just below `name:` and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
