### PR TITLE
Potential fix for code scanning alert no. 1118: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/documentation-linux-ci.yml
+++ b/.github/workflows/documentation-linux-ci.yml
@@ -17,6 +17,9 @@ on:
   workflow_dispatch:
     
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1118](https://github.com/qdraw/starsky/security/code-scanning/1118)

To address the issue, add a `permissions` block at the root level of the workflow in `.github/workflows/documentation-linux-ci.yml`. This will ensure the minimal required permissions are provided to the GITHUB_TOKEN for all jobs unless a job explicitly overrides it. Since all actions within this workflow only need to read repository contents (no pushing, issues, releases, or package writes), the most restrictive and appropriate setting is:

```yaml
permissions:
  contents: read
```

This block should be inserted before the `jobs:` top-level key (typically after the last workflow-level keyword, such as `on:` or any workflow-level configuration).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
