### PR TITLE
Sonar warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -144,3 +144,7 @@ dotnet_diagnostic.CS4014.severity = error
 
 # IDE0077: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0077
 dotnet_diagnostic.IDE0077.severity = error
+
+
+# Use '[OSCondition]' attribute instead of 'RuntimeInformation.IsOSPlatform' calls with early return or 'Assert.Inconclusive'
+dotnet_diagnostic.MSTEST0061.severity = warning

--- a/starsky/starskytest/starsky.foundation.native/PreviewImageNative/Helpers/CoreFoundationMacOsBindingsTests.cs
+++ b/starsky/starskytest/starsky.foundation.native/PreviewImageNative/Helpers/CoreFoundationMacOsBindingsTests.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using starsky.foundation.native.PreviewImageNative.Helpers;
 
@@ -8,14 +7,9 @@ namespace starskytest.starsky.foundation.native.PreviewImageNative.Helpers;
 public class CoreFoundationMacOsBindingsTests
 {
 	[TestMethod]
+	[OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
 	public void CreateCFStringCreateWithCString_Returns0__WindowsLinuxOnly()
 	{
-		// Arrange
-		if ( RuntimeInformation.IsOSPlatform(OSPlatform.OSX) )
-		{
-			Assert.Inconclusive("This test is only valid on non-macOS platforms.");
-		}
-
 		// Act
 		var result = CoreFoundationMacOsBindings.CreateCFStringCreateWithCString("input.jpg");
 		Assert.AreEqual(0, result);

--- a/starsky/starskytest/starsky.foundation.native/PreviewImageNative/Helpers/QuicklookMacOsTests.cs
+++ b/starsky/starskytest/starsky.foundation.native/PreviewImageNative/Helpers/QuicklookMacOsTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SixLabors.ImageSharp;
 using starsky.foundation.native.PreviewImageNative.Helpers;
@@ -15,14 +14,9 @@ namespace starskytest.starsky.foundation.native.PreviewImageNative.Helpers;
 public class QuicklookMacOsTests
 {
 	[TestMethod]
+	[OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
 	public void GenerateThumbnail_False__WindowsLinuxOnly()
 	{
-		// Arrange
-		if ( RuntimeInformation.IsOSPlatform(OSPlatform.OSX) )
-		{
-			Assert.Inconclusive("This test is only valid on non-macOS platforms.");
-		}
-
 		var (quicklook, _) = CreateSut();
 		// Act
 		Assert.IsFalse(quicklook.GenerateThumbnail("input.jpg", "output.webp", 100, 100));
@@ -36,14 +30,9 @@ public class QuicklookMacOsTests
 	}
 
 	[TestMethod]
+	[OSCondition(OperatingSystems.OSX)]
 	public void GenerateThumbnail_ShouldReturnFalse_WhenFilePathIsInvalid__MacOnly()
 	{
-		// Arrange
-		if ( !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) )
-		{
-			Assert.Inconclusive("This test is only valid on macOS platforms.");
-		}
-
 		var (quicklook, logger) = CreateSut();
 
 		// Act
@@ -56,14 +45,9 @@ public class QuicklookMacOsTests
 	}
 
 	[TestMethod]
+	[OSCondition(OperatingSystems.OSX)]
 	public void GenerateThumbnail_ShouldReturnFalse_WhenThumbnailCreationFails__MacOnly()
 	{
-		// Arrange
-		if ( !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) )
-		{
-			Assert.Inconclusive("This test is only valid on macOS platforms.");
-		}
-
 		var (quicklook, logger) = CreateSut();
 
 		var tempInput = Path.GetTempFileName();
@@ -92,14 +76,9 @@ public class QuicklookMacOsTests
 	[TestMethod]
 	[DataRow(0)]
 	[DataRow(100)]
+	[OSCondition(OperatingSystems.OSX)]
 	public void GenerateThumbnail_ShouldReturnTrue_WhenValidInput_Jpeg__MacOnly(int height)
 	{
-		// Arrange
-		if ( !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) )
-		{
-			Assert.Inconclusive("This test is only valid on macOS platforms.");
-		}
-
 		const string testName =
 			nameof(GenerateThumbnail_ShouldReturnTrue_WhenValidInput_Jpeg__MacOnly);
 		var (quicklook, _) = CreateSut();
@@ -138,14 +117,9 @@ public class QuicklookMacOsTests
 	}
 
 	[TestMethod]
+	[OSCondition(OperatingSystems.OSX)]
 	public void SaveCGImageAsFile_InvalidType__MacOnly()
 	{
-		// Arrange
-		if ( !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) )
-		{
-			Assert.Inconclusive("This test is only valid on macOS platforms.");
-		}
-
 		var (quicklook, logger) = CreateSut();
 
 		// Act
@@ -156,14 +130,9 @@ public class QuicklookMacOsTests
 	}
 
 	[TestMethod]
+	[OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
 	public void SaveCGImageAsFile_DllNotFoundException__WindowsLinuxOnly()
 	{
-		// Arrange
-		if ( RuntimeInformation.IsOSPlatform(OSPlatform.OSX) )
-		{
-			Assert.Inconclusive("This test is only valid on non-macOS platforms.");
-		}
-
 		var (quicklook, _) = CreateSut();
 
 		// Act
@@ -172,14 +141,9 @@ public class QuicklookMacOsTests
 	}
 
 	[TestMethod]
+	[OSCondition(OperatingSystems.OSX)]
 	public void ImageDestinationAddImageFinalize_InvalidType__MacOnly()
 	{
-		// Arrange
-		if ( !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) )
-		{
-			Assert.Inconclusive("This test is only valid on macOS platforms.");
-		}
-
 		var (quicklook, logger) = CreateSut();
 
 		// Act
@@ -189,14 +153,9 @@ public class QuicklookMacOsTests
 	}
 
 	[TestMethod]
+	[OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
 	public void ImageDestinationAddImageFinalize_DllNotFoundException__WindowsLinuxOnly()
 	{
-		// Arrange
-		if ( RuntimeInformation.IsOSPlatform(OSPlatform.OSX) )
-		{
-			Assert.Inconclusive("This test is only valid on non-macOS platforms.");
-		}
-
 		var (quicklook, _) = CreateSut();
 
 		// Act

--- a/starsky/starskytest/starsky.foundation.native/PreviewImageNative/PreviewImageNativeServiceTests.cs
+++ b/starsky/starskytest/starsky.foundation.native/PreviewImageNative/PreviewImageNativeServiceTests.cs
@@ -45,14 +45,9 @@ public class PreviewImageNativeServiceTests
 	}
 
 	[TestMethod]
+	[OSCondition(OperatingSystems.OSX)]
 	public void GeneratePreviewImage_ShouldReturnFalse_WhenThumbnailGenerationFails__MacOnly()
 	{
-		// Arrange
-		if ( !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) )
-		{
-			Assert.Inconclusive("This test is only valid on macOS platforms.");
-		}
-
 		var (service, logger) = CreateSut();
 
 		// Act
@@ -67,14 +62,9 @@ public class PreviewImageNativeServiceTests
 	}
 
 	[TestMethod]
+	[OSCondition(OperatingSystems.Windows)]
 	public void GeneratePreviewImage_ShouldReturnFalse_WhenThumbnailGenerationFails__WindowsOnly()
 	{
-		// Arrange
-		if ( !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) )
-		{
-			Assert.Inconclusive("This test is only valid on Windows platforms.");
-		}
-
 		var (service, logger) = CreateSut();
 
 		// Act
@@ -89,14 +79,9 @@ public class PreviewImageNativeServiceTests
 	}
 
 	[TestMethod]
+	[OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
 	public void GeneratePreviewImage_False__WindowsLinuxOnly()
 	{
-		// Arrange
-		if ( RuntimeInformation.IsOSPlatform(OSPlatform.OSX) )
-		{
-			Assert.Inconclusive("This test is only valid on non-macOS platforms.");
-		}
-
 		var (service, _) = CreateSut();
 
 		// Act
@@ -109,14 +94,9 @@ public class PreviewImageNativeServiceTests
 	}
 
 	[TestMethod]
+	[OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
 	public void GeneratePreviewImage_False__MacLinuxOnly()
 	{
-		// Arrange
-		if ( RuntimeInformation.IsOSPlatform(OSPlatform.Windows) )
-		{
-			Assert.Inconclusive("This test is only valid on non-windows platforms.");
-		}
-
 		var (service, _) = CreateSut();
 
 		// Act
@@ -129,26 +109,18 @@ public class PreviewImageNativeServiceTests
 	}
 
 	[TestMethod]
+	[OSCondition(ConditionMode.Exclude, OperatingSystems.Linux)]
 	public void IsSupported__MacAndWindowsOnly()
 	{
-		if ( RuntimeInformation.IsOSPlatform(OSPlatform.Linux) )
-		{
-			Assert.Inconclusive("This test is only valid on windows / mac os platforms.");
-		}
-
 		var (service, _) = CreateSut();
 		var big = service.IsSupported(1024);
 		Assert.AreEqual(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows), big);
 	}
 
 	[TestMethod]
+	[OSCondition(OperatingSystems.Linux)]
 	public void IsSupported__LinuxOnly()
 	{
-		if ( !RuntimeInformation.IsOSPlatform(OSPlatform.Linux) )
-		{
-			Assert.Inconclusive("This test is only valid on LInux platforms.");
-		}
-
 		var (service, _) = CreateSut();
 		var result = service.IsSupported();
 		Assert.IsFalse(result);

--- a/starsky/starskytest/starsky.foundation.video/GetDependencies/MacCodeSignTests.cs
+++ b/starsky/starskytest/starsky.foundation.video/GetDependencies/MacCodeSignTests.cs
@@ -209,14 +209,9 @@ public class MacCodeSignTests
 	}
 
 	[TestMethod]
+	[OSCondition(OperatingSystems.OSX)]
 	public async Task MacCodeSignAndXattrExecutable_QuarantineEventsV2_ShouldReturnTrue__MacOnly()
 	{
-		if ( !OperatingSystem.IsMacOS() )
-		{
-			Assert.Inconclusive("This test is only applicable on macOS.");
-			return;
-		}
-
 		// Arrange
 		var exeFile = await CreateStubExeFile();
 
@@ -261,17 +256,11 @@ public class MacCodeSignTests
 	}
 
 	[TestMethod]
+	[OSCondition(OperatingSystems.OSX)]
 	public async Task MacCodeSignAndXattrExecutable_CodeSign__MacOnly()
 	{
-		if ( !OperatingSystem.IsMacOS() )
-		{
-			Assert.Inconclusive("This test is only applicable on macOS.");
-			return;
-		}
-
 		// Arrange
 		var exeFile = await CreateStubExeFile();
-
 		var codeSignBefore = await Command.Run("codesign", "-dvv", exeFile).Task;
 
 		// Act


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request refactors several test files to improve platform-specific test handling by replacing manual runtime platform checks and inconclusive assertions with the `[OSCondition]` attribute. This makes the tests more declarative and easier to maintain, and also introduces a new analyzer warning to enforce this pattern.

Platform-specific test improvements:

* Replaced all manual `RuntimeInformation.IsOSPlatform` checks and `Assert.Inconclusive` calls in test methods with the `[OSCondition]` attribute to clearly indicate platform-specific execution for both macOS, Windows, and Linux tests in `CoreFoundationMacOsBindingsTests.cs`, `QuicklookMacOsTests.cs`, `PreviewImageNativeServiceTests.cs`, and `MacCodeSignTests.cs`. [[1]](diffhunk://#diff-65a7bf7991769f9a65de6e3f2eb150e288143ecd13b32aeba3047d1d572b3dfaR10-L18) [[2]](diffhunk://#diff-85ee706b79a20d169a548a766b142c1d89bb946a0ceefdac135605a19b94255cR17-L25) [[3]](diffhunk://#diff-85ee706b79a20d169a548a766b142c1d89bb946a0ceefdac135605a19b94255cR33-L46) [[4]](diffhunk://#diff-85ee706b79a20d169a548a766b142c1d89bb946a0ceefdac135605a19b94255cR48-L66) [[5]](diffhunk://#diff-85ee706b79a20d169a548a766b142c1d89bb946a0ceefdac135605a19b94255cR79-L102) [[6]](diffhunk://#diff-85ee706b79a20d169a548a766b142c1d89bb946a0ceefdac135605a19b94255cR120-L148) [[7]](diffhunk://#diff-85ee706b79a20d169a548a766b142c1d89bb946a0ceefdac135605a19b94255cR133-L166) [[8]](diffhunk://#diff-85ee706b79a20d169a548a766b142c1d89bb946a0ceefdac135605a19b94255cR144-L182) [[9]](diffhunk://#diff-85ee706b79a20d169a548a766b142c1d89bb946a0ceefdac135605a19b94255cR156-L199) [[10]](diffhunk://#diff-95654ba26b6756d949151f62f48ed72781c43024338ed2efc8ae022bc28426edR48-L55) [[11]](diffhunk://#diff-95654ba26b6756d949151f62f48ed72781c43024338ed2efc8ae022bc28426edR65-L77) [[12]](diffhunk://#diff-95654ba26b6756d949151f62f48ed72781c43024338ed2efc8ae022bc28426edR82-L99) [[13]](diffhunk://#diff-95654ba26b6756d949151f62f48ed72781c43024338ed2efc8ae022bc28426edR97-L119) [[14]](diffhunk://#diff-95654ba26b6756d949151f62f48ed72781c43024338ed2efc8ae022bc28426edR112-L151) [[15]](diffhunk://#diff-f46c7f47afe289fa9dbd78d5a487957d503dd39e545809e21199a3a0c6022e06R212-L219) [[16]](diffhunk://#diff-f46c7f47afe289fa9dbd78d5a487957d503dd39e545809e21199a3a0c6022e06R259-L274)

Code cleanup:

* Removed unnecessary `using System.Runtime.InteropServices;` statements from test files where platform checks are no longer performed manually. [[1]](diffhunk://#diff-65a7bf7991769f9a65de6e3f2eb150e288143ecd13b32aeba3047d1d572b3dfaL1) [[2]](diffhunk://#diff-85ee706b79a20d169a548a766b142c1d89bb946a0ceefdac135605a19b94255cL4)

Static analysis and code quality:

* Added a new analyzer rule (`MSTEST0061`) as a warning in `.editorconfig` to encourage the use of `[OSCondition]` instead of manual platform checks and inconclusive assertions in tests.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
