### PR TITLE
sonar 17

### DIFF
--- a/starsky/starsky/cleanup-build-tools.sh
+++ b/starsky/starsky/cleanup-build-tools.sh
@@ -178,7 +178,7 @@ then
         
         cd $ROOT_REPO_DIR"/starsky-tools/end2end"
         echo "next: re-install cypress"
-        npm ci
+        npm ci --ignore-scripts
     else
         echo "Skip: remove cypress cache. There is only 1 folder in the cypress cache, skip remove"
     fi

--- a/starsky/starskytest/Controllers/DeleteControllerTest.cs
+++ b/starsky/starskytest/Controllers/DeleteControllerTest.cs
@@ -49,7 +49,7 @@ public sealed class DeleteControllerTest
 		var options = builderDb.Options;
 		var context = new ApplicationDbContext(options);
 		_query = new Query(context,
-			new AppSettings(), null, new FakeIWebLogger(), memoryCache);
+			new AppSettings(), new FakeIServiceScopeFactory(), new FakeIWebLogger(), memoryCache);
 
 		// Inject Fake ExifTool; dependency injection
 		var services = new ServiceCollection();

--- a/starsky/starskytest/Controllers/DownloadPhotoControllerTest.cs
+++ b/starsky/starskytest/Controllers/DownloadPhotoControllerTest.cs
@@ -42,7 +42,7 @@ public sealed class DownloadPhotoControllerTest
 		builderDb.UseInMemoryDatabase(nameof(DownloadPhotoControllerTest));
 		var options = builderDb.Options;
 		var context = new ApplicationDbContext(options);
-		var scopeFactory = provider.GetService<IServiceScopeFactory>();
+		var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
 		_query = new Query(context, new AppSettings(), scopeFactory, new FakeIWebLogger(),
 			memoryCache);
 	}

--- a/starsky/starskytest/Controllers/ThumbnailControllerTest.cs
+++ b/starsky/starskytest/Controllers/ThumbnailControllerTest.cs
@@ -46,7 +46,7 @@ public sealed class ThumbnailControllerTest
 		var options = builderDb.Options;
 		var context = new ApplicationDbContext(options);
 		_query = new Query(context, new AppSettings(),
-			null, new FakeIWebLogger(), memoryCache);
+			new FakeIServiceScopeFactory(), new FakeIWebLogger(), memoryCache);
 	}
 
 	private static ThumbnailController CreateSut(IStorage storage, IQuery query,

--- a/starsky/starskytest/Controllers/UploadControllerTest.cs
+++ b/starsky/starskytest/Controllers/UploadControllerTest.cs
@@ -14,10 +14,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using starsky.Controllers;
-using starsky.foundation.import.Services;
 using starsky.foundation.database.Data;
 using starsky.foundation.database.Models;
 using starsky.foundation.database.Query;
+using starsky.foundation.import.Services;
 using starsky.foundation.platform.Helpers;
 using starsky.foundation.platform.Models;
 using starsky.foundation.platform.Services;
@@ -48,7 +48,7 @@ public sealed class UploadControllerTest
 		builderDb.UseInMemoryDatabase(nameof(ExportControllerTest));
 		var options = builderDb.Options;
 		var context = new ApplicationDbContext(options);
-		var scopeFactory = provider.GetService<IServiceScopeFactory>();
+		var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
 		var services = new ServiceCollection();
 
 		// Fake the readMeta output

--- a/starsky/starskytest/starsky.feature.rename/Services/BatchRenameServiceTest.cs
+++ b/starsky/starskytest/starsky.feature.rename/Services/BatchRenameServiceTest.cs
@@ -48,7 +48,7 @@ public class BatchRenameServiceTest
 			StorageFolder = PathHelper.AddBackslash(newImage.BasePath),
 			ThumbnailTempFolder = newImage.BasePath
 		};
-		_query = new Query(context, appSettings, null,
+		_query = new Query(context, appSettings, new FakeIServiceScopeFactory(),
 			new FakeIWebLogger(), memoryCache);
 
 		if ( _query.GetAllFilesAsync("/").Result.TrueForAll(p => p.FileName != newImage.FileName) )

--- a/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
+++ b/starsky/starskytest/starsky.feature.rename/Services/RenameServiceTest.cs
@@ -50,7 +50,7 @@ public sealed class RenameServiceTest
 			StorageFolder = PathHelper.AddBackslash(_newImage.BasePath),
 			ThumbnailTempFolder = _newImage.BasePath
 		};
