### PR TITLE
Potential fix for code scanning alert no. 1116: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/end2end-ubuntu-ci.yml
+++ b/.github/workflows/end2end-ubuntu-ci.yml
@@ -13,6 +13,8 @@ name: end2end on ubuntu-ci
 jobs:
   test:
     name: Test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       WEBSITE_SITE_NAME: "ci"


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1116](https://github.com/qdraw/starsky/security/code-scanning/1116)

To address the issue, you should add a `permissions` block to the workflow. The best practice is to do this at the job level (under the test job), unless you want it to apply globally to all jobs. In this concrete example, since only one job (`test`) exists, you can add it under the `test:` key, above `runs-on: ubuntu-latest`. The minimal permission requirement for CI tasks that check out code, run tests, and upload artifacts is usually `contents: read`; if you later add steps that require write access to issues, you can expand it then. 

The specific code edit required: insert

```yaml
permissions:
  contents: read
```

after line 15 in the `.github/workflows/end2end-ubuntu-ci.yml` file.

No imports, methods or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
