### PR TITLE
Potential fix for code scanning alert no. 1115: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/documentation-linux-ci.yml
+++ b/.github/workflows/documentation-linux-ci.yml
@@ -1,4 +1,6 @@
 name: Documentation Linux CI
+permissions:
+  contents: read
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1115](https://github.com/qdraw/starsky/security/code-scanning/1115)

The single best way to fix this issue is to add a `permissions` block to the workflow, explicitly assigning the minimal required permissions. For these jobs, only `contents: read` is required.  

You should add the following at the root/top level of the YAML workflow (right after the `name:` block and before `concurrency:`, `on:`, or `jobs:`):  
```yaml
permissions:
  contents: read
```
This ensures all jobs in the workflow inherit the least permissions unless a job overrides the block.

No other files need editing; no imports or further definitions are necessary. This is a YAML-only edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
