### PR TITLE
Import Backup timestamped copy of imported to a specified folder / Delete After setting Import specific for MountCLI

### DIFF
--- a/documentation/docs/features/import/import.md
+++ b/documentation/docs/features/import/import.md
@@ -218,6 +218,9 @@ Patching appsettings with `appsettings.patch.json` can also be used in this feat
 
 When enabled, imported files are copied to the configured storage folder using the fixed filename structure above. Use this to keep an immutable backup of original camera imports.
 
+## Mount watcher
+See [Mount Watcher CLI to Auto Import](mountwatchercli.md)
+
 ## Related
 
 - [Mount Watcher CLI to Auto Import](mountwatchercli.md)

--- a/documentation/docs/features/import/import.md
+++ b/documentation/docs/features/import/import.md
@@ -193,6 +193,31 @@ These 4 checks help ensure that only valid camera storage devices are scanned an
 ## Troubleshooting: Access to Path is denied on macOS
 See [Troubleshooting: Access to Path is denied on macOS](troubleshooting-access-to-path-macos.md)
 
+## Import Backup
+
+Starsky can optionally create a fixed-structure backup copy of imported files. The backup filename uses a deterministic timestamp + original name format; for example:
+
+20260326_082007_Schermafbeelding-2026-03-26-om-082007.png
+
+Enable the feature via environment variables:
+
+```json
+"app__ImportBackup__Enabled": "true",
+"app__ImportBackup__StorageFolder": "/data/backup_camera/1/"
+```
+
+Or set the same values in `appsettings.json` under the `ImportBackup` section:
+Patching appsettings with `appsettings.patch.json` can also be used in this feature
+
+```json
+"ImportBackup": {
+    "Enabled": "false",
+    "StorageFolder": "/data/backup_camera/1/"
+}
+```
+
+When enabled, imported files are copied to the configured storage folder using the fixed filename structure above. Use this to keep an immutable backup of original camera imports.
+
 ## Related
 
 - [Mount Watcher CLI to Auto Import](mountwatchercli.md)

--- a/documentation/docs/features/import/mountwatchercli.md
+++ b/documentation/docs/features/import/mountwatchercli.md
@@ -32,7 +32,6 @@ starskymountwatchercli --uninstall
 
 Additional flags:
 
-- `--verbose` or `-v` for verbose logging.
 - `--help` or `-h` to print usage and platform-specific service notes.
 
 ## Platform support
@@ -54,6 +53,26 @@ Additional flags:
 - [macOS may require Full Disk Access for stable operation on external media.](troubleshooting-access-to-path-macos.md)
 - Linux logs are visible with `journalctl` for the mount watcher service.
 - Windows logs are available in Event Viewer.
+
+## Delete after import
+
+When importing from mounted camera storage (for example via the mount watcher), Starsky can optionally delete the original files after a successful import.
+
+Set the option in `appsettings.json`:
+
+```json
+"ImportMountWatcher" : {
+    "DeleteAfter": "false"
+}
+```
+
+Or override with an environment variable:
+
+```json
+"app__ImportMountWatcher__DeleteAfter": "true"
+```
+
+When `DeleteAfter` is `true`, successfully imported files on the mounted device will be removed. Use this with caution — enable only when you want files removed from the source device after import.
 
 ## Related
 