-		_query = new Query(context, appSettings, null,
+		_query = new Query(context, appSettings, new FakeIServiceScopeFactory(),
 			new FakeIWebLogger(), memoryCache);
 
 		if ( _query.GetAllFilesAsync("/").Result.TrueForAll(p => p.FileName != _newImage.FileName) )
@@ -741,22 +741,22 @@ public sealed class RenameServiceTest
 	[TestMethod]
 	public async Task Rename_Move_SidecarFile_ShouldMove_FileToFolder()
 	{
-		const string item1dng = "/child_folder/test_20.dng";
+		const string item1Dng = "/child_folder/test_20.dng";
 		const string item1SideCar = "/child_folder/test_20.xmp";
 
-		await _query.AddItemAsync(new FileIndexItem(item1dng));
-		await _query.AddParentItemsAsync(item1dng);
+		await _query.AddItemAsync(new FileIndexItem(item1Dng));
+		await _query.AddParentItemsAsync(item1Dng);
 
 		var iStorage = new FakeIStorage(
 			new List<string> { "/", "/child_folder", "/child_folder2" },
-			new List<string> { item1dng, item1SideCar }); // item1
+			new List<string> { item1Dng, item1SideCar }); // item1
 
 		// Move DNG to different folder
 		var renameFs = await new RenameService(_query, iStorage, new FakeIWebLogger())
-			.Rename(item1dng, "/child_folder2");
+			.Rename(item1Dng, "/child_folder2");
 
-		Assert.AreEqual(item1dng, renameFs[0].FilePath);
-		Assert.AreEqual(item1dng.Replace("child_folder", "child_folder2"),
+		Assert.AreEqual(item1Dng, renameFs[0].FilePath);
+		Assert.AreEqual(item1Dng.Replace("child_folder", "child_folder2"),
 			renameFs[1].FilePath);
 
 		// did move the side car file
@@ -1125,7 +1125,8 @@ public sealed class RenameServiceTest
 
 		var appSettings = new AppSettings { StorageFolder = "/", ThumbnailTempFolder = "/" };
 		var memoryCache = new MemoryCache(new MemoryCacheOptions());
-		var query = new Query(context, appSettings, null, new FakeIWebLogger(), memoryCache);
+		var query = new Query(context, appSettings,
+			new FakeIServiceScopeFactory(), new FakeIWebLogger(), memoryCache);
 
 		var fileIndexItem = new FileIndexItem { FileHash = "test-hash", FilePath = "/test.jpg" };
 		await query.AddItemAsync(fileIndexItem);

--- a/starsky/starskytest/starsky.feature.trash/Services/MoveToTrashServiceTest.cs
+++ b/starsky/starskytest/starsky.feature.trash/Services/MoveToTrashServiceTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,7 +23,6 @@ using starsky.foundation.readmeta.Services;
 using starsky.foundation.realtime.Interfaces;
 using starsky.foundation.worker.Interfaces;
 using starskytest.FakeMocks;
-using System.Text.Json;
 
 namespace starskytest.starsky.feature.trash.Services;
 
@@ -96,7 +96,7 @@ public class MoveToTrashServiceTest
 			new FakeITrashConnectionService());
 
 		await moveToTrashService.CreateEvent([dirPath], true);
-		
+
 		var scope = scopeFactory.CreateScope();
 		var trashService2 = scope.ServiceProvider.GetService<ITrashService>() as FakeITrashService;
 		Assert.IsNotNull(trashService2);
@@ -227,7 +227,7 @@ public class MoveToTrashServiceTest
 		var serviceCollection =
 			new ServiceCollection().AddScoped(_ => new ApplicationDbContext(options));
 		var serviceScopeFactory =
-			serviceCollection.BuildServiceProvider().GetService<IServiceScopeFactory>();
+			serviceCollection.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
 		var storage = new FakeIStorage(
 			["/", "/test"],
@@ -284,7 +284,7 @@ public class MoveToTrashServiceTest
 		var serviceCollection =
 			new ServiceCollection().AddScoped(_ => new ApplicationDbContext(options));
 		var serviceScopeFactory =
-			serviceCollection.BuildServiceProvider().GetService<IServiceScopeFactory>();
+			serviceCollection.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
 		var storage = new FakeIStorage(
 			["/", "/test"],
@@ -339,7 +339,7 @@ public class MoveToTrashServiceTest
 			trashService, new FakeIMetaUpdateService(),
 			new FakeITrashConnectionService());
 
-		// used for end2end test to enable / disable the trash
+		// used for end-to-end test to enable / disable the trash
 		var result = moveToTrashService.DetectToUseSystemTrash();
 
 		Assert.IsFalse(result);
@@ -372,8 +372,7 @@ public class MoveToTrashServiceTest
 		const string path = "/trash/payload.jpg";
 		var appSettings = new AppSettings
 		{
-			UseSystemTrash = true,
-			DatabaseType = AppSettings.DatabaseTypeList.InMemoryDatabase
+			UseSystemTrash = true, DatabaseType = AppSettings.DatabaseTypeList.InMemoryDatabase
 		};
 
 		var builderDb = new DbContextOptionsBuilder<ApplicationDbContext>();
@@ -384,7 +383,7 @@ public class MoveToTrashServiceTest
 		var serviceCollection =
 			new ServiceCollection().AddScoped(_ => new ApplicationDbContext(options));
 		var serviceScopeFactory =
-			serviceCollection.BuildServiceProvider().GetService<IServiceScopeFactory>();
+			serviceCollection.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
 		var query = new Query(dbContext, appSettings, serviceScopeFactory,
 			new FakeIWebLogger());
@@ -421,7 +420,9 @@ public class MoveToTrashServiceTest
 		if ( isSystem )
 		{
 			// prepare a fake DB row so SystemTrashInQueue will remove it
-			var fakeQuery = new FakeIQuery([new FileIndexItem(path) { Status = FileIndexItem.ExifStatus.Ok }]);
+			var fakeQuery = new FakeIQuery([
+				new FileIndexItem(path) { Status = FileIndexItem.ExifStatus.Ok }
+			]);
 			var trashService = new FakeITrashService();
 			var sut = new MoveToTrashService(appSettings, fakeQuery,
 				new FakeMetaPreflight(), new FakeIUpdateBackgroundTaskQueue(),
@@ -429,10 +430,12 @@ public class MoveToTrashServiceTest
 
 			var payload = new MoveToTrashPayload
 			{
-				MoveToTrashList = [new FileIndexItem(path) { Status = FileIndexItem.ExifStatus.Ok }],
+				MoveToTrashList =
+					[new FileIndexItem(path) { Status = FileIndexItem.ExifStatus.Ok }],
 				IsSystemTrashEnabled = true,
 				ChangedFileIndexItemName = new Dictionary<string, List<string>>(),
-				FileIndexResultsList = [new FileIndexItem(path) { Status = FileIndexItem.ExifStatus.Ok }],
+				FileIndexResultsList =
+					[new FileIndexItem(path) { Status = FileIndexItem.ExifStatus.Ok }],
 				InputModel = new FileIndexItem(),
 				Collections = false
 			};
@@ -441,7 +444,8 @@ public class MoveToTrashServiceTest
 
 			// system trash should have been called and DB row removed
 			Assert.HasCount(1, trashService.InTrash);
-			var expected = appSettings.StorageFolder + path.Replace('/', Path.DirectorySeparatorChar);
+			var expected = appSettings.StorageFolder +
+			               path.Replace('/', Path.DirectorySeparatorChar);
 			Assert.AreEqual(expected, trashService.InTrash.FirstOrDefault());
 
 			var removed = await fakeQuery.GetObjectByFilePathAsync(path);
@@ -449,7 +453,9 @@ public class MoveToTrashServiceTest
 		}
 		else
 		{
-			var fakeQuery = new FakeIQuery([new FileIndexItem(path) { Status = FileIndexItem.ExifStatus.Ok }]);
+			var fakeQuery = new FakeIQuery([
+				new FileIndexItem(path) { Status = FileIndexItem.ExifStatus.Ok }
+			]);
 			var fakeMetaUpdate = new FakeIMetaUpdateService();
 			var trashService = new FakeITrashService();
 			var sut = new MoveToTrashService(appSettings, fakeQuery,
@@ -458,10 +464,12 @@ public class MoveToTrashServiceTest
 
 			var payload = new MoveToTrashPayload
 			{
-				MoveToTrashList = [new FileIndexItem(path) { Status = FileIndexItem.ExifStatus.Ok }],
+				MoveToTrashList =
+					[new FileIndexItem(path) { Status = FileIndexItem.ExifStatus.Ok }],
 				IsSystemTrashEnabled = false,
 				ChangedFileIndexItemName = new Dictionary<string, List<string>>(),
-				FileIndexResultsList = [new FileIndexItem(path) { Status = FileIndexItem.ExifStatus.Ok }],
+				FileIndexResultsList =
+					[new FileIndexItem(path) { Status = FileIndexItem.ExifStatus.Ok }],
 				InputModel = new FileIndexItem(),
 				Collections = false
 			};

--- a/starsky/starskytest/starsky.foundation.database/QueryTest/QueryFactoryTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/QueryTest/QueryFactoryTest.cs
@@ -4,51 +4,48 @@ using starsky.foundation.database.Models;
 using starsky.foundation.database.Query;
 using starskytest.FakeMocks;
 
-namespace starskytest.starsky.foundation.database.QueryTest
+namespace starskytest.starsky.foundation.database.QueryTest;
+
+[TestClass]
+public sealed class QueryFactoryTest
 {
-	[TestClass]
-	public sealed class QueryFactoryTest
+	[TestMethod]
+	public void QueryFactoryTest_Null()
 	{
-		[TestMethod]
-		public void QueryFactoryTest_Null()
-		{
-			var query = new QueryFactory(null,
-				null,null,null,null, null).Query();
-			Assert.IsNull(query);
-		}
-		
-		[TestMethod]
-		public void QueryFactoryTest_QueryReturn()
-		{
-			var query = new QueryFactory(null,new Query(null!,null!, 
-				null, new FakeIWebLogger()),null,
-				null,null, null).Query();
-			Assert.AreEqual(typeof(Query),query?.GetType());
-		}
-		
-		[TestMethod]
-		public void QueryFactoryTest_FakeIQueryReturn()
-		{
-			var fakeIQuery = new FakeIQuery(new List<FileIndexItem>{new FileIndexItem("/test.jpg")});
-			var query = new QueryFactory(null,fakeIQuery,null,
-				null,null, null).Query();
-			
-			var resultFakeIQuery = query as FakeIQuery;
-			Assert.AreEqual(1, resultFakeIQuery?.GetAllRecursive().Count);
-			Assert.AreEqual("/test.jpg", resultFakeIQuery?.GetAllRecursive()[0].FilePath);
-		}
-		
-		[TestMethod]
-		public void QueryFactoryTest_FakeIQuery_IgnoreNoItemsInList()
-		{
-			var fakeIQuery = new FakeIQuery(new List<FileIndexItem>());
-			var query = new QueryFactory(null,fakeIQuery,null,
-				null,null, null).Query();
-			
-			var resultFakeIQuery = query as FakeIQuery;
-			Assert.AreEqual(0, resultFakeIQuery?.GetAllRecursive().Count);
-		}
+		var query = new QueryFactory(null,
+			null, null, null, null, null).Query();
+		Assert.IsNull(query);
 	}
 
-}
+	[TestMethod]
+	public void QueryFactoryTest_QueryReturn()
+	{
+		var query = new QueryFactory(null, new Query(null!, null!,
+				null!, new FakeIWebLogger()), null,
+			null, null, null).Query();
+		Assert.AreEqual(typeof(Query), query?.GetType());
+	}
 
+	[TestMethod]
+	public void QueryFactoryTest_FakeIQueryReturn()
+	{
+		var fakeIQuery = new FakeIQuery(new List<FileIndexItem> { new("/test.jpg") });
+		var query = new QueryFactory(null, fakeIQuery, null,
+			null, null, null).Query();
+
+		var resultFakeIQuery = query as FakeIQuery;
+		Assert.AreEqual(1, resultFakeIQuery?.GetAllRecursive().Count);
+		Assert.AreEqual("/test.jpg", resultFakeIQuery?.GetAllRecursive()[0].FilePath);
+	}
+
+	[TestMethod]
+	public void QueryFactoryTest_FakeIQuery_IgnoreNoItemsInList()
+	{
+		var fakeIQuery = new FakeIQuery(new List<FileIndexItem>());
+		var query = new QueryFactory(null, fakeIQuery, null,
+			null, null, null).Query();
+
+		var resultFakeIQuery = query as FakeIQuery;
+		Assert.AreEqual(0, resultFakeIQuery?.GetAllRecursive().Count);
+	}
+}

--- a/starsky/starskytest/starsky.foundation.database/QueryTest/QueryGetAllFilesTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/QueryTest/QueryGetAllFilesTest.cs
@@ -156,7 +156,8 @@ public sealed class QueryGetAllFilesTest
 			DatabaseType = AppSettings.DatabaseTypeList.InMemoryDatabase
 		};
 		var dbContext = new SetupDatabaseTypes(appSettings).BuilderDbFactory();
-		var query = new Query(dbContext, new AppSettings(), null, new FakeIWebLogger(),
+		var query = new Query(dbContext, new AppSettings(),
+			null!, new FakeIWebLogger(),
 			new FakeMemoryCache());
 
 		await dbContext.FileIndex.AddAsync(

--- a/starsky/starskytest/starsky.foundation.database/QueryTest/QueryTestNoCacheTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/QueryTest/QueryTestNoCacheTest.cs
@@ -26,7 +26,8 @@ public sealed class QueryTestNoCacheTest
 		var options = builder.Options;
 		var context = new ApplicationDbContext(options);
 		var logger = new FakeIWebLogger();
-		_query = new Query(context, new AppSettings(), null, logger);
+		_query = new Query(context, new AppSettings(),
+			null!, logger);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/starsky.foundation.database/QueryTest/Query_AddParentItemsAsyncTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/QueryTest/Query_AddParentItemsAsyncTest.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -10,137 +9,146 @@ using starsky.foundation.database.Query;
 using starsky.foundation.platform.Models;
 using starskytest.FakeMocks;
 
-namespace starskytest.starsky.foundation.database.QueryTest
+namespace starskytest.starsky.foundation.database.QueryTest;
+
+[TestClass]
+public sealed class QueryAddParentItemsAsyncTest
 {
-	[TestClass]
-	public sealed class QueryAddParentItemsAsyncTest
+	private readonly ApplicationDbContext? _dbContext;
+	private readonly Query? _query;
+
+	public QueryAddParentItemsAsyncTest()
 	{
-		private readonly Query? _query;
-		private readonly ApplicationDbContext? _dbContext;
+		var provider = new ServiceCollection()
+			.AddMemoryCache()
+			.BuildServiceProvider();
+		var memoryCache = provider.GetRequiredService<IMemoryCache>();
+		var serviceScope = CreateNewScope();
+		var scope = serviceScope.CreateScope();
+		_dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-		private IServiceScopeFactory CreateNewScope()
-		{
-			var services = new ServiceCollection();
-			services.AddDbContext<ApplicationDbContext>(options => 
-				options.UseInMemoryDatabase(nameof(QueryAddParentItemsAsyncTest)));
-			var serviceProvider = services.BuildServiceProvider();
-			return serviceProvider.GetRequiredService<IServiceScopeFactory>();
-		}
-		
-		public QueryAddParentItemsAsyncTest()
-		{
-			var provider = new ServiceCollection()
-				.AddMemoryCache()
-				.BuildServiceProvider();
-			var memoryCache = provider.GetRequiredService<IMemoryCache>();
-			var serviceScope = CreateNewScope();
-			var scope = serviceScope.CreateScope();
-			_dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+		_query = new Query(_dbContext, new AppSettings(), serviceScope, new FakeIWebLogger(),
+			memoryCache);
+	}
 
-			_query = new Query(_dbContext, new AppSettings(), serviceScope, new FakeIWebLogger(),memoryCache);
-		}
+	public TestContext TestContext { get; set; }
 
-		[TestMethod]
-		public async Task CheckIfHomeItemIsCreated()
+	private static IServiceScopeFactory CreateNewScope()
+	{
+		var services = new ServiceCollection();
+		services.AddDbContext<ApplicationDbContext>(options =>
+			options.UseInMemoryDatabase(nameof(QueryAddParentItemsAsyncTest)));
+		var serviceProvider = services.BuildServiceProvider();
+		return serviceProvider.GetRequiredService<IServiceScopeFactory>();
+	}
+
+	[TestMethod]
+	public async Task CheckIfHomeItemIsCreated()
+	{
+		if ( _query == null || _dbContext == null )
 		{
-			if ( _query == null || _dbContext == null )
-			{
-				throw new WebException(
-					"_query & _dbContext should not be null");
-			}
-			
-			await _query.AddParentItemsAsync("/");
-			var result = await _dbContext.FileIndex.FirstOrDefaultAsync(p => p.FilePath == "/", TestContext.CancellationTokenSource.Token);
-			Assert.AreEqual("/", result?.FilePath);
-			Assert.IsNotNull(result);
-			
-			_dbContext.FileIndex.Remove(result);
-			await _dbContext.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
-		}
-		
-		[TestMethod]
-		public async Task Check_If_Slash_Is_Created()
-		{
-			if ( _query == null || _dbContext == null )
-			{
-				throw new WebException(
-					"_query & _dbContext should not be null");
-			}
-			
-			await _query.AddParentItemsAsync("/test");
-			var result = await _dbContext.FileIndex.FirstOrDefaultAsync(p => p.FilePath == "/", TestContext.CancellationTokenSource.Token);
-			Assert.AreEqual("/", result?.FilePath);
-			Assert.IsNotNull(result);
-			
-			_dbContext.FileIndex.Remove(result);
-			await _dbContext.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
-		}
-		
-		[TestMethod]
-		public async Task Check_If_Parent_Is_Created()
-		{
-			if ( _query == null || _dbContext == null )
-			{
-				throw new WebException(
-					"_query & _dbContext should not be null");
-			}
-			
-			await _query.AddParentItemsAsync("/test/file");
-			var result = await _dbContext.FileIndex.FirstOrDefaultAsync(p => p.FilePath == "/test", TestContext.CancellationTokenSource.Token);
-			Assert.AreEqual("/test", result?.FilePath);
-			Assert.IsNotNull(result);
-			
-			_dbContext.FileIndex.Remove(result);
-			await _dbContext.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
+			throw new WebException(
+				"_query & _dbContext should not be null");
 		}
 
-		[TestMethod]
-		public async Task MissingFolderIsAdded()
+		await _query.AddParentItemsAsync("/");
+		var result = await _dbContext.FileIndex.FirstOrDefaultAsync(p => p.FilePath == "/",
+			TestContext.CancellationTokenSource.Token);
+		Assert.AreEqual("/", result?.FilePath);
+		Assert.IsNotNull(result);
+
+		_dbContext.FileIndex.Remove(result);
+		await _dbContext.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
+	}
+
+	[TestMethod]
+	public async Task Check_If_Slash_Is_Created()
+	{
+		if ( _query == null || _dbContext == null )
 		{
-			if ( _query == null || _dbContext == null )
-			{
-				throw new WebException(
-					"_query & _dbContext should not be null");
-			}
-			
-			await _query.AddParentItemsAsync("/test/test/test");
-			
-			var folderInMiddle = await _dbContext.FileIndex.FirstOrDefaultAsync(p => p.FilePath == "/test/test", TestContext.CancellationTokenSource.Token);
-			
-			Assert.IsNotNull(folderInMiddle);
-			
-			_dbContext.FileIndex.Remove(folderInMiddle);
-			await _dbContext.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
-
-			await _query.AddParentItemsAsync("/test/test/test");
-			var result = await _dbContext.FileIndex.ToListAsync(TestContext.CancellationTokenSource.Token);
-
-			Assert.AreEqual("/", result.Find(p => p.FilePath == "/")?.FilePath);
-			Assert.AreEqual("/test", result.Find(p => p.FilePath == "/test")?.FilePath);
-			Assert.AreEqual("/test/test", result.Find(p => p.FilePath == "/test/test")?.FilePath);
+			throw new WebException(
+				"_query & _dbContext should not be null");
 		}
 
-		[TestMethod]
-		public async Task AddParentItemsAsync_Home()
+		await _query.AddParentItemsAsync("/test");
+		var result = await _dbContext.FileIndex.FirstOrDefaultAsync(p => p.FilePath == "/",
+			TestContext.CancellationTokenSource.Token);
+		Assert.AreEqual("/", result?.FilePath);
+		Assert.IsNotNull(result);
+
+		_dbContext.FileIndex.Remove(result);
+		await _dbContext.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
+	}
+
+	[TestMethod]
+	public async Task Check_If_Parent_Is_Created()
+	{
+		if ( _query == null || _dbContext == null )
 		{
-			var dbContext = CreateNewScope().CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
-			var query = new Query(dbContext,null!,null,null!);
-
-			await query.AddParentItemsAsync("/test/test/test");
-
-			var homeItem = dbContext.FileIndex.FirstOrDefault(p => p.FilePath == "/");
-			Assert.AreEqual(string.Empty, homeItem?.ParentDirectory);
-			Assert.AreEqual("/", homeItem?.FileName);
-
-			var test1 = dbContext.FileIndex.FirstOrDefault(p => p.FilePath == "/test");
-			Assert.AreEqual("/", test1?.ParentDirectory);
-			Assert.AreEqual("test", test1?.FileName);
-
-			var test2 = dbContext.FileIndex.FirstOrDefault(p => p.FilePath == "/test/test");
-			Assert.AreEqual("/test", test2?.ParentDirectory);
-			Assert.AreEqual("test", test2?.FileName);
+			throw new WebException(
+				"_query & _dbContext should not be null");
 		}
 
-		public TestContext TestContext { get; set; }
+		await _query.AddParentItemsAsync("/test/file");
+		var result = await _dbContext.FileIndex.FirstOrDefaultAsync(p => p.FilePath == "/test",
+			TestContext.CancellationTokenSource.Token);
+		Assert.AreEqual("/test", result?.FilePath);
+		Assert.IsNotNull(result);
+
+		_dbContext.FileIndex.Remove(result);
+		await _dbContext.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
+	}
+
+	[TestMethod]
+	public async Task MissingFolderIsAdded()
+	{
+		if ( _query == null || _dbContext == null )
+		{
+			throw new WebException(
+				"_query & _dbContext should not be null");
+		}
+
+		await _query.AddParentItemsAsync("/test/test/test");
+
+		var folderInMiddle = await _dbContext.FileIndex.FirstOrDefaultAsync(
+			p => p.FilePath == "/test/test", TestContext.CancellationTokenSource.Token);
+
+		Assert.IsNotNull(folderInMiddle);
+
+		_dbContext.FileIndex.Remove(folderInMiddle);
+		await _dbContext.SaveChangesAsync(TestContext.CancellationTokenSource.Token);
+
+		await _query.AddParentItemsAsync("/test/test/test");
+		var result =
+			await _dbContext.FileIndex.ToListAsync(TestContext.CancellationTokenSource.Token);
+
+		Assert.AreEqual("/", result.Find(p => p.FilePath == "/")?.FilePath);
+		Assert.AreEqual("/test", result.Find(p => p.FilePath == "/test")?.FilePath);
+		Assert.AreEqual("/test/test", result.Find(p => p.FilePath == "/test/test")?.FilePath);
+	}
+
+	[TestMethod]
+	public async Task AddParentItemsAsync_Home()
+	{
+		var dbContext = CreateNewScope().CreateScope().ServiceProvider
+			.GetRequiredService<ApplicationDbContext>();
+		var query = new Query(dbContext, null!, null!, null!);
+
+		await query.AddParentItemsAsync("/test/test/test");
+
+		var homeItem = await dbContext.FileIndex.FirstOrDefaultAsync(p => p.FilePath == "/",
+			TestContext.CancellationToken);
+		Assert.AreEqual(string.Empty, homeItem?.ParentDirectory);
+		Assert.AreEqual("/", homeItem?.FileName);
+
+		var test1 = await dbContext.FileIndex.FirstOrDefaultAsync(p => p.FilePath == "/test",
+			TestContext.CancellationToken);
+		Assert.AreEqual("/", test1?.ParentDirectory);
+		Assert.AreEqual("test", test1?.FileName);
+
+		var test2 = await dbContext.FileIndex.FirstOrDefaultAsync(p => p.FilePath == "/test/test",
+			TestContext.CancellationToken);
+		Assert.AreEqual("/test", test2?.ParentDirectory);
+		Assert.AreEqual("test", test2?.FileName);
 	}
 }

--- a/starsky/starskytest/starsky.foundation.thumbnailgeneration/Services/ThumbnailCleanerTest.cs
+++ b/starsky/starskytest/starsky.foundation.thumbnailgeneration/Services/ThumbnailCleanerTest.cs
@@ -37,7 +37,8 @@ public sealed class ThumbnailCleanerTest
 		builder.UseInMemoryDatabase(nameof(ThumbnailCleanerTest));
 		var options = builder.Options;
 		var context = new ApplicationDbContext(options);
-		_query = new Query(context, new AppSettings(), null, null!, memoryCache);
+		_query = new Query(context, new AppSettings(),
+			null!, null!, memoryCache);
 		_imageFormat = new AppSettings().ThumbnailImageFormat;
 	}
 


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request makes several improvements and refactorings to the test codebase, focusing on dependency injection consistency, code style, and minor bug fixes. The main changes ensure that all test classes consistently use `GetRequiredService<IServiceScopeFactory>()` instead of `GetService<IServiceScopeFactory>()`, update the way dependencies are passed to the `Query` class, and modernize C# syntax and project structure for better maintainability.

Dependency injection and test setup improvements:
* Replaced `GetService<IServiceScopeFactory>()` with `GetRequiredService<IServiceScopeFactory>()` in all relevant test files to ensure required services are always available and avoid potential null reference issues. [[1]](diffhunk://#diff-66946a1335f8e56552d3483394b9464535f8dd51f70f1ded43586e7fb300361bL45-R45) [[2]](diffhunk://#diff-ad0310492f5915a9630f68d718f0e856b6c88f81477221cdfc55b050bf0c7489L51-R51) [[3]](diffhunk://#diff-dbaf1a982bda344a691acdd436ac5d1dd68c6c773d27babab443d0dc670daaf7L230-R230) [[4]](diffhunk://#diff-dbaf1a982bda344a691acdd436ac5d1dd68c6c773d27babab443d0dc670daaf7L287-R287) [[5]](diffhunk://#diff-dbaf1a982bda344a691acdd436ac5d1dd68c6c773d27babab443d0dc670daaf7L387-R386)
* Updated the instantiation of the `Query` class in tests to consistently provide a `FakeIServiceScopeFactory` or `null!` as the `IServiceScopeFactory` parameter, improving test reliability and clarity. [[1]](diffhunk://#diff-bf537a9e39b0298fc6f991d9463abe73b621bbe9d99df22fd3570b2b3db10e9bL52-R52) [[2]](diffhunk://#diff-f3d47e7897bd38e4fa2d1d1be224deb5ce84984987a0948cf889157c5bb3d3a5L49-R49) [[3]](diffhunk://#diff-0d9bc5ed944b661b47a9b03d7cf69bbebe4052b6345e9a02a04d637eccc47b31L51-R51) [[4]](diffhunk://#diff-5de8ac4cb60d6ec6aedcf5e5d408743745dbcde55773ca189495a4921a0aa3caL53-R53) [[5]](diffhunk://#diff-5de8ac4cb60d6ec6aedcf5e5d408743745dbcde55773ca189495a4921a0aa3caL1128-R1129) [[6]](diffhunk://#diff-0353b9f82406675b7656b878d8668c61891bdb8acfbe8b240171cab54eae5fd1L159-R160) [[7]](diffhunk://#diff-5c1c1105dbdbb83257242f5fa0e844034779ee148fc2686b6b75a2a33e55ed82L29-R30)

Code style and modernization:
* Refactored namespace declarations to use file-scoped namespaces and removed unnecessary braces for a cleaner, more modern C# style. [[1]](diffhunk://#diff-47031d63e73b7e42a40451dbab3e493b644d1662a6591c56be9ef3ed1922b208L7-R8) [[2]](diffhunk://#diff-af4f8c5a2e3973fb468451fc4e144827f01dec71504d96413278962576709c9eL13-R18)
* Improved collection initializations and formatting for better readability and to leverage C# 9/10 features (e.g., target-typed `new()`, collection initializers). [[1]](diffhunk://#diff-47031d63e73b7e42a40451dbab3e493b644d1662a6591c56be9ef3ed1922b208L24-R32) [[2]](diffhunk://#diff-dbaf1a982bda344a691acdd436ac5d1dd68c6c773d27babab443d0dc670daaf7L424-R438) [[3]](diffhunk://#diff-dbaf1a982bda344a691acdd436ac5d1dd68c6c773d27babab443d0dc670daaf7L444-R458) [[4]](diffhunk://#diff-dbaf1a982bda344a691acdd436ac5d1dd68c6c773d27babab443d0dc670daaf7L461-R472)

Test logic and minor bug fixes:
* Fixed variable naming inconsistencies (e.g., `item1dng` to `item1Dng`) and ensured code correctness in test assertions and test setup.
* Added or reordered using directives for clarity and to resolve compilation issues. [[1]](diffhunk://#diff-ad0310492f5915a9630f68d718f0e856b6c88f81477221cdfc55b050bf0c7489L17-R20) [[2]](diffhunk://#diff-dbaf1a982bda344a691acdd436ac5d1dd68c6c773d27babab443d0dc670daaf7R5) [[3]](diffhunk://#diff-dbaf1a982bda344a691acdd436ac5d1dd68c6c773d27babab443d0dc670daaf7L25) [[4]](diffhunk://#diff-af4f8c5a2e3973fb468451fc4e144827f01dec71504d96413278962576709c9eL1)
* Improved comments for clarity and corrected typos.

Test utility and structure enhancements:
* Added or refactored helper methods for creating service scopes in test initialization, improving code reuse and maintainability.
* Ensured all test contexts are properly set up and used, such as introducing `TestContext` where necessary. [[1]](diffhunk://#diff-af4f8c5a2e3973fb468451fc4e144827f01dec71504d96413278962576709c9eL40-R42) [[2]](diffhunk://#diff-af4f8c5a2e3973fb468451fc4e144827f01dec71504d96413278962576709c9eL53-R56)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
