### PR TITLE
Potential fix for code scanning alert no. 1119: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/end2end-windows-ci.yml
+++ b/.github/workflows/end2end-windows-ci.yml
@@ -13,6 +13,8 @@ on:
     - '.github/workflows/end2end-windows-ci.yml'
 
 name: end2end on windows-ci
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/qdraw/starsky/security/code-scanning/1119](https://github.com/qdraw/starsky/security/code-scanning/1119)

To fix this issue, we should explicitly set minimal permissions for the workflow/job, so the `GITHUB_TOKEN` used during execution does not have unnecessary write access to the repository. In this workflow, none of the steps require write access to the repository or issues; the only action that requires access is `actions/checkout` for cloning the code, which only needs read access to repo contents. Therefore, the best fix is to add a `permissions` block with `contents: read` at either the root level (applies to all jobs) or specifically within the `test` job. Adding it to the root will make it easier to manage if new jobs are added, and matches the example given in the background. No new imports or definitions are needed; this is a simple YAML addition at the top level (before `jobs:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
