### PR TITLE
Potential fix for code scanning alert no. 1114: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/desktop-electron-sonarqube-missing-net-dependency.yml
+++ b/.github/workflows/desktop-electron-sonarqube-missing-net-dependency.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron:  '36 0 * * 0,2,4,6'
 
+permissions:
+  contents: read
+
 env:
   PR_NUMBER_GITHUB: ${{ github.event.pull_request.number }}
   


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1114](https://github.com/qdraw/starsky/security/code-scanning/1114)

The best way to fix the problem is to explicitly add a `permissions` block limiting the default GITHUB_TOKEN privileges for the workflow. According to GitHub's recommendations, the minimal required set for most workflows that only need to read the repository is `contents: read`. This block can be placed at the root of the YAML file (top-level, just after `name:` or after `on:`), or at the job level (inside the `build` job under `jobs:`). For generality and future-proofing, set it at the top level to apply to all jobs. 

To implement the change:
- Insert a new block `permissions:`, with value `contents: read`, after the `name:` line or after the `on:` block (before `env:`).
- No new methods, imports, or definitions are needed because this is a change in workflow metadata, not executable code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
