### PR TITLE
Potential fix for code scanning alert no. 1110: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clientapp-react-linux-ci.yml
+++ b/.github/workflows/clientapp-react-linux-ci.yml
@@ -1,4 +1,6 @@
 name: ClientApp React Linux CI
+permissions:
+  contents: read
 # see also Windows CI
 
 concurrency: 


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1110](https://github.com/qdraw/starsky/security/code-scanning/1110)

To fix this issue, add a `permissions` block at the root of the workflow. This restricts all jobs in the workflow (unless overridden per job) to the minimal required permissions. Based on the current set of workflow steps (checkout, cache, installing dependencies, building, testing), only read access to repository contents is needed. Place the following block directly after the `name:` and before `concurrency:`:

```yaml
permissions:
  contents: read
```

No additional imports or modifications are needed elsewhere, only the addition of this single block in `.github/workflows/clientapp-react-linux-ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