--- a/documentation/docs/getting-started/configuration/config-options.md
+++ b/documentation/docs/getting-started/configuration/config-options.md
@@ -39,3 +39,44 @@ This file is located for macOS `~/Library/Application Support/starsky/appsetting
 and Windows `C:\Users\<username>\AppData\Local\starsky\appsettings.local.json`.
 When using the desktop app the environment variable `app__AppSettingsLocalPath` is used
 
+## Configuration overwrite order
+
+Starsky reads configuration files and environment variables in a fixed order — later items override earlier ones. Use this order when you need to know which value wins when the same key is present in multiple places:
+
+1. `appsettings.json` (project folder)
+2. `appsettings.default.json` (project folder)
+3. `appsettings.patch.json` (project folder)
+4. `appsettings.{machineName}.json` (machine-specific)
+5. `appsettings.{machineName}.patch.json` (machine-specific patch)
+6. Environment variable: `app__appsettingspath` (path to an `appsettings.json` to load)
+7. Environment variable: `app__appsettingslocalpath` (path to an `appsettings.local.json` to load)
+8. Specific environment variables (for example `app__storageFolder`, `app__databaseConnection`, etc.)
+
+Notes:
+- Environment variables use the `app__` prefix and replace `:` with `__` and `.` with `_` (for example `app__databaseType`).
+- Environment variables and the `app__appsettings*` paths are a convenient way to override settings without editing files.
+
+### Import Backup (example)
+
+The Import Backup feature can be configured either via environment variables or in `appsettings.json`. This is an example, it can be used with all features in the appSettings
+
+Environment variable example:
+
+```json
+"app__ImportBackup__Enabled": "true",
+"app__ImportBackup__StorageFolder": "/data/backup_camera/1/"
+```
+
+Or `appsettings.json` section:
+
+```json
+"ImportBackup": {
+	"Enabled": "false",
+	"StorageFolder": ""
+}
+```
+
+When enabled, imported files are copied to the configured storage folder using a fixed filename structure (for example `20260326_082007_Schermafbeelding-2026-03-26-om-082007.png`).
+
+For more details see the Import documentation: [Import Backup](../../features/import/import.md#import-backup)
+

--- a/history.md
+++ b/history.md
@@ -47,6 +47,8 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## version 0.7.15 - 2026-04-? {#v0.7.15}
 
+- [x] (Added) _Back-end_ Import Backup timestamped copy of imported to a specified folder (PR #2965)
+- [x] (Added) _Back-end_ Delete After setting Import specific for MountCLI (PR #2965)
 - [x] (Fixed) _Back-end_ Native FileSystem interop on Intel macOS vs Apple Silicon (PR #2960)
 - [x] (Fixed) _Back-end_ Zero-payload non-mdat atom (e.g. wide, free) gives hash back (PR #2955)
 - [x] (Fixed) _Back-end_ GetWindowsDriveInfo where Z:\\ was used to find an unused drive. (PR #2905)

--- a/starsky/starsky.foundation.import/Services/Import.cs
+++ b/starsky/starsky.foundation.import/Services/Import.cs
@@ -45,6 +45,7 @@ namespace starsky.foundation.import.Services;
 public class Import : IImport
 {
 	private readonly AppSettings _appSettings;
+	private readonly ImportBackup _backup;
 
 	private readonly IConsole _console;
 	private readonly IExifTool _exifTool;
@@ -105,6 +106,7 @@ public class Import : IImport
 		_thumbnailQuery = thumbnailQuery;
 		_objectCreateIndexItemService =
 			new ObjectCreateIndexItemService(appSettings, reverseGeoCode);
+		_backup = new ImportBackup(selectorStorage, logger);
 	}
 
 	/// <summary>
@@ -179,7 +181,7 @@ public class Import : IImport
 		var importIndexItemsList = ( await preflightItemList.AsEnumerable()
 			.ForEachAsync(
 				async preflightItem
-					=> await Importer(preflightItem, importSettings),
+					=> await Importer(preflightItem, importSettings, _appSettings.ImportBackup),
 				_appSettings.MaxDegreesOfParallelism) )!.ToList();
 
 		return importIndexItemsList;
@@ -538,9 +540,11 @@ public class Import : IImport
 	/// </summary>
 	/// <param name="importIndexItem">config file</param>
 	/// <param name="importSettings">optional settings</param>
+	/// <param name="importBackup">backup before importing</param>
 	/// <returns>status</returns>
 	internal async Task<ImportIndexItem> Importer(ImportIndexItem? importIndexItem,
-		ImportSettingsModel importSettings)
+		ImportSettingsModel importSettings,
+		AppSettingsImportBackupModel importBackup)
 	{
 		if ( importIndexItem is not { Status: ImportStatus.Ok } )
 		{
@@ -562,6 +566,10 @@ public class Import : IImport
 		// Add item to database
 		await AddToQueryAndImportDatabaseAsync(importIndexItem, importSettings);
 
+		// Backup content
+		await _backup.CopyStreamFromHostToBackup(importIndexItem, importBackup);
+
+		// Actual copy
 		if ( !await CopyStreamFromHostToSubPathStorage(importIndexItem, importSettings) )
 		{
 			return importIndexItem;

--- a/starsky/starsky.foundation.import/Services/ImportBackup.cs
+++ b/starsky/starsky.foundation.import/Services/ImportBackup.cs
@@ -20,9 +20,17 @@ public class ImportBackup(ISelectorStorage selectorStorage, IWebLogger logger)
 		ImportIndexItem importIndexItem,
 		AppSettingsImportBackupModel importBackup)
 	{
-		if ( !importBackup.Enabled || 
-		     !_filesystemStorage.ExistFolder(importBackup.StorageFolder ?? ""))
+		var backupFolderExists = !_filesystemStorage.ExistFolder(importBackup.StorageFolder ?? "");
+		if ( !importBackup.Enabled || backupFolderExists )
 		{
+			if ( backupFolderExists && importBackup.Enabled )
+			{
+				logger.LogError(
+					$"[ImportBackup] Skipped backup due backup folder " +
+					$"does not exist: " +
+					$"{importBackup.StorageFolder}");
+			}
+
 			return null;
 		}
 

--- a/starsky/starsky.foundation.import/Services/ImportBackup.cs
+++ b/starsky/starsky.foundation.import/Services/ImportBackup.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using starsky.foundation.database.Models;
+using starsky.foundation.platform.Helpers;
+using starsky.foundation.platform.Interfaces;
+using starsky.foundation.platform.Models;
+using starsky.foundation.storage.Interfaces;
+using starsky.foundation.storage.Storage;
+using starsky.foundation.storage.Structure;
+
+namespace starsky.foundation.import.Services;
+
+public class ImportBackup(ISelectorStorage selectorStorage, IWebLogger logger)
+{
+	private readonly IStorage _filesystemStorage =
+		selectorStorage.Get(SelectorStorage.StorageServices.HostFilesystem);
+
+	public async Task<bool?> CopyStreamFromHostToBackup(
+		ImportIndexItem importIndexItem,
+		AppSettingsImportBackupModel importBackup)
+	{
+		if ( !importBackup.Enabled )
+		{
+			return null;
+		}
+
+		var backupFileName = GetFileName(importIndexItem);
+		var backupFilePath = Path.Combine(importBackup.StorageFolder!, backupFileName);
+		var sourceFileSize = _filesystemStorage.Info(importIndexItem.SourceFullFilePath).Size;
+
+		try
+		{
+			var sourceStream = _filesystemStorage.ReadStream(importIndexItem.SourceFullFilePath);
+			await _filesystemStorage.WriteStreamAsync(sourceStream, backupFilePath);
+			// SourceStream is disposed in WriteStreamAsync
+		}
+		catch ( AggregateException exception )
+		{
+			//  For example: System.IO.IOException: No space left on device 
+			logger.LogError(
+				$"[ImportBackup] CopyStream  {backupFilePath} - retry helper failed {exception.Message}",
+				exception);
+		}
+
+		var backupFileSize = _filesystemStorage.Info(backupFilePath).Size;
+		if ( sourceFileSize == backupFileSize )
+		{
+			return true;
+		}
+
+		logger.LogError(
+			$"[ImportBackup] Filesize does not match H:{sourceFileSize} - B:{backupFileSize} " +
+			$"H: {importIndexItem.SourceFullFilePath} - S: {importIndexItem.FilePath}");
+
+		return false;
+	}
+
+	private string GetFileName(ImportIndexItem importIndexItem)
+	{
+		var inputModel = new StructureInputModel(
+			importIndexItem.FileIndexItem!.DateTime,
+			importIndexItem.FileIndexItem.FileCollectionName!,
+			FilenamesHelper.GetFileExtensionWithoutDot(importIndexItem.FileIndexItem
+				.FileName!),
+			importIndexItem.FileIndexItem.ImageFormat,
+			string.Empty);
+
+		var structureService =
+			new StructureService(selectorStorage,
+				new AppSettingsStructureModel
+				{
+					DefaultPattern = "/yyyyMMdd_HHmmss_{filenamebase}.ext"
+				}, logger);
+
+
+		return structureService.ParseFileName(inputModel);
+	}
+}

--- a/starsky/starsky.foundation.import/Services/ImportBackup.cs
+++ b/starsky/starsky.foundation.import/Services/ImportBackup.cs
@@ -20,7 +20,8 @@ public class ImportBackup(ISelectorStorage selectorStorage, IWebLogger logger)
 		ImportIndexItem importIndexItem,
 		AppSettingsImportBackupModel importBackup)
 	{
-		if ( !importBackup.Enabled )
+		if ( !importBackup.Enabled || 
+		     !_filesystemStorage.ExistFolder(importBackup.StorageFolder ?? ""))
 		{
 			return null;
 		}

--- a/starsky/starsky.foundation.import/Services/ImportBackup.cs
+++ b/starsky/starsky.foundation.import/Services/ImportBackup.cs
@@ -60,7 +60,7 @@ public class ImportBackup(ISelectorStorage selectorStorage, IWebLogger logger)
 	{
 		var inputModel = new StructureInputModel(
 			importIndexItem.FileIndexItem!.DateTime,
-			importIndexItem.FileIndexItem.FileCollectionName!,
+			Path.GetFileNameWithoutExtension(importIndexItem.SourceFullFilePath),
 			FilenamesHelper.GetFileExtensionWithoutDot(importIndexItem.FileIndexItem
 				.FileName!),
 			importIndexItem.FileIndexItem.ImageFormat,

--- a/starsky/starsky.foundation.mountwatch/Services/MountWatcherCli.cs
+++ b/starsky/starsky.foundation.mountwatch/Services/MountWatcherCli.cs
@@ -272,7 +272,9 @@ public class MountWatcherCli
 
 			var importSettings = new ImportSettingsModel
 			{
-				RecursiveDirectory = true, IndexMode = true, DeleteAfter = false
+				RecursiveDirectory = true,
+				IndexMode = true, 
+				DeleteAfter = _appSettings.ImportMountWatcher.DeleteAfter
 			};
 
 			var result = await _importService.Importer(

--- a/starsky/starsky.foundation.platform/Helpers/AppSettingsCompareHelper.cs
+++ b/starsky/starsky.foundation.platform/Helpers/AppSettingsCompareHelper.cs
@@ -92,6 +92,19 @@ public static class AppSettingsCompareHelper
 				newImportTransformation, differenceList);
 		}
 
+		if ( propertyB.PropertyType == typeof(AppSettingsImportBackupModel) )
+		{
+			var oldImportBackup =
+				( AppSettingsImportBackupModel? ) propertyInfoFromA.GetValue(
+					sourceIndexItem,
+					null);
+			var newImportBackup =
+				( AppSettingsImportBackupModel? ) propertyB.GetValue(updateObject, null);
+			CompareAppSettingsImportBackupModel(propertyB.Name, sourceIndexItem,
+				oldImportBackup,
+				newImportBackup, differenceList);
+		}
+
 		if ( propertyInfoFromA.PropertyType ==
 		     typeof(List<AppSettingsDefaultEditorApplication>) &&
 		     propertyB.PropertyType == typeof(List<AppSettingsDefaultEditorApplication>) )
@@ -151,6 +164,27 @@ public static class AppSettingsCompareHelper
 				oldAppSettingsPublishProfilesRemoteValue,
 				newAppSettingsPublishProfilesRemoteValue, differenceList);
 		}
+	}
+
+	private static void CompareAppSettingsImportBackupModel(string propertyBName,
+		AppSettings sourceIndexItem, AppSettingsImportBackupModel? oldImportBackup,
+		AppSettingsImportBackupModel? newImportBackup, List<string> differenceList)
+	{
+		if ( oldImportBackup == null ||
+		     newImportBackup == null ||
+		     // compare lists
+		     JsonSerializer.Serialize(oldImportBackup) ==
+		     JsonSerializer.Serialize(newImportBackup) ||
+		     // default options
+		     JsonSerializer.Serialize(newImportBackup) ==
+		     JsonSerializer.Serialize(new AppSettingsImportBackupModel()) )
+		{
+			return;
+		}
+
+		sourceIndexItem.GetType().GetProperty(propertyBName)!.SetValue(sourceIndexItem,
+			newImportBackup, null);
+		differenceList.Add(propertyBName.ToLowerInvariant());
 	}
 
 	private static void CompareAppSettingsCloudSettings(string propertyBName,

--- a/starsky/starsky.foundation.platform/Helpers/AppSettingsCompareHelper.cs
+++ b/starsky/starsky.foundation.platform/Helpers/AppSettingsCompareHelper.cs
@@ -105,6 +105,19 @@ public static class AppSettingsCompareHelper
 				newImportBackup, differenceList);
 		}
 
+		if ( propertyB.PropertyType == typeof(AppSettingsMountWatcherModel) )
+		{
+			var oldMountWatcherModel =
+				( AppSettingsMountWatcherModel? ) propertyInfoFromA.GetValue(
+					sourceIndexItem,
+					null);
+			var newMountWatcherModel =
+				( AppSettingsMountWatcherModel? ) propertyB.GetValue(updateObject, null);
+			CompareAppSettingsMountWatcherModel(propertyB.Name, sourceIndexItem,
+				oldMountWatcherModel,
+				newMountWatcherModel, differenceList);
+		}
+
 		if ( propertyInfoFromA.PropertyType ==
 		     typeof(List<AppSettingsDefaultEditorApplication>) &&
 		     propertyB.PropertyType == typeof(List<AppSettingsDefaultEditorApplication>) )
@@ -164,6 +177,29 @@ public static class AppSettingsCompareHelper
 				oldAppSettingsPublishProfilesRemoteValue,
 				newAppSettingsPublishProfilesRemoteValue, differenceList);
 		}
+	}
+
+	private static void CompareAppSettingsMountWatcherModel(string propertyBName,
+		AppSettings sourceIndexItem,
+		AppSettingsMountWatcherModel? oldMountWatcherModel,
+		AppSettingsMountWatcherModel? newMountWatcherModel,
+		List<string> differenceList)
+	{
+		if ( oldMountWatcherModel == null ||
+		     newMountWatcherModel == null ||
+		     // compare lists
+		     JsonSerializer.Serialize(oldMountWatcherModel) ==
+		     JsonSerializer.Serialize(newMountWatcherModel) ||
+		     // default options
+		     JsonSerializer.Serialize(newMountWatcherModel) ==
+		     JsonSerializer.Serialize(new AppSettingsMountWatcherModel()) )
+		{
+			return;
+		}
+
+		sourceIndexItem.GetType().GetProperty(propertyBName)!.SetValue(sourceIndexItem,
+			newMountWatcherModel, null);
+		differenceList.Add(propertyBName.ToLowerInvariant());
 	}
 
 	private static void CompareAppSettingsImportBackupModel(string propertyBName,

--- a/starsky/starsky.foundation.platform/Models/AppSettings.cs
+++ b/starsky/starsky.foundation.platform/Models/AppSettings.cs
@@ -283,6 +283,8 @@ public sealed class AppSettings
 	[PackageTelemetry]
 	public AppSettingsImportTransformationModel ImportTransformation { get; set; } = new();
 
+	[PackageTelemetry] public AppSettingsImportBackupModel ImportBackup { get; set; } = new();
+
 	/// <summary>
 	///     Used for syncing gpx files
 	/// </summary>
@@ -689,7 +691,7 @@ public sealed class AppSettings
 			if ( EnablePackageTelemetryPrivate == null )
 			{
 #pragma warning disable CS0162
-#if ( DEBUG )
+#if DEBUG
 				return false;
 #endif
 				// ReSharper disable once HeuristicUnreachableCode

--- a/starsky/starsky.foundation.platform/Models/AppSettings.cs
+++ b/starsky/starsky.foundation.platform/Models/AppSettings.cs
@@ -285,6 +285,8 @@ public sealed class AppSettings
 
 	[PackageTelemetry] public AppSettingsImportBackupModel ImportBackup { get; set; } = new();
 
+	[PackageTelemetry] public AppSettingsMountWatcherModel ImportMountWatcher { get; set; } = new();
+
 	/// <summary>
 	///     Used for syncing gpx files
 	/// </summary>

--- a/starsky/starsky.foundation.platform/Models/AppSettingsImportBackupModel.cs
+++ b/starsky/starsky.foundation.platform/Models/AppSettingsImportBackupModel.cs
@@ -1,0 +1,7 @@
+namespace starsky.foundation.platform.Models;
+
+public class AppSettingsImportBackupModel
+{
+	public bool Enabled { get; set; } = false;
+	public string? StorageFolder { get; set; }
+}

--- a/starsky/starsky.foundation.platform/Models/AppSettingsImportBackupModel.cs
+++ b/starsky/starsky.foundation.platform/Models/AppSettingsImportBackupModel.cs
@@ -2,6 +2,6 @@ namespace starsky.foundation.platform.Models;
 
 public class AppSettingsImportBackupModel
 {
-	public bool Enabled { get; set; } = false;
+	public bool Enabled { get; set; }
 	public string? StorageFolder { get; set; }
 }

--- a/starsky/starsky.foundation.platform/Models/AppSettingsMountWatcherModel.cs
+++ b/starsky/starsky.foundation.platform/Models/AppSettingsMountWatcherModel.cs
@@ -1,0 +1,9 @@
+namespace starsky.foundation.platform.Models;
+
+public class AppSettingsMountWatcherModel
+{
+	/// <summary>
+	///     Delete the source image after successful import
+	/// </summary>
+	public bool DeleteAfter { get; set; }
+}

--- a/starsky/starsky/Properties/default-init-launchSettings.json
+++ b/starsky/starsky/Properties/default-init-launchSettings.json
@@ -52,7 +52,9 @@
         "___app__PublishProfilesRemote__default__0__type": "ftp",
         "___app__PublishProfilesRemote__default__0__ftp__webFtp": "ftp://ftp.example.com/test",
         "___app__PublishProfilesRemote__Profiles___default__0__type": "ftp",
-        "___app__PublishProfilesRemote__Profiles___default__0__ftp__webFtp": "ftp://user:pass@ftp.example.com/path"
+        "___app__PublishProfilesRemote__Profiles___default__0__ftp__webFtp": "ftp://user:pass@ftp.example.com/path",
+        "___app__ImportBackup__Enabled": "false",
+        "___app__ImportBackup__StorageFolder": "remove prefix underscores ___ and update value"
       }
     },
     "IIS": {

--- a/starsky/starsky/appsettings.json
+++ b/starsky/starsky/appsettings.json
@@ -39,6 +39,10 @@
       "$RECYCLE.BIN",
       "Photos Library.photoslibrary"
     ],
+    "ImportBackup" : {
+      "Enabled": "false",
+      "StorageFolder": ""
+    },
     "VideoUseLocalTime": [
       {
         "Make": "Sony",

--- a/starsky/starsky/appsettings.json
+++ b/starsky/starsky/appsettings.json
@@ -39,9 +39,12 @@
       "$RECYCLE.BIN",
       "Photos Library.photoslibrary"
     ],
-    "ImportBackup" : {
+    "ImportBackup": {
       "Enabled": "false",
       "StorageFolder": ""
+    },
+    "ImportMountWatcher": {
+      "DeleteAfter": "false"
     },
     "VideoUseLocalTime": [
       {

--- a/starsky/starsky/pm2-deploy-on-env.sh
+++ b/starsky/starsky/pm2-deploy-on-env.sh
@@ -122,7 +122,8 @@ files=(
   "dependencies/exiftool-unix/exiftool"
   "pm2-restore-x-rights.sh"
   "pm2-warmup.sh"
-  "service-deploy-systemd.sh"
+  "service-deploy-systemd.sh",
+  "github-artifacts-download.sh",
   "starsky"
 )
 

--- a/starsky/starsky/pm2-new-instance.sh
+++ b/starsky/starsky/pm2-new-instance.sh
@@ -231,69 +231,35 @@ if [[ -d "$USER_VIEWS_DIR" ]]; then
 fi
 
 # execute rights for specific files
-if [[ -f starskygeocli ]]; then
-    chmod +x ./starskygeocli
-fi
+# excute right for specific files
+files=(
+  "starskygeocli"
+  "starskyimportercli"
+  "starskysynchronizecli"
+  "starskythumbnailcli"
+  "starskythumbnailmetacli"
+  "starskywebftpcli"
+  "starskywebhtmlcli"
+  "starskyadmincli"
+  "starskymountwatchercli"
+  "starskydependenciesdownloadcli"
+  "pm2-deploy-on-env.sh"
+  "pm2-install-latest-release.sh"
+  "pm2-new-instance.sh"
+  "pm2-download-azure-devops.sh"
+  "dependencies/exiftool-unix/exiftool"
+  "pm2-restore-x-rights.sh"
+  "pm2-warmup.sh"
+  "service-deploy-systemd.sh",
+  "github-artifacts-download.sh"
+  "starsky"
+)
 
-if [[ -f starskyimportercli ]]; then
-    chmod +x ./starskyimportercli
-fi
-
-if [[ -f starskysynchronizecli ]]; then
-    chmod +x ./starskysynchronizecli
-fi
-
-if [[ -f starskythumbnailcli ]]; then
-    chmod +x ./starskythumbnailcli
-fi
-
-if [[ -f starskythumbnailmetacli ]]; then
-    chmod +x ./starskythumbnailmetacli
-fi
-
-if [[ -f starskywebftpcli ]]; then
-    chmod +x ./starskywebftpcli
-fi
-
-if [[ -f starskywebhtmlcli ]]; then
-    chmod +x ./starskywebhtmlcli
-fi
-
-if [[ -f starskyadmincli ]]; then
-    chmod +x ./starskyadmincli
-fi
-
-if [[ -f pm2-deploy-on-env.sh ]]; then
-    chmod +x ./pm2-deploy-on-env.sh
-fi
-
-if [[ -f pm2-install-latest-release.sh ]]; then
-    chmod +x ./pm2-install-latest-release.sh
-fi
-
-if [[ -f pm2-restore-x-rights.sh ]]; then
-    chmod +x ./pm2-restore-x-rights.sh
-fi
-
-if [[ -f pm2-warmup.sh ]]; then
-    chmod +x ./pm2-warmup.sh
-fi
-
-if [[ -f pm2-new-instance.sh ]]; then
-    chmod +x ./pm2-new-instance.sh
-fi
-
-if [[ -f pm2-download-azure-devops.sh ]]; then
-    chmod +x ./pm2-download-azure-devops.sh
-fi
-
-if [[ -f github-artifacts-download.sh ]]; then
-    chmod +x ./github-artifacts-download.sh
-fi
-
-if [[ -f starsky ]]; then
-    chmod +x ./starsky
-fi
+for file in "${files[@]}"; do
+  if [[ -f "$file" ]]; then
+    chmod +x "$file"
+  fi
+done
 
 MAC_CODESIGN_SCRIPT="$CURRENT_DIR/mac-self-codesign.sh"
 if [[ $(uname) = "Darwin" ]] && [[ -f "$MAC_CODESIGN_SCRIPT" ]]; then

--- a/starsky/starsky/pm2-restore-x-rights.sh
+++ b/starsky/starsky/pm2-restore-x-rights.sh
@@ -24,7 +24,8 @@ files=(
   "dependencies/exiftool-unix/exiftool"
   "pm2-restore-x-rights.sh"
   "pm2-warmup.sh"
-  "service-deploy-systemd.sh"
+  "service-deploy-systemd.sh",
+  "github-artifacts-download.sh"
   "starsky"
 )
 

--- a/starsky/starskymountwatchercli/Properties/default-init-launchSettings.json
+++ b/starsky/starskymountwatchercli/Properties/default-init-launchSettings.json
@@ -5,6 +5,7 @@
       "commandName": "Project",
       "commandLineArgs": "-h",
       "environmentVariables": {
+        "app__ImportMountWatcher__DeleteAfter": "false"
       }
     }
   }

--- a/starsky/starskytest/FakeMocks/FakeIStorage.cs
+++ b/starsky/starskytest/FakeMocks/FakeIStorage.cs
@@ -467,7 +467,7 @@ public class FakeIStorage : IStorage
 	/// <param name="stream">stream</param>
 	/// <param name="path">where to write to</param>
 	/// <returns>is Success</returns>
-	public Task<bool> WriteStreamAsync(Stream stream, string path)
+	public virtual Task<bool> WriteStreamAsync(Stream stream, string path)
 	{
 		return Task.FromResult(WriteStream(stream, path));
 	}

--- a/starsky/starskytest/starsky.foundation.import/Services/ImportBackupTests.cs
+++ b/starsky/starskytest/starsky.foundation.import/Services/ImportBackupTests.cs
@@ -89,6 +89,44 @@ public sealed class ImportBackupTests
 	}
 
 	[TestMethod]
+	public async Task CopyStreamFromHostToBackup_WritesBackup_WithExpectedFileName()
+	{
+		// Arrange
+		var sourceBytes = new byte[] { 1, 2, 3, 4, 5 };
+		var storage = new FakeIStorage(["/", "/backup"],
+			["/test.jpg"], new List<byte[]> { sourceBytes });
+		var selector = new FakeSelectorStorage(storage);
+		var logger = new FakeIWebLogger();
+		var sut = new ImportBackup(selector, logger);
+
+		var importIndexItem = new ImportIndexItem
+		{
+			SourceFullFilePath = "/test.jpg",
+			FileIndexItem = new FileIndexItem
+			{
+				FileName = "test.jpg",
+				DateTime = new DateTime(2018, 4, 22, 16, 14, 54, DateTimeKind.Local),
+				ImageFormat = ExtensionRolesHelper.ImageFormat.jpg
+			}
+		};
+
+		var importBackup = new AppSettingsImportBackupModel
+		{
+			Enabled = true,
+			StorageFolder = "/backup"
+		};
+
+		// Act
+		var result = await sut.CopyStreamFromHostToBackup(importIndexItem, importBackup);
+
+		// Assert
+		Assert.IsTrue(result);
+		var files = storage.GetAllFilesInDirectory("/backup").ToList();
+		Assert.HasCount(1, files);
+		Assert.AreEqual("/backup/20180422_161454_test.jpg", files[0]);
+	}
+
+	[TestMethod]
 	public async Task CopyStreamFromHostToBackup_ReturnsFalse_WhenWriteFails()
 	{
 		var sourceBytes = "\t\t\t"u8.ToArray();

--- a/starsky/starskytest/starsky.foundation.import/Services/ImportBackupTests.cs
+++ b/starsky/starskytest/starsky.foundation.import/Services/ImportBackupTests.cs
@@ -45,6 +45,38 @@ public sealed class ImportBackupTests
 		var result = await sut.CopyStreamFromHostToBackup(importIndexItem, importBackup);
 		Assert.IsNull(result);
 	}
+	
+	[TestMethod]
+	public async Task CopyStreamFromHostToBackup_ReturnsNull_WhenDisabled_DueNotFoundOutputDir()
+	{
+		var storage = new FakeIStorage(["/"],  // backup is not here
+			["/test.jpg"],
+			new List<byte[]> { new byte[] { 1, 2, 3 } });
+		var selector = new FakeSelectorStorage(storage);
+		var logger = new FakeIWebLogger();
+
+		var sut = new ImportBackup(selector, logger);
+
+		var importIndexItem = new ImportIndexItem
+		{
+			SourceFullFilePath = "/test.jpg",
+			FileIndexItem = new FileIndexItem
+			{
+				FileName = "test.jpg",
+				DateTime = new DateTime(2020, 1, 2,
+					3, 4, 5, DateTimeKind.Local),
+				ImageFormat = ExtensionRolesHelper.ImageFormat.jpg
+			}
+		};
+
+		var importBackup = new AppSettingsImportBackupModel
+		{
+			Enabled = true, StorageFolder = "/backup"
+		};
+
+		var result = await sut.CopyStreamFromHostToBackup(importIndexItem, importBackup);
+		Assert.IsNull(result);
+	}
 
 	[TestMethod]
 	public async Task CopyStreamFromHostToBackup_WritesBackupAndReturnsTrue_WhenSizesMatch()
@@ -130,7 +162,7 @@ public sealed class ImportBackupTests
 	public async Task CopyStreamFromHostToBackup_ReturnsFalse_WhenWriteFails()
 	{
 		var sourceBytes = "\t\t\t"u8.ToArray();
-		var storageForSelector = new FakeIStorage(["/"], ["/test.jpg"],
+		var storageForSelector = new FakeIStorage(["/", "/backup"], ["/test.jpg"],
 			new List<byte[]> { sourceBytes }, null,
 			null, new AggregateException(new IOException("Simulated write failure")));
 		var selector = new FakeSelectorStorage(storageForSelector);

--- a/starsky/starskytest/starsky.foundation.import/Services/ImportBackupTests.cs
+++ b/starsky/starskytest/starsky.foundation.import/Services/ImportBackupTests.cs
@@ -45,11 +45,14 @@ public sealed class ImportBackupTests
 		var result = await sut.CopyStreamFromHostToBackup(importIndexItem, importBackup);
 		Assert.IsNull(result);
 	}
-	
+
 	[TestMethod]
-	public async Task CopyStreamFromHostToBackup_ReturnsNull_WhenDisabled_DueNotFoundOutputDir()
+	[DataRow("/backup")]
+	[DataRow(null)]
+	public async Task CopyStreamFromHostToBackup_ReturnsNull_WhenDisabled_DueNotFoundOutputDir(
+		string? backupFolder)
 	{
-		var storage = new FakeIStorage(["/"],  // backup is not here
+		var storage = new FakeIStorage(["/"], // backup is not here
 			["/test.jpg"],
 			new List<byte[]> { new byte[] { 1, 2, 3 } });
 		var selector = new FakeSelectorStorage(storage);
@@ -71,7 +74,8 @@ public sealed class ImportBackupTests
 
 		var importBackup = new AppSettingsImportBackupModel
 		{
-			Enabled = true, StorageFolder = "/backup"
+			Enabled = true, 
+			StorageFolder = backupFolder
 		};
 
 		var result = await sut.CopyStreamFromHostToBackup(importIndexItem, importBackup);
@@ -144,8 +148,7 @@ public sealed class ImportBackupTests
 
 		var importBackup = new AppSettingsImportBackupModel
 		{
-			Enabled = true,
-			StorageFolder = "/backup"
+			Enabled = true, StorageFolder = "/backup"
 		};
 
 		// Act

--- a/starsky/starskytest/starsky.foundation.import/Services/ImportBackupTests.cs
+++ b/starsky/starskytest/starsky.foundation.import/Services/ImportBackupTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using starsky.foundation.database.Models;
+using starsky.foundation.import.Services;
+using starsky.foundation.platform.Helpers;
+using starsky.foundation.platform.Models;
+using starskytest.FakeMocks;
+
+namespace starskytest.starsky.foundation.import.Services;
+
+[TestClass]
+public sealed class ImportBackupTests
+{
+	[TestMethod]
+	public async Task CopyStreamFromHostToBackup_ReturnsNull_WhenDisabled()
+	{
+		var storage = new FakeIStorage(["/"], ["/test.jpg"],
+			new List<byte[]> { new byte[] { 1, 2, 3 } });
+		var selector = new FakeSelectorStorage(storage);
+		var logger = new FakeIWebLogger();
+
+		var sut = new ImportBackup(selector, logger);
+
+		var importIndexItem = new ImportIndexItem
+		{
+			SourceFullFilePath = "/test.jpg",
+			FileIndexItem = new FileIndexItem
+			{
+				FileName = "test.jpg",
+				DateTime = new DateTime(2020, 1, 2,
+					3, 4, 5, DateTimeKind.Local),
+				ImageFormat = ExtensionRolesHelper.ImageFormat.jpg
+			}
+		};
+
+		var importBackup = new AppSettingsImportBackupModel
+		{
+			Enabled = false, StorageFolder = "/backup"
+		};
+
+		var result = await sut.CopyStreamFromHostToBackup(importIndexItem, importBackup);
+		Assert.IsNull(result);
+	}
+
+	[TestMethod]
+	public async Task CopyStreamFromHostToBackup_WritesBackupAndReturnsTrue_WhenSizesMatch()
+	{
+		var sourceBytes = new byte[] { 1, 2, 3, 4, 5 };
+		var storage = new FakeIStorage(["/", "/backup"],
+			["/test.jpg"], new List<byte[]> { sourceBytes });
+		var selector = new FakeSelectorStorage(storage);
+		var logger = new FakeIWebLogger();
+
+		var sut = new ImportBackup(selector, logger);
+
+		var importIndexItem = new ImportIndexItem
+		{
+			SourceFullFilePath = "/test.jpg",
+			FileIndexItem = new FileIndexItem
+			{
+				FileName = "test.jpg",
+				DateTime = new DateTime(2020, 1, 2,
+					3, 4, 5, DateTimeKind.Local),
+				ImageFormat = ExtensionRolesHelper.ImageFormat.jpg
+			}
+		};
+
+		var importBackup = new AppSettingsImportBackupModel
+		{
+			Enabled = true, StorageFolder = "/backup"
+		};
+
+		var result = await sut.CopyStreamFromHostToBackup(importIndexItem, importBackup);
+		Assert.IsTrue(result);
+
+		// Expect a file created under /backup with size same as source
+		var files = storage.GetAllFilesInDirectory("/backup").ToList();
+		Assert.IsNotNull(files);
+		// check that at least one file exists in backup folder
+		Assert.IsNotEmpty(files);
+		var backupPath = files[0];
+		Assert.IsTrue(storage.ExistFile(backupPath));
+		var info = storage.Info(backupPath);
+		Assert.AreEqual(sourceBytes.Length, info.Size);
+	}
+
+	[TestMethod]
+	public async Task CopyStreamFromHostToBackup_ReturnsFalse_WhenWriteFails()
+	{
+		var sourceBytes = "\t\t\t"u8.ToArray();
+		var storageForSelector = new FakeIStorage(["/"], ["/test.jpg"],
+			new List<byte[]> { sourceBytes }, null,
+			null, new AggregateException(new IOException("Simulated write failure")));
+		var selector = new FakeSelectorStorage(storageForSelector);
+		var logger = new FakeIWebLogger();
+		var sut = new ImportBackup(selector, logger);
+
+		var importIndexItem = new ImportIndexItem
+		{
+			SourceFullFilePath = "/test.jpg",
+			FileIndexItem = new FileIndexItem
+			{
+				FileName = "test.jpg",
+				DateTime = DateTime.UtcNow,
+				ImageFormat = ExtensionRolesHelper.ImageFormat.jpg
+			}
+		};
+
+		var importBackup = new AppSettingsImportBackupModel
+		{
+			Enabled = true, StorageFolder = "/backup"
+		};
+
+		var result = await sut.CopyStreamFromHostToBackup(importIndexItem, importBackup);
+		Assert.IsFalse(result);
+		// error has been logged
+		Assert.IsNotEmpty(logger.TrackedExceptions);
+	}
+}

--- a/starsky/starskytest/starsky.foundation.import/Services/ImportBackupTests.cs
+++ b/starsky/starskytest/starsky.foundation.import/Services/ImportBackupTests.cs
@@ -158,7 +158,7 @@ public sealed class ImportBackupTests
 		Assert.IsTrue(result);
 		var files = storage.GetAllFilesInDirectory("/backup").ToList();
 		Assert.HasCount(1, files);
-		Assert.AreEqual("/backup/20180422_161454_test.jpg", files[0]);
+		Assert.AreEqual($"/backup{Path.DirectorySeparatorChar}20180422_161454_test.jpg", files[0]);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/starsky.foundation.import/Services/ImportTest.cs
+++ b/starsky/starskytest/starsky.foundation.import/Services/ImportTest.cs
@@ -569,7 +569,7 @@ public sealed class ImportTest : VerifyBase
 		var backupFiles = storage.GetAllFilesInDirectory("/backup").ToList();
 		Assert.IsNotEmpty(backupFiles);
 		Assert.HasCount(1, backupFiles);
-		Assert.AreEqual("/backup/20180422_161454_test.jpg", backupFiles[0]);
+		Assert.AreEqual($"/backup{Path.DirectorySeparatorChar}20180422_161454_test.jpg", backupFiles[0]);
 
 		// import should have created a copy in subpath (not only the original /test.jpg)
 		var allFiles = storage.GetAllFilesInDirectoryRecursive("/").ToList();

--- a/starsky/starskytest/starsky.foundation.import/Services/ImportTest.cs
+++ b/starsky/starskytest/starsky.foundation.import/Services/ImportTest.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using starsky.foundation.database.Models;
 using starsky.foundation.geo.ReverseGeoCode;
@@ -518,6 +519,64 @@ public sealed class ImportTest : VerifyBase
 
 		Assert.AreEqual(ImportStatus.Ok, result.FirstOrDefault()?.Status);
 		Assert.IsFalse(storage.ExistFile("/test.jpg"));
+	}
+
+	[TestMethod]
+	public async Task Importer_WithBackup_CreatesBackupAndImportsFile()
+	{
+		// Arrange: source file and backup folder
+		var storage = new FakeIStorage(["/", "/backup"],
+			["/test.jpg"],
+			new List<byte[]> { CreateAnImage.Bytes.ToArray() });
+		var selector = new FakeSelectorStorage(storage);
+
+		var appSettings = new AppSettings
+		{
+			ImportBackup =
+				new AppSettingsImportBackupModel { Enabled = true, StorageFolder = "/backup" },
+			Structure = new AppSettingsStructureModel
+			{
+				DefaultPattern = "/yyyy/MM/yyyy_MM_dd*/yyyyMMdd_HHmmss.ext"
+			}
+		};
+
+		var importService = new Import(
+			selector,
+			appSettings,
+			new FakeIImportQuery(),
+			new FakeExifTool(storage, appSettings),
+			new FakeIQuery(),
+			new FakeConsoleWrapper([]),
+			new FakeIMetaExifThumbnailService(),
+			new FakeIWebLogger(),
+			new FakeIThumbnailQuery(),
+			new FakeIReverseGeoCodeService(),
+			new MemoryCache(new MemoryCacheOptions())
+		);
+
+		var importSettings = new ImportSettingsModel { IndexMode = false };
+
+		// Act
+		var result = await importService.Importer(new List<string> { "/test.jpg" }, importSettings);
+
+		// Assert
+		Assert.IsNotNull(result);
+		Assert.IsNotEmpty(result);
+		var first = result[0];
+		Assert.AreEqual(ImportStatus.Ok, first.Status);
+
+		// backup file should be created under /backup
+		var backupFiles = storage.GetAllFilesInDirectory("/backup").ToList();
+		Assert.IsNotEmpty(backupFiles);
+		Assert.HasCount(1, backupFiles);
+		Assert.AreEqual("/backup/20180422_161454_test.jpg", backupFiles[0]);
+
+		// import should have created a copy in subpath (not only the original /test.jpg)
+		var allFiles = storage.GetAllFilesInDirectoryRecursive("/").ToList();
+		Assert.IsGreaterThanOrEqualTo(2, allFiles.Count);
+
+		var importDone = storage.ExistFile("/2018/04/2018_04_22/20180422_161454.jpg");
+		Assert.IsTrue(importDone);
 	}
 
 	private static AppSettings SetupReverseGeoCodeServiceData()

--- a/starsky/starskytest/starsky.foundation.import/Services/ImportTest.cs
+++ b/starsky/starskytest/starsky.foundation.import/Services/ImportTest.cs
@@ -867,7 +867,7 @@ public sealed class ImportTest : VerifyBase
 				Status = ImportStatus.Ok,
 				FileIndexItem = new FileIndexItem { FilePath = "/test.jpg" }
 			},
-			new ImportSettingsModel());
+			new ImportSettingsModel(), new AppSettingsImportBackupModel());
 
 		Assert.IsFalse(subPathStorage.ExistFile("/test.jpg"));
 		Assert.IsFalse(await fakeImportQuery.IsHashInImportDbAsync("hash73845934893459"));
@@ -1130,7 +1130,7 @@ public sealed class ImportTest : VerifyBase
 
 		var result = await importService.Importer(
 			new ImportIndexItem { Status = ImportStatus.FileError },
-			new ImportSettingsModel());
+			new ImportSettingsModel(), new AppSettingsImportBackupModel());
 		Assert.AreEqual(ImportStatus.FileError, result.Status);
 	}
 

--- a/starsky/starskytest/starsky.foundation.platform/Helpers/AppSettingsCompareHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Helpers/AppSettingsCompareHelperTest.cs
@@ -238,6 +238,39 @@ public sealed class AppSettingsCompareHelperTest
 	}
 
 	[TestMethod]
+	public void AppSettingsMountWatcher()
+	{
+		var source = new AppSettings
+		{
+			ImportMountWatcher = new AppSettingsMountWatcherModel { DeleteAfter = false }
+		};
+
+		var to = new AppSettings
+		{
+			ImportMountWatcher = new AppSettingsMountWatcherModel { DeleteAfter = true }
+		};
+
+		AppSettingsCompareHelper.Compare(source, to);
+
+		Assert.IsTrue(source.ImportMountWatcher.DeleteAfter);
+	}
+
+	[TestMethod]
+	public void ImportMountWatcherModel_Ignore_DefaultOption()
+	{
+		var source = new AppSettings
+		{
+			ImportMountWatcher = new AppSettingsMountWatcherModel { DeleteAfter = true }
+		};
+
+		var to = new AppSettings { ImportMountWatcher = new AppSettingsMountWatcherModel() };
+
+		AppSettingsCompareHelper.Compare(source, to);
+
+		Assert.IsTrue(source.ImportMountWatcher.DeleteAfter);
+	}
+
+	[TestMethod]
 	public void StringCompare()
 	{
 		var source = new AppSettings

--- a/starsky/starskytest/starsky.foundation.platform/Helpers/AppSettingsCompareHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Helpers/AppSettingsCompareHelperTest.cs
@@ -193,6 +193,51 @@ public sealed class AppSettingsCompareHelperTest
 	}
 
 	[TestMethod]
+	public void AppSettingsImportBackupModel()
+	{
+		var source = new AppSettings
+		{
+			ImportBackup = new AppSettingsImportBackupModel
+			{
+				Enabled = false, StorageFolder = "/test-1"
+			}
+		};
+
+		var to = new AppSettings
+		{
+			ImportBackup = new AppSettingsImportBackupModel
+			{
+				Enabled = true, StorageFolder = "/test"
+			}
+		};
+
+		AppSettingsCompareHelper.Compare(source, to);
+
+		Assert.IsTrue(source.ImportBackup.Enabled);
+		Assert.AreEqual("/test", source.ImportBackup.StorageFolder);
+	}
+
+	[TestMethod]
+	public void AppSettingsImportBackupModel_Ignore_DefaultOption()
+	{
+		var source = new AppSettings
+		{
+			ImportBackup = new AppSettingsImportBackupModel
+			{
+				Enabled = true, StorageFolder = "/test"
+			}
+		};
+
+		var to = new AppSettings { ImportBackup = new AppSettingsImportBackupModel() };
+
+		AppSettingsCompareHelper.Compare(source, to);
+
+		Assert.IsTrue(source.ImportBackup.Enabled);
+		Assert.AreEqual("/test",
+			source.ImportBackup.StorageFolder);
+	}
+
+	[TestMethod]
 	public void StringCompare()
 	{
 		var source = new AppSettings


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request introduces two new configurable import features—Import Backup and Delete After Import—along with associated documentation, configuration model changes, and supporting code. The Import Backup feature allows for an immutable backup of imported files, while Delete After Import enables automatic removal of files from the source device after import. Both features are configurable via environment variables or `appsettings.json`. Additionally, the configuration system and related documentation have been updated to clarify override order and usage.

**New Import Features:**

* **Import Backup:** Adds support for creating a deterministic, timestamped backup copy of imported files to a specified folder. This is controlled via the new `ImportBackup` section in `appsettings.json` or environment variables. The backup process is implemented in the new `ImportBackup` service and integrated into the import workflow. [[1]](diffhunk://#diff-9c8287595a48fd97b3ef0f3c68c779d0136ddb6b1bf27450e90b1464f4d0cb21R196-R223) [[2]](diffhunk://#diff-3c65c740b20a10199ed8e4cf06499caf49ac531b3ec432acc6e5654ce49fe949R48) [[3]](diffhunk://#diff-3c65c740b20a10199ed8e4cf06499caf49ac531b3ec432acc6e5654ce49fe949R109) [[4]](diffhunk://#diff-3c65c740b20a10199ed8e4cf06499caf49ac531b3ec432acc6e5654ce49fe949L182-R184) [[5]](diffhunk://#diff-3c65c740b20a10199ed8e4cf06499caf49ac531b3ec432acc6e5654ce49fe949R543-R547) [[6]](diffhunk://#diff-3c65c740b20a10199ed8e4cf06499caf49ac531b3ec432acc6e5654ce49fe949R569-R572) [[7]](diffhunk://#diff-c51e46a0228c2bf85bf3c029bcb4778786cd03dbb792784e11c61704c6ece9ceR1-R88) [[8]](diffhunk://#diff-dec4b780d916ee13787523633e42702260f25534a949bc8fadfa3cbf9a4ac36cR1-R7) [[9]](diffhunk://#diff-233b2f2e840bcf6ff71c4335a04cb38b9542eaaee7bf61473677f5164cafa063L55-R57) [[10]](diffhunk://#diff-1d2a9c731d1a6ff5becc4316c04291e8eed793890811b6f8d41651be1c54ba67R42-R48)

* **Delete After Import:** Introduces an option to delete original files from the mounted device after a successful import, configurable via the new `ImportMountWatcher` section in `appsettings.json` or environment variables. The mount watcher now respects this setting. [[1]](diffhunk://#diff-4b499617270672db798e592bbfe6e36732fc6db1c6839309785270bea0cd8d00R57-R76) [[2]](diffhunk://#diff-6b72c43cca4a91a74da0d302f69eeb7ced6a1ef7c42ee32b08d020a25cf35d6bL275-R277) [[3]](diffhunk://#diff-567ae17a0d920fb3d5b8560c807e5bd34e7745d337091a405e3a929ee468fd92R1-R9) [[4]](diffhunk://#diff-e0764733bce82b9c55a7cff335735b1275139ec059d1e39b50bb1671f123f49aR8) [[5]](diffhunk://#diff-1d2a9c731d1a6ff5becc4316c04291e8eed793890811b6f8d41651be1c54ba67R42-R48)

**Configuration and Documentation Updates:**

* **Configuration Model and Override Order:** Adds `ImportBackup` and `ImportMountWatcher` models to `AppSettings`, and documents the configuration file/environment variable override order with examples for new features. [[1]](diffhunk://#diff-0e27e057ba40e882bc1e16d9a077ffce5a26cc87d8c758c7b59a2e9a351ba360R286-R289) [[2]](diffhunk://#diff-6d962cc157295de5785aed6d0ba16479d5bc75faf3d8be509ddf33b24ac1b56dR42-R82) [[3]](diffhunk://#diff-dec4b780d916ee13787523633e42702260f25534a949bc8fadfa3cbf9a4ac36cR1-R7) [[4]](diffhunk://#diff-567ae17a0d920fb3d5b8560c807e5bd34e7745d337091a405e3a929ee468fd92R1-R9)

* **Documentation:** Updates import and mount watcher documentation to describe the new features, configuration options, and usage scenarios. [[1]](diffhunk://#diff-9c8287595a48fd97b3ef0f3c68c779d0136ddb6b1bf27450e90b1464f4d0cb21R196-R223) [[2]](diffhunk://#diff-4b499617270672db798e592bbfe6e36732fc6db1c6839309785270bea0cd8d00R57-R76) [[3]](diffhunk://#diff-6d962cc157295de5785aed6d0ba16479d5bc75faf3d8be509ddf33b24ac1b56dR42-R82)

**Supporting Changes:**

* Updates the configuration comparison helper to support the new settings models, ensuring hot-reload and difference detection work as expected. [[1]](diffhunk://#diff-32e70689ab2e456e214d4d5e9d62ad63274b4e99246d58fed99a6ca6845098adR95-R120) [[2]](diffhunk://#diff-32e70689ab2e456e214d4d5e9d62ad63274b4e99246d58fed99a6ca6845098adR182-R225)

These changes make import workflows more robust, configurable, and safer for users needing backup and cleanup automation.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
