### PR TITLE
Feature/202604 fileindex

### DIFF
--- a/history.md
+++ b/history.md
@@ -43,6 +43,8 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## version 0.7.16 - _(Unreleased)_ - 2026-?-? {#v0.7.16}
 
+- [x] (Fixed) _Back-end_ JSON converter FileIndexItem that ensures the `Id` property is always
+  included during serialization and deserialization (PR #2997)
 - [x] (Fixed) _Back-end_ InjectServiceScope utility provides Execute and ExecuteAsync (PR #2921)
 - [x] (Added) _Back-end_ Export/Download Zipper export directory structure (PR #2833 Issue #81)
 

--- a/starsky/starsky.feature.trash/Interfaces/IMoveToTrashService.cs
+++ b/starsky/starsky.feature.trash/Interfaces/IMoveToTrashService.cs
@@ -1,4 +1,4 @@
-using starsky.feature.trash.Services;
+using starsky.feature.trash.Models;
 using starsky.foundation.database.Models;
 
 namespace starsky.feature.trash.Interfaces;
@@ -6,8 +6,8 @@ namespace starsky.feature.trash.Interfaces;
 public interface IMoveToTrashService
 {
 	/// <summary>
-	/// Move a file to the internal trash or system trash
-	/// Depends on the feature toggle
+	///     Move a file to the internal trash or system trash
+	///     Depends on the feature toggle
 	/// </summary>
 	/// <param name="inputFilePaths">list of paths</param>
 	/// <param name="collections">is stack collections enabled</param>
@@ -16,21 +16,21 @@ public interface IMoveToTrashService
 		bool collections);
 
 	/// <summary>
-	/// Is supported and enabled in the feature toggle
+	///     Is supported and enabled in the feature toggle
 	/// </summary>
 	/// <returns>Should you use it?</returns>
 	bool IsEnabled();
 
 	/// <summary>
-	/// Is it supported to use the system Trash
-	/// It does NOT check if the feature toggle is enabled
-	/// Used by End2End test to enable system trash if supported on the platform
+	///     Is it supported to use the system Trash
+	///     It does NOT check if the feature toggle is enabled
+	///     Used by End2End test to enable system trash if supported on the platform
 	/// </summary>
 	/// <returns>true if supported</returns>
 	public bool DetectToUseSystemTrash();
 
 	/// <summary>
-	/// Moves the specified list of files to the trash asynchronously.
+	///     Moves the specified list of files to the trash asynchronously.
 	/// </summary>
 	/// <param name="payload">Payload</param>
 	/// <returns>A task representing the asynchronous operation.</returns>

--- a/starsky/starsky.feature.trash/Models/MoveToTrashPayload.cs
+++ b/starsky/starsky.feature.trash/Models/MoveToTrashPayload.cs
@@ -2,16 +2,21 @@ using System.Text.Json.Serialization;
 using starsky.foundation.database.JsonConverters;
 using starsky.foundation.database.Models;
 
-namespace starsky.foundation.metaupdate.Models;
+namespace starsky.feature.trash.Models;
 
-public sealed class MetaUpdateBackgroundPayload
+public sealed class MoveToTrashPayload
 {
+	[JsonConverter(typeof(FileIndexItemWithIdJsonConverter))]
+	public List<FileIndexItem> MoveToTrashList { get; set; } = [];
+
+	public bool IsSystemTrashEnabled { get; set; }
 	public Dictionary<string, List<string>> ChangedFileIndexItemName { get; set; } = new();
 
 	[JsonConverter(typeof(FileIndexItemWithIdJsonConverter))]
 	public List<FileIndexItem> FileIndexResultsList { get; set; } = [];
 
+	[JsonConverter(typeof(FileIndexItemWithIdJsonConverter))]
+	public FileIndexItem InputModel { get; set; } = new();
+
 	public bool Collections { get; set; }
-	public bool Append { get; set; }
-	public int RotateClock { get; set; }
 }

--- a/starsky/starsky.feature.trash/Models/MoveToTrashPayload.cs
+++ b/starsky/starsky.feature.trash/Models/MoveToTrashPayload.cs
@@ -6,16 +6,16 @@ namespace starsky.feature.trash.Models;
 
 public sealed class MoveToTrashPayload
 {
-	[JsonConverter(typeof(FileIndexItemWithIdJsonConverter))]
-	public List<FileIndexItem> MoveToTrashList { get; set; } = [];
+	[JsonConverter(typeof(FileIndexItemWithIdJsonConverterFactory))]
+	public List<FileIndexItem> MoveToTrashList { get; set; } = new();
 
 	public bool IsSystemTrashEnabled { get; set; }
 	public Dictionary<string, List<string>> ChangedFileIndexItemName { get; set; } = new();
 
-	[JsonConverter(typeof(FileIndexItemWithIdJsonConverter))]
-	public List<FileIndexItem> FileIndexResultsList { get; set; } = [];
+	[JsonConverter(typeof(FileIndexItemWithIdJsonConverterFactory))]
+	public List<FileIndexItem> FileIndexResultsList { get; set; } = new();
 
-	[JsonConverter(typeof(FileIndexItemWithIdJsonConverter))]
+	[JsonConverter(typeof(FileIndexItemWithIdJsonConverterFactory))]
 	public FileIndexItem InputModel { get; set; } = new();
 
 	public bool Collections { get; set; }

--- a/starsky/starsky.feature.trash/Models/MoveToTrashPayload.cs
+++ b/starsky/starsky.feature.trash/Models/MoveToTrashPayload.cs
@@ -7,13 +7,13 @@ namespace starsky.feature.trash.Models;
 public sealed class MoveToTrashPayload
 {
 	[JsonConverter(typeof(FileIndexItemWithIdJsonConverterFactory))]
-	public List<FileIndexItem> MoveToTrashList { get; set; } = new();
+	public List<FileIndexItem> MoveToTrashList { get; set; } = [];
 
 	public bool IsSystemTrashEnabled { get; set; }
 	public Dictionary<string, List<string>> ChangedFileIndexItemName { get; set; } = new();
 
 	[JsonConverter(typeof(FileIndexItemWithIdJsonConverterFactory))]
-	public List<FileIndexItem> FileIndexResultsList { get; set; } = new();
+	public List<FileIndexItem> FileIndexResultsList { get; set; } = [];
 
 	[JsonConverter(typeof(FileIndexItemWithIdJsonConverterFactory))]
 	public FileIndexItem InputModel { get; set; } = new();

--- a/starsky/starsky.feature.trash/Services/MoveToTrashJobHandler.cs
+++ b/starsky/starsky.feature.trash/Services/MoveToTrashJobHandler.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using starsky.feature.trash.Interfaces;
+using starsky.feature.trash.Models;
 using starsky.foundation.injection;
 using starsky.foundation.worker.Interfaces;
 

--- a/starsky/starsky.feature.trash/Services/MoveToTrashService.cs
+++ b/starsky/starsky.feature.trash/Services/MoveToTrashService.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using starsky.feature.trash.Interfaces;
+using starsky.feature.trash.Models;
 using starsky.foundation.database.Interfaces;
 using starsky.foundation.database.Models;
 using starsky.foundation.injection;
@@ -197,14 +198,4 @@ public class MoveToTrashService : IMoveToTrashService
 
 		await _query.RemoveItemAsync(persistedItems);
 	}
-}
-
-public sealed class MoveToTrashPayload
-{
-	public List<FileIndexItem> MoveToTrashList { get; set; } = [];
-	public bool IsSystemTrashEnabled { get; set; }
-	public Dictionary<string, List<string>> ChangedFileIndexItemName { get; set; } = new();
-	public List<FileIndexItem> FileIndexResultsList { get; set; } = [];
-	public FileIndexItem InputModel { get; set; } = new();
-	public bool Collections { get; set; }
 }

--- a/starsky/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializer.cs
+++ b/starsky/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializer.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace starsky.foundation.database.JsonConverters;
 
-public class DefaultJsonFileIndexJsonSerializer
+public static class DefaultJsonFileIndexJsonSerializer
 {
 	/// <summary>
 	///     PascalCase (No Naming policy)

--- a/starsky/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializer.cs
+++ b/starsky/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializer.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace starsky.foundation.database.JsonConverters;
+
+public class DefaultJsonFileIndexJsonSerializer
+{
+	/// <summary>
+	///     PascalCase (No Naming policy)
+	///     Bool is written as quoted string "true" or "false"
+	/// </summary>
+	public static JsonSerializerOptions WithIdConverter =>
+		new()
+		{
+			PropertyNamingPolicy = null,
+			DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+			PropertyNameCaseInsensitive = true,
+			AllowTrailingCommas = true,
+			WriteIndented = false,
+			Converters = { new FileIndexItemWithIdJsonConverter() }
+		};
+}

--- a/starsky/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializer.cs
+++ b/starsky/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializer.cs
@@ -17,6 +17,6 @@ public class DefaultJsonFileIndexJsonSerializer
 			PropertyNameCaseInsensitive = true,
 			AllowTrailingCommas = true,
 			WriteIndented = false,
-			Converters = { new FileIndexItemWithIdJsonConverter() }
+			Converters = { new FileIndexItemWithIdJsonConverterFactory() }
 		};
 }

--- a/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverter.cs
+++ b/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverter.cs
@@ -14,20 +14,32 @@ public sealed class FileIndexItemWithIdJsonConverter : JsonConverter<FileIndexIt
 	public override FileIndexItem Read(ref Utf8JsonReader reader, Type typeToConvert,
 		JsonSerializerOptions options)
 	{
-		// Create a copy of options but ensure the Id is not ignored and avoid recursion
-		var readOptions = new JsonSerializerOptions(options)
+		// Build read options based on provided options but ensure Id is not ignored
+		var readOptions = new JsonSerializerOptions
 		{
-			DefaultIgnoreCondition = JsonIgnoreCondition.Never
+			PropertyNamingPolicy = options.PropertyNamingPolicy,
+			DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+			PropertyNameCaseInsensitive = options.PropertyNameCaseInsensitive,
+			AllowTrailingCommas = options.AllowTrailingCommas,
+			WriteIndented = options.WriteIndented
 		};
 
-		// Remove this converter from the copy to avoid recursion
-		for ( var i = readOptions.Converters.Count - 1; i >= 0; i-- )
+		// Copy converters except this one to avoid recursion
+			foreach ( var conv in options.Converters )
 		{
-			var conv = readOptions.Converters[i];
-			if ( conv?.GetType() == typeof(FileIndexItemWithIdJsonConverter) )
+			if ( conv == null )
 			{
-				readOptions.Converters.RemoveAt(i);
+				continue;
 			}
+
+				// Skip this converter and the factory to avoid recursion when building safe options
+				if ( conv.GetType() == typeof(FileIndexItemWithIdJsonConverter) ||
+					 conv.GetType() == typeof(FileIndexItemWithIdJsonConverterFactory) )
+			{
+				continue;
+			}
+
+			readOptions.Converters.Add(conv);
 		}
 
 		using var jsonDoc = JsonDocument.ParseValue(ref reader);
@@ -39,22 +51,31 @@ public sealed class FileIndexItemWithIdJsonConverter : JsonConverter<FileIndexIt
 	public override void Write(Utf8JsonWriter writer, FileIndexItem value,
 		JsonSerializerOptions options)
 	{
-		// Create safe options that do NOT contain this converter to avoid recursion
-		var safeOptions = new JsonSerializerOptions(options);
-
-		for ( var i = options.Converters.Count - 1; i >= 0; i-- )
+		// Build safe options that copy key settings but exclude this converter to avoid recursion
+		var safeOptions = new JsonSerializerOptions
 		{
-			var conv = options.Converters[i];
-			if ( conv?.GetType() == typeof(FileIndexItemWithIdJsonConverter) )
+			PropertyNamingPolicy = options.PropertyNamingPolicy,
+			DefaultIgnoreCondition = options.DefaultIgnoreCondition,
+			PropertyNameCaseInsensitive = options.PropertyNameCaseInsensitive,
+			AllowTrailingCommas = options.AllowTrailingCommas,
+			WriteIndented = options.WriteIndented
+		};
+
+		foreach ( var conv in options.Converters )
+		{
+			if ( conv == null )
 			{
-				// skip adding this converter
 				continue;
 			}
-			// Only add converters that aren't already present on the safe copy
-			if ( !safeOptions.Converters.Contains(conv) )
+
+			// Skip this converter and the factory to avoid recursion when building safe options
+			if ( conv.GetType() == typeof(FileIndexItemWithIdJsonConverter) ||
+				 conv.GetType() == typeof(FileIndexItemWithIdJsonConverterFactory) )
 			{
-				safeOptions.Converters.Add(conv);
+				continue;
 			}
+
+			safeOptions.Converters.Add(conv);
 		}
 
 		// Serialize to JSON element first using the safe options
@@ -67,9 +88,10 @@ public sealed class FileIndexItemWithIdJsonConverter : JsonConverter<FileIndexIt
 		// First, write the Id field explicitly
 		writer.WriteNumber("id", value.Id);
 
-		// Then write all other properties from the serialized JSON
+		// Then write all other properties from the serialized JSON (write name and value)
 		foreach ( var property in element.EnumerateObject() )
 		{
+			writer.WritePropertyName(property.Name);
 			property.Value.WriteTo(writer);
 		}
 

--- a/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverter.cs
+++ b/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverter.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using starsky.foundation.database.Models;
+
+namespace starsky.foundation.database.JsonConverters;
+
+/// <summary>
+///     Custom JSON converter for FileIndexItem that includes the Id field.
+///     Uses reflection to serialize all properties dynamically, overriding the [JsonIgnore] on Id.
+/// </summary>
+public sealed class FileIndexItemWithIdJsonConverter : JsonConverter<FileIndexItem>
+{
+	public override FileIndexItem Read(ref Utf8JsonReader reader, Type typeToConvert,
+		JsonSerializerOptions options)
+	{
+		// Create a copy of options but ensure the Id is not ignored and avoid recursion
+		var readOptions = new JsonSerializerOptions(options)
+		{
+			DefaultIgnoreCondition = JsonIgnoreCondition.Never
+		};
+
+		// Remove this converter from the copy to avoid recursion
+		for ( var i = readOptions.Converters.Count - 1; i >= 0; i-- )
+		{
+			var conv = readOptions.Converters[i];
+			if ( conv?.GetType() == typeof(FileIndexItemWithIdJsonConverter) )
+			{
+				readOptions.Converters.RemoveAt(i);
+			}
+		}
+
+		using var jsonDoc = JsonDocument.ParseValue(ref reader);
+		var element = jsonDoc.RootElement;
+		var json = element.GetRawText();
+		return JsonSerializer.Deserialize<FileIndexItem>(json, readOptions) ?? new FileIndexItem();
+	}
+
+	public override void Write(Utf8JsonWriter writer, FileIndexItem value,
+		JsonSerializerOptions options)
+	{
+		// Create safe options that do NOT contain this converter to avoid recursion
+		var safeOptions = new JsonSerializerOptions(options);
+
+		for ( var i = options.Converters.Count - 1; i >= 0; i-- )
+		{
+			var conv = options.Converters[i];
+			if ( conv?.GetType() == typeof(FileIndexItemWithIdJsonConverter) )
+			{
+				// skip adding this converter
+				continue;
+			}
+			// Only add converters that aren't already present on the safe copy
+			if ( !safeOptions.Converters.Contains(conv) )
+			{
+				safeOptions.Converters.Add(conv);
+			}
+		}
+
+		// Serialize to JSON element first using the safe options
+		var jsonString = JsonSerializer.Serialize(value, safeOptions);
+		using var jsonDoc = JsonDocument.Parse(jsonString);
+		var element = jsonDoc.RootElement;
+
+		writer.WriteStartObject();
+
+		// First, write the Id field explicitly
+		writer.WriteNumber("id", value.Id);
+
+		// Then write all other properties from the serialized JSON
+		foreach ( var property in element.EnumerateObject() )
+		{
+			property.Value.WriteTo(writer);
+		}
+
+		writer.WriteEndObject();
+	}
+}

--- a/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverter.cs
+++ b/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverter.cs
@@ -6,7 +6,7 @@ using starsky.foundation.database.Models;
 namespace starsky.foundation.database.JsonConverters;
 
 /// <summary>
-///     Custom JSON converter for FileIndexItem that includes the Id field.
+///     Custom JSON converter for FileIndexItem that includes the `Id` field.
 ///     Uses reflection to serialize all properties dynamically, overriding the [JsonIgnore] on Id.
 /// </summary>
 public sealed class FileIndexItemWithIdJsonConverter : JsonConverter<FileIndexItem>

--- a/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverter.cs
+++ b/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverter.cs
@@ -25,16 +25,11 @@ public sealed class FileIndexItemWithIdJsonConverter : JsonConverter<FileIndexIt
 		};
 
 		// Copy converters except this one to avoid recursion
-			foreach ( var conv in options.Converters )
+		foreach ( var conv in options.Converters )
 		{
-			if ( conv == null )
-			{
-				continue;
-			}
-
-				// Skip this converter and the factory to avoid recursion when building safe options
-				if ( conv.GetType() == typeof(FileIndexItemWithIdJsonConverter) ||
-					 conv.GetType() == typeof(FileIndexItemWithIdJsonConverterFactory) )
+			// Skip this converter and the factory to avoid recursion when building safe options
+			if ( conv is FileIndexItemWithIdJsonConverter
+			    or FileIndexItemWithIdJsonConverterFactory )
 			{
 				continue;
 			}
@@ -63,14 +58,9 @@ public sealed class FileIndexItemWithIdJsonConverter : JsonConverter<FileIndexIt
 
 		foreach ( var conv in options.Converters )
 		{
-			if ( conv == null )
-			{
-				continue;
-			}
-
 			// Skip this converter and the factory to avoid recursion when building safe options
-			if ( conv.GetType() == typeof(FileIndexItemWithIdJsonConverter) ||
-				 conv.GetType() == typeof(FileIndexItemWithIdJsonConverterFactory) )
+			if ( conv is FileIndexItemWithIdJsonConverter
+			    or FileIndexItemWithIdJsonConverterFactory )
 			{
 				continue;
 			}

--- a/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverter.cs
+++ b/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using starsky.foundation.database.Models;
@@ -40,7 +41,25 @@ public sealed class FileIndexItemWithIdJsonConverter : JsonConverter<FileIndexIt
 		using var jsonDoc = JsonDocument.ParseValue(ref reader);
 		var element = jsonDoc.RootElement;
 		var json = element.GetRawText();
-		return JsonSerializer.Deserialize<FileIndexItem>(json, readOptions) ?? new FileIndexItem();
+
+		var result = JsonSerializer.Deserialize<FileIndexItem>(json, readOptions) ??
+		             new FileIndexItem();
+
+		// If JSON contains an explicit id field, set it on the result even if the POCO has [JsonIgnore]
+		// (we write "id" in Write as lower-case). Be case-insensitive to support different naming policies.
+		foreach ( var propValue in element.EnumerateObject()
+			         .Where(prop =>
+				         string.Equals(prop.Name, "id", StringComparison.OrdinalIgnoreCase))
+			         .Select(prop => prop.Value) )
+		{
+			if ( propValue.ValueKind == JsonValueKind.Number &&
+			     propValue.TryGetInt32(out var idVal) )
+			{
+				result.Id = idVal;
+			}
+		}
+
+		return result;
 	}
 
 	public override void Write(Utf8JsonWriter writer, FileIndexItem value,

--- a/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactory.cs
+++ b/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactory.cs
@@ -32,14 +32,9 @@ public sealed class FileIndexItemWithIdJsonConverterFactory : JsonConverterFacto
 
 		var genDef = typeToConvert.GetGenericTypeDefinition();
 		var arg = typeToConvert.GetGenericArguments()[0];
-		if ( arg == typeof(FileIndexItem) &&
-		     ( genDef == typeof(List<>) || genDef == typeof(IList<>) ||
-		       genDef == typeof(IEnumerable<>) ) )
-		{
-			return true;
-		}
-
-		return false;
+		return arg == typeof(FileIndexItem) &&
+		       ( genDef == typeof(List<>) || genDef == typeof(IList<>) ||
+		         genDef == typeof(IEnumerable<>) );
 	}
 
 	public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)

--- a/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactory.cs
+++ b/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactory.cs
@@ -133,12 +133,13 @@ public sealed class FileIndexItemWithIdJsonConverterFactory : JsonConverterFacto
 			reader.Read();
 			while ( reader.TokenType != JsonTokenType.EndArray )
 			{
-				var item = _elementConverter.Read(ref reader, typeof(FileIndexItem), options);
+				var item = _elementConverter.Read(ref reader,
+					typeof(FileIndexItem), options);
 				list.Add(item);
 				reader.Read();
 			}
 
-			return list.ToArray();
+			return [.. list];
 		}
 
 		public override void Write(Utf8JsonWriter writer, FileIndexItem[]? value,

--- a/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactory.cs
+++ b/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactory.cs
@@ -58,17 +58,9 @@ public sealed class FileIndexItemWithIdJsonConverterFactory : JsonConverterFacto
 		{
 			var genDef = typeToConvert.GetGenericTypeDefinition();
 			var arg = typeToConvert.GetGenericArguments()[0];
-			if ( arg == typeof(FileIndexItem) && genDef == typeof(List<>) )
-			{
-				return new ListFileIndexItemConverter();
-			}
-
-			if ( arg == typeof(FileIndexItem) && genDef == typeof(IEnumerable<>) )
-			{
-				return new ListFileIndexItemConverter();
-			}
-
-			if ( arg == typeof(FileIndexItem) && genDef == typeof(IList<>) )
+			if ( ( arg == typeof(FileIndexItem) && genDef == typeof(List<>) ) ||
+			     ( arg == typeof(FileIndexItem) && genDef == typeof(IEnumerable<>) ) ||
+			     ( arg == typeof(FileIndexItem) && genDef == typeof(IList<>) ) )
 			{
 				return new ListFileIndexItemConverter();
 			}
@@ -106,7 +98,7 @@ public sealed class FileIndexItemWithIdJsonConverterFactory : JsonConverterFacto
 			return list;
 		}
 
-		public override void Write(Utf8JsonWriter writer, List<FileIndexItem> value,
+		public override void Write(Utf8JsonWriter writer, List<FileIndexItem>? value,
 			JsonSerializerOptions options)
 		{
 			if ( value == null )
@@ -154,7 +146,7 @@ public sealed class FileIndexItemWithIdJsonConverterFactory : JsonConverterFacto
 			return list.ToArray();
 		}
 
-		public override void Write(Utf8JsonWriter writer, FileIndexItem[] value,
+		public override void Write(Utf8JsonWriter writer, FileIndexItem[]? value,
 			JsonSerializerOptions options)
 		{
 			if ( value == null )

--- a/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactory.cs
+++ b/starsky/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactory.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using starsky.foundation.database.Models;
+
+namespace starsky.foundation.database.JsonConverters;
+
+/// <summary>
+///     JsonConverterFactory that provides converters for FileIndexItem and common collections of
+///     FileIndexItem
+///     when the attribute is applied to either a single item or a list/array property.
+/// </summary>
+public sealed class FileIndexItemWithIdJsonConverterFactory : JsonConverterFactory
+{
+	public override bool CanConvert(Type typeToConvert)
+	{
+		if ( typeToConvert == typeof(FileIndexItem) )
+		{
+			return true;
+		}
+
+		if ( typeToConvert.IsArray && typeToConvert.GetElementType() == typeof(FileIndexItem) )
+		{
+			return true;
+		}
+
+		if ( !typeToConvert.IsGenericType )
+		{
+			return false;
+		}
+
+		var genDef = typeToConvert.GetGenericTypeDefinition();
+		var arg = typeToConvert.GetGenericArguments()[0];
+		if ( arg == typeof(FileIndexItem) &&
+		     ( genDef == typeof(List<>) || genDef == typeof(IList<>) ||
+		       genDef == typeof(IEnumerable<>) ) )
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+	{
+		if ( typeToConvert == typeof(FileIndexItem) )
+		{
+			return new FileIndexItemWithIdJsonConverter();
+		}
+
+		if ( typeToConvert.IsArray && typeToConvert.GetElementType() == typeof(FileIndexItem) )
+		{
+			return new FileIndexItemArrayConverter();
+		}
+
+		if ( typeToConvert.IsGenericType )
+		{
+			var genDef = typeToConvert.GetGenericTypeDefinition();
+			var arg = typeToConvert.GetGenericArguments()[0];
+			if ( arg == typeof(FileIndexItem) && genDef == typeof(List<>) )
+			{
+				return new ListFileIndexItemConverter();
+			}
+
+			if ( arg == typeof(FileIndexItem) && genDef == typeof(IEnumerable<>) )
+			{
+				return new ListFileIndexItemConverter();
+			}
+
+			if ( arg == typeof(FileIndexItem) && genDef == typeof(IList<>) )
+			{
+				return new ListFileIndexItemConverter();
+			}
+		}
+
+		throw new NotSupportedException($"Cannot create converter for {typeToConvert}");
+	}
+
+	private sealed class ListFileIndexItemConverter : JsonConverter<List<FileIndexItem>>
+	{
+		private readonly FileIndexItemWithIdJsonConverter _elementConverter = new();
+
+		public override List<FileIndexItem> Read(ref Utf8JsonReader reader, Type typeToConvert,
+			JsonSerializerOptions options)
+		{
+			if ( reader.TokenType == JsonTokenType.Null )
+			{
+				return null!;
+			}
+
+			if ( reader.TokenType != JsonTokenType.StartArray )
+			{
+				throw new JsonException();
+			}
+
+			var list = new List<FileIndexItem>();
+			reader.Read();
+			while ( reader.TokenType != JsonTokenType.EndArray )
+			{
+				var item = _elementConverter.Read(ref reader, typeof(FileIndexItem), options);
+				list.Add(item);
+				reader.Read();
+			}
+
+			return list;
+		}
+
+		public override void Write(Utf8JsonWriter writer, List<FileIndexItem> value,
+			JsonSerializerOptions options)
+		{
+			if ( value == null )
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartArray();
+			foreach ( var item in value )
+			{
+				_elementConverter.Write(writer, item, options);
+			}
+
+			writer.WriteEndArray();
+		}
+	}
+
+	private sealed class FileIndexItemArrayConverter : JsonConverter<FileIndexItem[]>
+	{
+		private readonly FileIndexItemWithIdJsonConverter _elementConverter = new();
+
+		public override FileIndexItem[] Read(ref Utf8JsonReader reader, Type typeToConvert,
+			JsonSerializerOptions options)
+		{
+			if ( reader.TokenType == JsonTokenType.Null )
+			{
+				return null!;
+			}
+
+			if ( reader.TokenType != JsonTokenType.StartArray )
+			{
+				throw new JsonException();
+			}
+
+			var list = new List<FileIndexItem>();
+			reader.Read();
+			while ( reader.TokenType != JsonTokenType.EndArray )
+			{
+				var item = _elementConverter.Read(ref reader, typeof(FileIndexItem), options);
+				list.Add(item);
+				reader.Read();
+			}
+
+			return list.ToArray();
+		}
+
+		public override void Write(Utf8JsonWriter writer, FileIndexItem[] value,
+			JsonSerializerOptions options)
+		{
+			if ( value == null )
+			{
+				writer.WriteNullValue();
+				return;
+			}
+
+			writer.WriteStartArray();
+			foreach ( var item in value )
+			{
+				_elementConverter.Write(writer, item, options);
+			}
+
+			writer.WriteEndArray();
+		}
+	}
+}

--- a/starsky/starsky.foundation.metaupdate/Models/ExifTimezoneCorrection.cs
+++ b/starsky/starsky.foundation.metaupdate/Models/ExifTimezoneCorrection.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+using starsky.foundation.database.JsonConverters;
 using starsky.foundation.database.Models;
 
 namespace starsky.foundation.metaupdate.Models;
@@ -37,5 +39,6 @@ public class ExifTimezoneCorrectionResult
 	/// </summary>
 	public string Error { get; set; } = string.Empty;
 
+	[JsonConverter(typeof(FileIndexItemWithIdJsonConverterFactory))]
 	public FileIndexItem? FileIndexItem { get; set; }
 }

--- a/starsky/starsky.foundation.metaupdate/Models/MetaReplaceBackgroundPayload.cs
+++ b/starsky/starsky.foundation.metaupdate/Models/MetaReplaceBackgroundPayload.cs
@@ -16,6 +16,6 @@ public sealed class MetaReplaceBackgroundPayload
 	///     The already-modified items (with the replaced values) to be written to
 	///     EXIF / the database by the background job.
 	/// </summary>
-	[JsonConverter(typeof(FileIndexItemWithIdJsonConverter))]
-	public List<FileIndexItem> FileIndexResultsList { get; set; } = [];
+	[JsonConverter(typeof(FileIndexItemWithIdJsonConverterFactory))]
+	public List<FileIndexItem> FileIndexResultsList { get; set; } = new();
 }

--- a/starsky/starsky.foundation.metaupdate/Models/MetaReplaceBackgroundPayload.cs
+++ b/starsky/starsky.foundation.metaupdate/Models/MetaReplaceBackgroundPayload.cs
@@ -17,5 +17,5 @@ public sealed class MetaReplaceBackgroundPayload
 	///     EXIF / the database by the background job.
 	/// </summary>
 	[JsonConverter(typeof(FileIndexItemWithIdJsonConverterFactory))]
-	public List<FileIndexItem> FileIndexResultsList { get; set; } = new();
+	public List<FileIndexItem> FileIndexResultsList { get; set; } = [];
 }

--- a/starsky/starsky.foundation.metaupdate/Models/MetaReplaceBackgroundPayload.cs
+++ b/starsky/starsky.foundation.metaupdate/Models/MetaReplaceBackgroundPayload.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+using starsky.foundation.database.JsonConverters;
 using starsky.foundation.database.Models;
 
 namespace starsky.foundation.metaupdate.Models;
@@ -5,14 +7,15 @@ namespace starsky.foundation.metaupdate.Models;
 public sealed class MetaReplaceBackgroundPayload
 {
 	/// <summary>
-	/// Pre-computed map of filePath → changed field names, so the job does not
-	/// have to re-read from a potentially stale cache.
+	///     Pre-computed map of filePath → changed field names, so the job does not
+	///     have to re-read from a potentially stale cache.
 	/// </summary>
 	public Dictionary<string, List<string>> ChangedFileIndexItemName { get; set; } = new();
 
 	/// <summary>
-	/// The already-modified items (with the replaced values) to be written to
-	/// EXIF / the database by the background job.
+	///     The already-modified items (with the replaced values) to be written to
+	///     EXIF / the database by the background job.
 	/// </summary>
+	[JsonConverter(typeof(FileIndexItemWithIdJsonConverter))]
 	public List<FileIndexItem> FileIndexResultsList { get; set; } = [];
 }

--- a/starsky/starsky.foundation.metaupdate/Models/MetaUpdateBackgroundPayload.cs
+++ b/starsky/starsky.foundation.metaupdate/Models/MetaUpdateBackgroundPayload.cs
@@ -8,8 +8,8 @@ public sealed class MetaUpdateBackgroundPayload
 {
 	public Dictionary<string, List<string>> ChangedFileIndexItemName { get; set; } = new();
 
-	[JsonConverter(typeof(FileIndexItemWithIdJsonConverter))]
-	public List<FileIndexItem> FileIndexResultsList { get; set; } = [];
+	[JsonConverter(typeof(FileIndexItemWithIdJsonConverterFactory))]
+	public List<FileIndexItem> FileIndexResultsList { get; set; } = new();
 
 	public bool Collections { get; set; }
 	public bool Append { get; set; }

--- a/starsky/starsky.foundation.metaupdate/Models/MetaUpdateBackgroundPayload.cs
+++ b/starsky/starsky.foundation.metaupdate/Models/MetaUpdateBackgroundPayload.cs
@@ -9,7 +9,7 @@ public sealed class MetaUpdateBackgroundPayload
 	public Dictionary<string, List<string>> ChangedFileIndexItemName { get; set; } = new();
 
 	[JsonConverter(typeof(FileIndexItemWithIdJsonConverterFactory))]
-	public List<FileIndexItem> FileIndexResultsList { get; set; } = new();
+	public List<FileIndexItem> FileIndexResultsList { get; set; } = [];
 
 	public bool Collections { get; set; }
 	public bool Append { get; set; }

--- a/starsky/starsky.foundation.metaupdate/Services/MetaUpdateBackgroundJobHandler.cs
+++ b/starsky/starsky.foundation.metaupdate/Services/MetaUpdateBackgroundJobHandler.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
+using starsky.foundation.database.JsonConverters;
 using starsky.foundation.injection;
 using starsky.foundation.metaupdate.Interfaces;
 using starsky.foundation.metaupdate.Models;
@@ -21,7 +22,8 @@ public sealed class MetaUpdateBackgroundJobHandler(IServiceScopeFactory scopeFac
 			throw new ArgumentException("Missing payload");
 		}
 
-		var payload = JsonSerializer.Deserialize<MetaUpdateBackgroundPayload>(payloadJson)
+		var payload = JsonSerializer.Deserialize<MetaUpdateBackgroundPayload>(payloadJson,
+			              DefaultJsonFileIndexJsonSerializer.WithIdConverter)
 		              ?? throw new ArgumentException("Invalid payload");
 		using var scope = scopeFactory.CreateScope();
 		var metaUpdateService = scope.ServiceProvider

--- a/starsky/starsky.foundation.mountwatch/Services/MountWatcherCli.cs
+++ b/starsky/starsky.foundation.mountwatch/Services/MountWatcherCli.cs
@@ -77,6 +77,16 @@ public class MountWatcherCli
 	}
 
 	/// <summary>
+	///     Handle mount detected event
+	/// </summary>
+	/// <summary>
+	///     Exposed for tests: last task started to handle a mount event. Tests may await this
+	///     task to deterministically observe logging and import behavior instead of relying
+	///     on timing delays.
+	/// </summary>
+	public Task? LastHandleMountTask { get; private set; }
+
+	/// <summary>
 	///     Start the mount watcher and listen for camera mounts.
 	///     Handles --install / --uninstall before starting the watcher loop.
 	/// </summary>
@@ -244,18 +254,14 @@ public class MountWatcherCli
 		var mountPath = NormalizeMountPath(eventArgs.MountPath);
 		_logger.LogInformation($"Mount detected: {mountPath}");
 
-		_ = Task.Run(async () => await HandleMountDetectedAsync(mountPath));
+		// store the task so tests can await the completion deterministically
+		LastHandleMountTask = Task.Run(async () => await HandleMountDetectedAsync(mountPath));
 	}
 
 	internal static string NormalizeMountPath(string mountPath)
 	{
 		var normalized = mountPath.Trim();
-		if ( normalized.Length <= 1 )
-		{
-			return normalized;
-		}
-
-		return normalized.TrimEnd('/');
+		return normalized.Length <= 1 ? normalized : normalized.TrimEnd('/');
 	}
 
 	private async Task HandleMountDetectedAsync(string mountPath)

--- a/starsky/starsky/Controllers/MetaUpdateController.cs
+++ b/starsky/starsky/Controllers/MetaUpdateController.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using starsky.foundation.database.JsonConverters;
 using starsky.foundation.database.Models;
 using starsky.foundation.metaupdate.Interfaces;
 using starsky.foundation.metaupdate.Models;
@@ -23,10 +24,10 @@ namespace starsky.Controllers;
 public sealed class MetaUpdateController : Controller
 {
 	private readonly IUpdateBackgroundTaskQueue _bgTaskQueue;
+	private readonly IMetaUpdateConnectionService _connectionService;
 	private readonly IWebLogger _logger;
 	private readonly IMetaPreflight _metaPreflight;
 	private readonly IMetaUpdateService _metaUpdateService;
-	private readonly IMetaUpdateConnectionService _connectionService;
 
 	public MetaUpdateController(IMetaPreflight metaPreflight,
 		IMetaUpdateService metaUpdateService,
@@ -93,14 +94,15 @@ public sealed class MetaUpdateController : Controller
 			TraceParentId = Activity.Current?.Id,
 			PriorityLane = ProcessTaskQueue.PriorityLaneUpdate,
 			JobType = MetaUpdateBackgroundJobHandler.MetaUpdate,
-			PayloadJson = JsonSerializer.Serialize(new MetaUpdateBackgroundPayload
-			{
-				ChangedFileIndexItemName = changedFileIndexItemName,
-				FileIndexResultsList = fileIndexResultsList,
-				Collections = collections,
-				Append = append,
-				RotateClock = rotateClock
-			})
+			PayloadJson = JsonSerializer.Serialize(
+				new MetaUpdateBackgroundPayload
+				{
+					ChangedFileIndexItemName = changedFileIndexItemName,
+					FileIndexResultsList = fileIndexResultsList,
+					Collections = collections,
+					Append = append,
+					RotateClock = rotateClock
+				}, DefaultJsonFileIndexJsonSerializer.WithIdConverter)
 		});
 
 		// before sending not founds

--- a/starsky/starskytest/FakeMocks/FakeIMoveToTrashService.cs
+++ b/starsky/starskytest/FakeMocks/FakeIMoveToTrashService.cs
@@ -1,7 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using starsky.feature.trash.Interfaces;
-using starsky.feature.trash.Services;
+using starsky.feature.trash.Models;
 using starsky.foundation.database.Models;
 
 namespace starskytest.FakeMocks;
@@ -41,7 +42,7 @@ public class FakeIMoveToTrashService : IMoveToTrashService
 
 	public Task MoveToTrashAsync(MoveToTrashPayload payload)
 	{
-		throw new System.NotImplementedException();
+		throw new NotImplementedException();
 	}
 
 	public bool IsEnabled()

--- a/starsky/starskytest/starsky.feature.trash/Models/MoveToTrashPayloadJsonTest.cs
+++ b/starsky/starskytest/starsky.feature.trash/Models/MoveToTrashPayloadJsonTest.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using starsky.feature.trash.Models;
+using starsky.foundation.database.JsonConverters;
+using starsky.foundation.database.Models;
+
+namespace starskytest.starsky.feature.trash.Models;
+
+[TestClass]
+public sealed class MoveToTrashPayloadJsonTest
+{
+	[TestMethod]
+	public void Serialize_MoveToTrashPayload_IncludesIds()
+	{
+		var payload = new MoveToTrashPayload
+		{
+			MoveToTrashList =
+			[
+				new FileIndexItem { Id = 10, FileName = "a.jpg" },
+				new FileIndexItem { Id = 20, FileName = "b.jpg" }
+			],
+			FileIndexResultsList = [new FileIndexItem { Id = 30, FileName = "c.jpg" }],
+			InputModel = new FileIndexItem { Id = 40, FileName = "d.jpg" }
+		};
+
+		// Use the serializer options that register the converter as well
+		var json =
+			JsonSerializer.Serialize(payload, DefaultJsonFileIndexJsonSerializer.WithIdConverter);
+
+		Assert.Contains("\"id\":10", json, json);
+		Assert.Contains("\"id\":20", json, json);
+		Assert.Contains("\"id\":30", json, json);
+		Assert.Contains("\"id\":40", json, json);
+	}
+}

--- a/starsky/starskytest/starsky.feature.trash/Services/MoveToTrashServiceTest.cs
+++ b/starsky/starskytest/starsky.feature.trash/Services/MoveToTrashServiceTest.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using starsky.feature.trash.Interfaces;
+using starsky.feature.trash.Models;
 using starsky.feature.trash.Services;
 using starsky.foundation.database.Data;
 using starsky.foundation.database.Interfaces;

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializerTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializerTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -26,7 +27,22 @@ public sealed class DefaultJsonFileIndexJsonSerializerTest
 
 		// The custom converter should include the id field
 		Assert.IsTrue(json.Contains("\"id\":42") || json.Contains("\"id\": 42"), json);
-		Assert.IsTrue(json.Contains("\"fileName\":") || json.Contains("fileName"), json);
+
+		// Parse JSON and assert that a filename property exists (case-insensitive)
+		using var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+		var hasFileName = false;
+		foreach ( var prop in root.EnumerateObject() )
+		{
+			if ( string.Equals(prop.Name, "fileName", StringComparison.OrdinalIgnoreCase) ||
+			     string.Equals(prop.Name, "FileName", StringComparison.OrdinalIgnoreCase) )
+			{
+				hasFileName = true;
+				break;
+			}
+		}
+
+		Assert.IsTrue(hasFileName, json);
 	}
 
 	[TestMethod]

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializerTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializerTest.cs
@@ -75,4 +75,40 @@ public sealed class DefaultJsonFileIndexJsonSerializerTest
 		Assert.Contains("\"id\":1", json, json);
 		Assert.Contains("\"id\":2", json, json);
 	}
+
+	[TestMethod]
+	public void Deserialize_List_NullJson_ReturnsNull()
+	{
+		const string json = "null";
+		var result = JsonSerializer.Deserialize<List<FileIndexItem>>(json,
+			DefaultJsonFileIndexJsonSerializer.WithIdConverter);
+		Assert.IsNull(result);
+	}
+
+	[TestMethod]
+	public void Deserialize_List_WrongToken_ThrowsJsonException()
+	{
+		const string json = "{}"; // not an array
+		Assert.ThrowsExactly<JsonException>(() =>
+			JsonSerializer.Deserialize<List<FileIndexItem>>(json,
+				DefaultJsonFileIndexJsonSerializer.WithIdConverter));
+	}
+
+	[TestMethod]
+	public void Deserialize_Array_NullJson_ReturnsNull()
+	{
+		const string json = "null";
+		var result = JsonSerializer.Deserialize<FileIndexItem[]>(json,
+			DefaultJsonFileIndexJsonSerializer.WithIdConverter);
+		Assert.IsNull(result);
+	}
+
+	[TestMethod]
+	public void Deserialize_Array_WrongToken_ThrowsJsonException()
+	{
+		const string json = "{}"; // not an array
+		Assert.ThrowsExactly<JsonException>(() =>
+			JsonSerializer.Deserialize<FileIndexItem[]>(json,
+				DefaultJsonFileIndexJsonSerializer.WithIdConverter));
+	}
 }

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializerTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializerTest.cs
@@ -111,4 +111,41 @@ public sealed class DefaultJsonFileIndexJsonSerializerTest
 			JsonSerializer.Deserialize<FileIndexItem[]>(json,
 				DefaultJsonFileIndexJsonSerializer.WithIdConverter));
 	}
+
+	[TestMethod]
+	public void Serialize_NullList_WritesNull()
+	{
+		List<FileIndexItem>? items = null;
+		var json = JsonSerializer.Serialize(items, DefaultJsonFileIndexJsonSerializer.WithIdConverter);
+		Assert.AreEqual("null", json);
+	}
+
+	[TestMethod]
+	public void Serialize_NullArray_WritesNull()
+	{
+		FileIndexItem[]? items = null;
+		var json = JsonSerializer.Serialize(items, DefaultJsonFileIndexJsonSerializer.WithIdConverter);
+		Assert.AreEqual("null", json);
+	}
+
+	[TestMethod]
+	public void Deserialize_List_Valid_ReturnsList()
+	{
+		const string json = "[{\"id\":1,\"FileName\":\"a.jpg\"},{\"id\":2,\"FileName\":\"b.jpg\"}]";
+		var result = JsonSerializer.Deserialize<List<FileIndexItem>>(json, DefaultJsonFileIndexJsonSerializer.WithIdConverter);
+		Assert.IsNotNull(result);
+		Assert.HasCount(2, result);
+		Assert.AreEqual(1, result[0].Id);
+		Assert.AreEqual("a.jpg", result[0].FileName);
+	}
+
+	[TestMethod]
+	public void Deserialize_Array_Valid_ReturnsArray()
+	{
+		const string json = "[{\"id\":3,\"FileName\":\"c.jpg\"}]";
+		var result = JsonSerializer.Deserialize<FileIndexItem[]>(json, DefaultJsonFileIndexJsonSerializer.WithIdConverter);
+		Assert.IsNotNull(result);
+		Assert.HasCount(1, result);
+		Assert.AreEqual(3, result[0].Id);
+	}
 }

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializerTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializerTest.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using starsky.foundation.database.JsonConverters;
+using starsky.foundation.database.Models;
+
+namespace starskytest.starsky.foundation.database.JsonConverters;
+
+[TestClass]
+public sealed class DefaultJsonFileIndexJsonSerializerTest
+{
+	[TestMethod]
+	public void Serialize_WithIdConverter_IncludesId()
+	{
+		var item = new FileIndexItem
+		{
+			FileName = "test.jpg",
+			ParentDirectory = "/",
+			FileHash = "hash",
+			// set Id even though model has [JsonIgnore]
+			Id = 42
+		};
+
+		var json =
+			JsonSerializer.Serialize(item, DefaultJsonFileIndexJsonSerializer.WithIdConverter);
+
+		// The custom converter should include the id field
+		Assert.IsTrue(json.Contains("\"id\":42") || json.Contains("\"id\": 42"), json);
+		Assert.IsTrue(json.Contains("\"fileName\":") || json.Contains("fileName"), json);
+	}
+
+	[TestMethod]
+	public void Serialize_ListWithOptions_IncludesIdForEach()
+	{
+		var items = new List<FileIndexItem>
+		{
+			new() { Id = 1, FileName = "a.jpg" }, new() { Id = 2, FileName = "b.jpg" }
+		};
+
+		var json =
+			JsonSerializer.Serialize(items, DefaultJsonFileIndexJsonSerializer.WithIdConverter);
+
+		Assert.Contains("\"id\":1", json, json);
+		Assert.Contains("\"id\":2", json, json);
+	}
+}

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializerTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/DefaultJsonFileIndexJsonSerializerTest.cs
@@ -59,4 +59,20 @@ public sealed class DefaultJsonFileIndexJsonSerializerTest
 		Assert.Contains("\"id\":1", json, json);
 		Assert.Contains("\"id\":2", json, json);
 	}
+
+	[TestMethod]
+	public void Serialize_ToArrayWithOptions_IncludesIdForEach()
+	{
+		var items = new List<FileIndexItem>
+		{
+			new() { Id = 1, FileName = "a.jpg" }, new() { Id = 2, FileName = "b.jpg" }
+		}.ToArray();
+
+		var json =
+			JsonSerializer.Serialize(items,
+				DefaultJsonFileIndexJsonSerializer.WithIdConverter);
+
+		Assert.Contains("\"id\":1", json, json);
+		Assert.Contains("\"id\":2", json, json);
+	}
 }

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactoryTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactoryTest.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using starsky.foundation.database.JsonConverters;
+using starsky.foundation.database.Models;
+
+namespace starskytest.starsky.foundation.database.JsonConverters;
+
+[TestClass]
+public sealed class FileIndexItemWithIdJsonConverterFactoryTest
+{
+    [TestMethod]
+    public void CanConvert_ReturnsExpected()
+    {
+        var factory = new FileIndexItemWithIdJsonConverterFactory();
+
+        Assert.IsTrue(factory.CanConvert(typeof(FileIndexItem)));
+        Assert.IsTrue(factory.CanConvert(typeof(FileIndexItem[])));
+        Assert.IsTrue(factory.CanConvert(typeof(List<FileIndexItem>)));
+        Assert.IsTrue(factory.CanConvert(typeof(IList<FileIndexItem>)));
+        Assert.IsTrue(factory.CanConvert(typeof(IEnumerable<FileIndexItem>)));
+
+        Assert.IsFalse(factory.CanConvert(typeof(string)));
+        Assert.IsFalse(factory.CanConvert(typeof(List<string>)));
+    }
+
+    [TestMethod]
+    public void CreateConverter_Unsupported_Throws()
+    {
+        var factory = new FileIndexItemWithIdJsonConverterFactory();
+        var options = new JsonSerializerOptions();
+        Assert.ThrowsExactly<NotSupportedException>(() => factory.CreateConverter(typeof(string), options));
+    }
+
+    [TestMethod]
+    public void InnerConverters_ReadWrite_Behavior()
+    {
+        var factory = new FileIndexItemWithIdJsonConverterFactory();
+        var options = new JsonSerializerOptions();
+
+        // List converter
+        var listConv = (JsonConverter<List<FileIndexItem>>)factory.CreateConverter(typeof(List<FileIndexItem>), options);
+        // write null list
+        using (var ms = new System.IO.MemoryStream())
+        using (var writer = new Utf8JsonWriter(ms))
+        {
+            listConv.Write(writer, null!, options);
+            writer.Flush();
+            var json = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+            Assert.AreEqual("null", json);
+        }
+
+        // read null
+        var readerNull = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("null"));
+        readerNull.Read();
+        var readNull = listConv.Read(ref readerNull, typeof(List<FileIndexItem>), options);
+        Assert.IsNull(readNull);
+
+        // read wrong token
+        var readerWrong = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("{}"));
+        readerWrong.Read();
+        try
+        {
+            listConv.Read(ref readerWrong, typeof(List<FileIndexItem>), options);
+            Assert.Fail("Expected JsonException");
+        }
+        catch (JsonException)
+        {
+            // expected
+        }
+
+        // valid read
+        var jsonValid = "[{\"id\":5,\"FileName\":\"x.jpg\"}]";
+        var readerValid = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes(jsonValid));
+        readerValid.Read();
+        var list = listConv.Read(ref readerValid, typeof(List<FileIndexItem>), options);
+        Assert.IsNotNull(list);
+        Assert.HasCount(1, list);
+        Assert.AreEqual(5, list[0].Id);
+
+        // Array converter
+        var arrayConv = (JsonConverter<FileIndexItem[]>)factory.CreateConverter(typeof(FileIndexItem[]), options);
+        using (var ms2 = new System.IO.MemoryStream())
+        using (var writer2 = new Utf8JsonWriter(ms2))
+        {
+            arrayConv.Write(writer2, null!, options);
+            writer2.Flush();
+            var json = System.Text.Encoding.UTF8.GetString(ms2.ToArray());
+            Assert.AreEqual("null", json);
+        }
+
+        var readerArrayValid = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("[{\"id\":6,\"FileName\":\"y.jpg\"}]"));
+        readerArrayValid.Read();
+        var arr = arrayConv.Read(ref readerArrayValid, typeof(FileIndexItem[]), options);
+        Assert.IsNotNull(arr);
+        Assert.HasCount(1, arr);
+        Assert.AreEqual(6, arr[0].Id);
+    }
+}
+

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactoryTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactoryTest.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,141 +13,154 @@ namespace starskytest.starsky.foundation.database.JsonConverters;
 [TestClass]
 public sealed class FileIndexItemWithIdJsonConverterFactoryTest
 {
-    [TestMethod]
-    public void CanConvert_ReturnsExpected()
-    {
-        var factory = new FileIndexItemWithIdJsonConverterFactory();
+	[TestMethod]
+	public void CanConvert_ReturnsExpected()
+	{
+		var factory = new FileIndexItemWithIdJsonConverterFactory();
 
-        Assert.IsTrue(factory.CanConvert(typeof(FileIndexItem)));
-        Assert.IsTrue(factory.CanConvert(typeof(FileIndexItem[])));
-        Assert.IsTrue(factory.CanConvert(typeof(List<FileIndexItem>)));
-        Assert.IsTrue(factory.CanConvert(typeof(IList<FileIndexItem>)));
-        Assert.IsTrue(factory.CanConvert(typeof(IEnumerable<FileIndexItem>)));
+		Assert.IsTrue(factory.CanConvert(typeof(FileIndexItem)));
+		Assert.IsTrue(factory.CanConvert(typeof(FileIndexItem[])));
+		Assert.IsTrue(factory.CanConvert(typeof(List<FileIndexItem>)));
+		Assert.IsTrue(factory.CanConvert(typeof(IList<FileIndexItem>)));
+		Assert.IsTrue(factory.CanConvert(typeof(IEnumerable<FileIndexItem>)));
 
-        Assert.IsFalse(factory.CanConvert(typeof(string)));
-        Assert.IsFalse(factory.CanConvert(typeof(List<string>)));
-    }
+		Assert.IsFalse(factory.CanConvert(typeof(string)));
+		Assert.IsFalse(factory.CanConvert(typeof(List<string>)));
+	}
 
-    [TestMethod]
-    public void CreateConverter_Unsupported_Throws()
-    {
-        var factory = new FileIndexItemWithIdJsonConverterFactory();
-        var options = new JsonSerializerOptions();
-        Assert.ThrowsExactly<NotSupportedException>(() => factory.CreateConverter(typeof(string), options));
-    }
+	[TestMethod]
+	public void CreateConverter_Unsupported_Throws()
+	{
+		var factory = new FileIndexItemWithIdJsonConverterFactory();
+		var options = new JsonSerializerOptions();
+		Assert.ThrowsExactly<NotSupportedException>(() =>
+			factory.CreateConverter(typeof(string), options));
+	}
 
-    [TestMethod]
-    public void InnerConverters_ReadWrite_Behavior()
-    {
-        var factory = new FileIndexItemWithIdJsonConverterFactory();
-        var options = new JsonSerializerOptions();
+	[TestMethod]
+	public void InnerConverters_ReadWrite_Behavior()
+	{
+		var factory = new FileIndexItemWithIdJsonConverterFactory();
+		var options = new JsonSerializerOptions();
 
-        // List converter
-        var listConv = (JsonConverter<List<FileIndexItem>>)factory.CreateConverter(typeof(List<FileIndexItem>), options);
-        // write null list
-        using (var ms = new System.IO.MemoryStream())
-        using (var writer = new Utf8JsonWriter(ms))
-        {
-            listConv.Write(writer, null!, options);
-            writer.Flush();
-            var json = System.Text.Encoding.UTF8.GetString(ms.ToArray());
-            Assert.AreEqual("null", json);
-        }
+		// List converter
+		var listConv =
+			( JsonConverter<List<FileIndexItem>> ) factory.CreateConverter(
+				typeof(List<FileIndexItem>), options);
+		// write null list
+		using ( var ms = new MemoryStream() )
+		using ( var writer = new Utf8JsonWriter(ms) )
+		{
+			listConv.Write(writer, null!, options);
+			writer.Flush();
+			var json = Encoding.UTF8.GetString(ms.ToArray());
+			Assert.AreEqual("null", json);
+		}
 
-        // read null
-        var readerNull = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("null"));
-        readerNull.Read();
-        var readNull = listConv.Read(ref readerNull, typeof(List<FileIndexItem>), options);
-        Assert.IsNull(readNull);
+		// read null
+		var readerNull = new Utf8JsonReader("null"u8);
+		readerNull.Read();
+		var readNull = listConv.Read(ref readerNull, typeof(List<FileIndexItem>), options);
+		Assert.IsNull(readNull);
 
-        // read wrong token
-        var readerWrong = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("{}"));
-        readerWrong.Read();
-        try
-        {
-            listConv.Read(ref readerWrong, typeof(List<FileIndexItem>), options);
-            Assert.Fail("Expected JsonException");
-        }
-        catch (JsonException)
-        {
-            // expected
-        }
+		// read wrong token
+		var readerWrong = new Utf8JsonReader("{}"u8);
+		readerWrong.Read();
+		try
+		{
+			listConv.Read(ref readerWrong, typeof(List<FileIndexItem>), options);
+			Assert.Fail("Expected JsonException");
+		}
+		catch ( JsonException )
+		{
+			// expected
+		}
 
-        // valid read
-        var jsonValid = "[{\"id\":5,\"FileName\":\"x.jpg\"}]";
-        var readerValid = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes(jsonValid));
-        readerValid.Read();
-        var list = listConv.Read(ref readerValid, typeof(List<FileIndexItem>), options);
-        Assert.IsNotNull(list);
-        Assert.HasCount(1, list);
-        Assert.AreEqual(5, list[0].Id);
+		// valid read
+		var jsonValid = "[{\"id\":5,\"FileName\":\"x.jpg\"}]";
+		var readerValid = new Utf8JsonReader(Encoding.UTF8.GetBytes(jsonValid));
+		readerValid.Read();
+		var list = listConv.Read(ref readerValid, typeof(List<FileIndexItem>), options);
+		Assert.IsNotNull(list);
+		Assert.HasCount(1, list);
+		Assert.AreEqual(5, list[0].Id);
 
-        // Array converter
-        var arrayConv = (JsonConverter<FileIndexItem[]>)factory.CreateConverter(typeof(FileIndexItem[]), options);
-        using (var ms2 = new System.IO.MemoryStream())
-        using (var writer2 = new Utf8JsonWriter(ms2))
-        {
-            arrayConv.Write(writer2, null!, options);
-            writer2.Flush();
-            var json = System.Text.Encoding.UTF8.GetString(ms2.ToArray());
-            Assert.AreEqual("null", json);
-        }
+		// Array converter
+		var arrayConv =
+			( JsonConverter<FileIndexItem[]> ) factory.CreateConverter(typeof(FileIndexItem[]),
+				options);
+		using ( var ms2 = new MemoryStream() )
+		using ( var writer2 = new Utf8JsonWriter(ms2) )
+		{
+			arrayConv.Write(writer2, null!, options);
+			writer2.Flush();
+			var json = Encoding.UTF8.GetString(ms2.ToArray());
+			Assert.AreEqual("null", json);
+		}
 
-        var readerArrayValid = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("[{\"id\":6,\"FileName\":\"y.jpg\"}]"));
-        readerArrayValid.Read();
-        var arr = arrayConv.Read(ref readerArrayValid, typeof(FileIndexItem[]), options);
-        Assert.IsNotNull(arr);
-        Assert.HasCount(1, arr);
-        Assert.AreEqual(6, arr[0].Id);
-    }
+		var readerArrayValid =
+			new Utf8JsonReader("[{\"id\":6,\"FileName\":\"y.jpg\"}]"u8);
+		readerArrayValid.Read();
+		var arr = arrayConv.Read(ref readerArrayValid, typeof(FileIndexItem[]), options);
+		Assert.IsNotNull(arr);
+		Assert.HasCount(1, arr);
+		Assert.AreEqual(6, arr[0].Id);
+	}
 
-    [TestMethod]
-    public void CreateConverter_ForIEnumerableAndIList_Works()
-    {
-        var factory = new FileIndexItemWithIdJsonConverterFactory();
-        var options = new JsonSerializerOptions();
+	[TestMethod]
+	public void CreateConverter_ForIEnumerableAndIList_Works()
+	{
+		var factory = new FileIndexItemWithIdJsonConverterFactory();
+		var options = new JsonSerializerOptions();
 
-        // IEnumerable<FileIndexItem>
-        var enumConvObj = factory.CreateConverter(typeof(IEnumerable<FileIndexItem>), options);
-        var enumConv = (JsonConverter<List<FileIndexItem>>)enumConvObj; // underlying converter is ListFileIndexItemConverter
+		// IEnumerable<FileIndexItem>
+		var enumConvObj = factory.CreateConverter(typeof(IEnumerable<FileIndexItem>), options);
+		var enumConv =
+			( JsonConverter<List<FileIndexItem>> )
+			enumConvObj; // underlying converter is ListFileIndexItemConverter
 
-        var readerValidEnum = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("[{\"id\":7,\"FileName\":\"z.jpg\"}]"));
-        readerValidEnum.Read();
-        var listEnum = enumConv.Read(ref readerValidEnum, typeof(List<FileIndexItem>), options);
-        Assert.IsNotNull(listEnum);
-        Assert.AreEqual(1, listEnum.Count);
-        Assert.AreEqual(7, listEnum[0].Id);
+		var readerValidEnum =
+			new Utf8JsonReader("[{\"id\":7,\"FileName\":\"z.jpg\"}]"u8);
+		readerValidEnum.Read();
+		var listEnum = enumConv.Read(ref readerValidEnum, typeof(List<FileIndexItem>), options);
+		Assert.IsNotNull(listEnum);
+		Assert.HasCount(1, listEnum);
+		Assert.AreEqual(7, listEnum[0].Id);
 
-        // IList<FileIndexItem>
-        var ilistConvObj = factory.CreateConverter(typeof(IList<FileIndexItem>), options);
-        var ilistConv = (JsonConverter<List<FileIndexItem>>)ilistConvObj;
+		// IList<FileIndexItem>
+		var ilistConvObj = factory.CreateConverter(typeof(IList<FileIndexItem>), options);
+		var ilistConv = ( JsonConverter<List<FileIndexItem>> ) ilistConvObj;
 
-        var readerValidIList = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("[{\"id\":8,\"FileName\":\"w.jpg\"}]"));
-        readerValidIList.Read();
-        var listIList = ilistConv.Read(ref readerValidIList, typeof(List<FileIndexItem>), options);
-        Assert.IsNotNull(listIList);
-        Assert.AreEqual(1, listIList.Count);
-        Assert.AreEqual(8, listIList[0].Id);
-    }
+		var readerValidIList =
+			new Utf8JsonReader("[{\"id\":8,\"FileName\":\"w.jpg\"}]"u8);
+		readerValidIList.Read();
+		var listIList = ilistConv.Read(ref readerValidIList, typeof(List<FileIndexItem>), options);
+		Assert.IsNotNull(listIList);
+		Assert.HasCount(1, listIList);
+		Assert.AreEqual(8, listIList[0].Id);
+	}
 
-    [TestMethod]
-    public void Read_NullToken_ReturnsNull_ForListAndArray()
-    {
-        var factory = new FileIndexItemWithIdJsonConverterFactory();
-        var options = new JsonSerializerOptions();
+	[TestMethod]
+	public void Read_NullToken_ReturnsNull_ForListAndArray()
+	{
+		var factory = new FileIndexItemWithIdJsonConverterFactory();
+		var options = new JsonSerializerOptions();
 
-        var listConv = (JsonConverter<List<FileIndexItem>>)factory.CreateConverter(typeof(List<FileIndexItem>), options);
-        var arrayConv = (JsonConverter<FileIndexItem[]>)factory.CreateConverter(typeof(FileIndexItem[]), options);
+		var listConv =
+			( JsonConverter<List<FileIndexItem>> ) factory.CreateConverter(
+				typeof(List<FileIndexItem>), options);
+		var arrayConv =
+			( JsonConverter<FileIndexItem[]> ) factory.CreateConverter(typeof(FileIndexItem[]),
+				options);
 
-        var readerListNull = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("null"));
-        readerListNull.Read();
-        var listNull = listConv.Read(ref readerListNull, typeof(List<FileIndexItem>), options);
-        Assert.IsNull(listNull);
+		var readerListNull = new Utf8JsonReader("null"u8);
+		readerListNull.Read();
+		var listNull = listConv.Read(ref readerListNull, typeof(List<FileIndexItem>), options);
+		Assert.IsNull(listNull);
 
-        var readerArrayNull = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("null"));
-        readerArrayNull.Read();
-        var arrNull = arrayConv.Read(ref readerArrayNull, typeof(FileIndexItem[]), options);
-        Assert.IsNull(arrNull);
-    }
+		var readerArrayNull = new Utf8JsonReader("null"u8);
+		readerArrayNull.Read();
+		var arrNull = arrayConv.Read(ref readerArrayNull, typeof(FileIndexItem[]), options);
+		Assert.IsNull(arrNull);
+	}
 }
-

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactoryTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactoryTest.cs
@@ -98,5 +98,34 @@ public sealed class FileIndexItemWithIdJsonConverterFactoryTest
         Assert.HasCount(1, arr);
         Assert.AreEqual(6, arr[0].Id);
     }
+
+    [TestMethod]
+    public void CreateConverter_ForIEnumerableAndIList_Works()
+    {
+        var factory = new FileIndexItemWithIdJsonConverterFactory();
+        var options = new JsonSerializerOptions();
+
+        // IEnumerable<FileIndexItem>
+        var enumConvObj = factory.CreateConverter(typeof(IEnumerable<FileIndexItem>), options);
+        var enumConv = (JsonConverter<List<FileIndexItem>>)enumConvObj; // underlying converter is ListFileIndexItemConverter
+
+        var readerValidEnum = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("[{\"id\":7,\"FileName\":\"z.jpg\"}]"));
+        readerValidEnum.Read();
+        var listEnum = enumConv.Read(ref readerValidEnum, typeof(List<FileIndexItem>), options);
+        Assert.IsNotNull(listEnum);
+        Assert.AreEqual(1, listEnum.Count);
+        Assert.AreEqual(7, listEnum[0].Id);
+
+        // IList<FileIndexItem>
+        var ilistConvObj = factory.CreateConverter(typeof(IList<FileIndexItem>), options);
+        var ilistConv = (JsonConverter<List<FileIndexItem>>)ilistConvObj;
+
+        var readerValidIList = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("[{\"id\":8,\"FileName\":\"w.jpg\"}]"));
+        readerValidIList.Read();
+        var listIList = ilistConv.Read(ref readerValidIList, typeof(List<FileIndexItem>), options);
+        Assert.IsNotNull(listIList);
+        Assert.AreEqual(1, listIList.Count);
+        Assert.AreEqual(8, listIList[0].Id);
+    }
 }
 

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactoryTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterFactoryTest.cs
@@ -127,5 +127,25 @@ public sealed class FileIndexItemWithIdJsonConverterFactoryTest
         Assert.AreEqual(1, listIList.Count);
         Assert.AreEqual(8, listIList[0].Id);
     }
+
+    [TestMethod]
+    public void Read_NullToken_ReturnsNull_ForListAndArray()
+    {
+        var factory = new FileIndexItemWithIdJsonConverterFactory();
+        var options = new JsonSerializerOptions();
+
+        var listConv = (JsonConverter<List<FileIndexItem>>)factory.CreateConverter(typeof(List<FileIndexItem>), options);
+        var arrayConv = (JsonConverter<FileIndexItem[]>)factory.CreateConverter(typeof(FileIndexItem[]), options);
+
+        var readerListNull = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("null"));
+        readerListNull.Read();
+        var listNull = listConv.Read(ref readerListNull, typeof(List<FileIndexItem>), options);
+        Assert.IsNull(listNull);
+
+        var readerArrayNull = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes("null"));
+        readerArrayNull.Read();
+        var arrNull = arrayConv.Read(ref readerArrayNull, typeof(FileIndexItem[]), options);
+        Assert.IsNull(arrNull);
+    }
 }
 

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -183,5 +184,41 @@ public sealed class FileIndexItemWithIdJsonConverterTest
 		Assert.IsNotNull(result);
 		Assert.AreEqual(0, result.Id);
 		Assert.AreEqual("noid.jpg", result.FileName);
+	}
+
+	[TestMethod]
+	public void Read_WhenInnerDeserializerReturnsNull_UsesNewFileIndexItem()
+	{
+		var conv = new FileIndexItemWithIdJsonConverter();
+		var json = "{}"; // empty object
+		var bytes = Encoding.UTF8.GetBytes(json);
+		var reader = new Utf8JsonReader(bytes);
+		reader.Read();
+
+		var options = new JsonSerializerOptions();
+		// Add a custom converter that will return null when deserializing FileIndexItem
+		options.Converters.Add(new NullReturningConverter());
+
+		var result = conv.Read(ref reader, typeof(FileIndexItem), options);
+
+		Assert.IsNotNull(result);
+		// should be default values
+		Assert.AreEqual(0, result.Id);
+		Assert.IsTrue(string.IsNullOrEmpty(result.FileName));
+	}
+
+	private sealed class NullReturningConverter : JsonConverter<FileIndexItem>
+	{
+		public override FileIndexItem Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			// consume the token to keep reader state consistent
+			using var _ = JsonDocument.ParseValue(ref reader);
+			return null!; // intentional: simulate a null-returning inner deserializer
+		}
+
+		public override void Write(Utf8JsonWriter writer, FileIndexItem value, JsonSerializerOptions options)
+		{
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterTest.cs
@@ -11,67 +11,113 @@ namespace starskytest.starsky.foundation.database.JsonConverters;
 [TestClass]
 public sealed class FileIndexItemWithIdJsonConverterTest
 {
-    [TestMethod]
-    public void Write_WithFactoryAndOtherConverters_WritesIdAndProperties()
-    {
-        var conv = new FileIndexItemWithIdJsonConverter();
-        var item = new FileIndexItem { Id = 5, FileName = "a.jpg", ParentDirectory = "/" };
+	[TestMethod]
+	public void Write_WithFactoryAndOtherConverters_WritesIdAndProperties()
+	{
+		var conv = new FileIndexItemWithIdJsonConverter();
+		var item = new FileIndexItem { Id = 5, FileName = "a.jpg", ParentDirectory = "/" };
 
-        var options = new JsonSerializerOptions();
-        // include factory and another converter to exercise the safeOptions copy logic
-        options.Converters.Add(new FileIndexItemWithIdJsonConverterFactory());
-        options.Converters.Add(new JsonStringEnumConverter());
+		var options = new JsonSerializerOptions();
+		// include factory and another converter to exercise the safeOptions copy logic
+		options.Converters.Add(new FileIndexItemWithIdJsonConverterFactory());
+		options.Converters.Add(new JsonStringEnumConverter());
 
-        using var ms = new MemoryStream();
-        using ( var writer = new Utf8JsonWriter(ms) )
-        {
-            conv.Write(writer, item, options);
-        }
+		using var ms = new MemoryStream();
+		using ( var writer = new Utf8JsonWriter(ms) )
+		{
+			conv.Write(writer, item, options);
+		}
 
-        var json = Encoding.UTF8.GetString(ms.ToArray());
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
+		var json = Encoding.UTF8.GetString(ms.ToArray());
+		using var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
 
-        Assert.IsTrue(root.TryGetProperty("id", out var idProp) && idProp.GetInt32() == 5, json);
-        Assert.IsTrue(root.TryGetProperty("FileName", out var fnProp) && fnProp.GetString() == "a.jpg", json);
-    }
+		Assert.IsTrue(root.TryGetProperty("id", out var idProp) && idProp.GetInt32() == 5, json);
+		Assert.IsTrue(
+			root.TryGetProperty("FileName", out var fnProp) && fnProp.GetString() == "a.jpg", json);
+	}
 
-    [TestMethod]
-    public void Read_WithFactoryAndOtherConverters_ParsesProperties()
-    {
-        var conv = new FileIndexItemWithIdJsonConverter();
-        var json = "{\"id\":7,\"FileName\":\"b.jpg\",\"ParentDirectory\":\"/\"}";
-        var bytes = Encoding.UTF8.GetBytes(json);
-        var reader = new Utf8JsonReader(bytes);
-        // advance to the first token (StartObject)
-        reader.Read();
+	[TestMethod]
+	public void Read_WithFactoryAndOtherConverters_ParsesProperties()
+	{
+		var conv = new FileIndexItemWithIdJsonConverter();
+		var json = "{\"id\":7,\"FileName\":\"b.jpg\",\"ParentDirectory\":\"/\"}";
+		var bytes = Encoding.UTF8.GetBytes(json);
+		var reader = new Utf8JsonReader(bytes);
+		// advance to the first token (StartObject)
+		reader.Read();
 
-        var options = new JsonSerializerOptions();
-        options.Converters.Add(new FileIndexItemWithIdJsonConverterFactory());
-        options.Converters.Add(new JsonStringEnumConverter());
+		var options = new JsonSerializerOptions();
+		options.Converters.Add(new FileIndexItemWithIdJsonConverterFactory());
+		options.Converters.Add(new JsonStringEnumConverter());
 
-        var result = conv.Read(ref reader, typeof(FileIndexItem), options);
+		var result = conv.Read(ref reader, typeof(FileIndexItem), options);
 
-        Assert.IsNotNull(result);
-        Assert.AreEqual("b.jpg", result.FileName);
-        Assert.AreEqual("/", result.ParentDirectory);
-        // Id is ignored by the POCO [JsonIgnore] so it may not be populated by the internal deserialize
-        // Ensure the converter returned an object and populated other properties.
-    }
+		Assert.IsNotNull(result);
+		Assert.AreEqual("b.jpg", result.FileName);
+		Assert.AreEqual("/", result.ParentDirectory);
+		// Id is ignored by the POCO [JsonIgnore] so it may not be populated by the internal deserialize
+		// Ensure the converter returned an object and populated other properties.
+	}
 
-    [TestMethod]
-    public void Roundtrip_SerializeDeserialize_PropertiesRemain()
-    {
-        var item = new FileIndexItem { Id = 10, FileName = "c.jpg", ParentDirectory = "/" };
-        var options = DefaultJsonFileIndexJsonSerializer.WithIdConverter;
+	[TestMethod]
+	public void Roundtrip_SerializeDeserialize_PropertiesRemain()
+	{
+		var item = new FileIndexItem { Id = 10, FileName = "c.jpg", ParentDirectory = "/" };
+		var options = DefaultJsonFileIndexJsonSerializer.WithIdConverter;
 
-        var json = JsonSerializer.Serialize(item, options);
-        var deserialized = JsonSerializer.Deserialize<FileIndexItem>(json, options);
+		var json = JsonSerializer.Serialize(item, options);
+		var deserialized = JsonSerializer.Deserialize<FileIndexItem>(json, options);
 
-        Assert.IsNotNull(deserialized);
-        Assert.AreEqual(item.FileName, deserialized.FileName);
-        Assert.AreEqual(item.ParentDirectory, deserialized.ParentDirectory);
-        // Id is not round-tripped to the property because FileIndexItem.Id has [JsonIgnore]
-    }
+		Assert.IsNotNull(deserialized);
+		Assert.AreEqual(item.FileName, deserialized.FileName);
+		Assert.AreEqual(item.ParentDirectory, deserialized.ParentDirectory);
+		// Id is not round-tripped to the property because FileIndexItem.Id has [JsonIgnore]
+	}
+
+	[TestMethod]
+	public void Read_SetsId_CaseInsensitiveAndHandlesNonNumeric()
+	{
+		var conv = new FileIndexItemWithIdJsonConverter();
+
+		// Numeric id with different casing
+		const string json1 = "{\"Id\":9,\"FileName\":\"d.jpg\",\"ParentDirectory\":\"/\"}";
+		var bytes1 = Encoding.UTF8.GetBytes(json1);
+		var reader1 = new Utf8JsonReader(bytes1);
+		reader1.Read();
+		var options = new JsonSerializerOptions();
+		options.Converters.Add(new FileIndexItemWithIdJsonConverterFactory());
+		var result1 = conv.Read(ref reader1, typeof(FileIndexItem), options);
+		Assert.AreEqual(9, result1.Id);
+
+		// Non-numeric id should not throw and should leave Id as default (0)
+		var json2 = "{\"id\":\"not-a-number\",\"FileName\":\"e.jpg\"}";
+		var bytes2 = Encoding.UTF8.GetBytes(json2);
+		var reader2 = new Utf8JsonReader(bytes2);
+		reader2.Read();
+		var result2 = conv.Read(ref reader2, typeof(FileIndexItem), options);
+		Assert.AreEqual(0, result2.Id);
+	}
+
+	[TestMethod]
+	public void Write_RespectsPropertyNamingPolicy_WhenProvided()
+	{
+		var conv = new FileIndexItemWithIdJsonConverter();
+		var item = new FileIndexItem { Id = 11, FileName = "f.jpg", ParentDirectory = "/" };
+
+		var options =
+			new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+		options.Converters.Add(new FileIndexItemWithIdJsonConverterFactory());
+
+		using var ms = new MemoryStream();
+		using ( var writer = new Utf8JsonWriter(ms) )
+		{
+			conv.Write(writer, item, options);
+		}
+
+		var json = Encoding.UTF8.GetString(ms.ToArray());
+		// with camelCase naming policy, properties should be camel-cased
+		Assert.IsTrue(json.Contains("\"id\":11"), json);
+		Assert.IsTrue(json.Contains("\"fileName\"") || json.Contains("\"FileName\""), json);
+	}
 }
-

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterTest.cs
@@ -1,0 +1,77 @@
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using starsky.foundation.database.JsonConverters;
+using starsky.foundation.database.Models;
+
+namespace starskytest.starsky.foundation.database.JsonConverters;
+
+[TestClass]
+public sealed class FileIndexItemWithIdJsonConverterTest
+{
+    [TestMethod]
+    public void Write_WithFactoryAndOtherConverters_WritesIdAndProperties()
+    {
+        var conv = new FileIndexItemWithIdJsonConverter();
+        var item = new FileIndexItem { Id = 5, FileName = "a.jpg", ParentDirectory = "/" };
+
+        var options = new JsonSerializerOptions();
+        // include factory and another converter to exercise the safeOptions copy logic
+        options.Converters.Add(new FileIndexItemWithIdJsonConverterFactory());
+        options.Converters.Add(new JsonStringEnumConverter());
+
+        using var ms = new MemoryStream();
+        using ( var writer = new Utf8JsonWriter(ms) )
+        {
+            conv.Write(writer, item, options);
+        }
+
+        var json = Encoding.UTF8.GetString(ms.ToArray());
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.IsTrue(root.TryGetProperty("id", out var idProp) && idProp.GetInt32() == 5, json);
+        Assert.IsTrue(root.TryGetProperty("FileName", out var fnProp) && fnProp.GetString() == "a.jpg", json);
+    }
+
+    [TestMethod]
+    public void Read_WithFactoryAndOtherConverters_ParsesProperties()
+    {
+        var conv = new FileIndexItemWithIdJsonConverter();
+        var json = "{\"id\":7,\"FileName\":\"b.jpg\",\"ParentDirectory\":\"/\"}";
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var reader = new Utf8JsonReader(bytes);
+        // advance to the first token (StartObject)
+        reader.Read();
+
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new FileIndexItemWithIdJsonConverterFactory());
+        options.Converters.Add(new JsonStringEnumConverter());
+
+        var result = conv.Read(ref reader, typeof(FileIndexItem), options);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("b.jpg", result.FileName);
+        Assert.AreEqual("/", result.ParentDirectory);
+        // Id is ignored by the POCO [JsonIgnore] so it may not be populated by the internal deserialize
+        // Ensure the converter returned an object and populated other properties.
+    }
+
+    [TestMethod]
+    public void Roundtrip_SerializeDeserialize_PropertiesRemain()
+    {
+        var item = new FileIndexItem { Id = 10, FileName = "c.jpg", ParentDirectory = "/" };
+        var options = DefaultJsonFileIndexJsonSerializer.WithIdConverter;
+
+        var json = JsonSerializer.Serialize(item, options);
+        var deserialized = JsonSerializer.Deserialize<FileIndexItem>(json, options);
+
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual(item.FileName, deserialized.FileName);
+        Assert.AreEqual(item.ParentDirectory, deserialized.ParentDirectory);
+        // Id is not round-tripped to the property because FileIndexItem.Id has [JsonIgnore]
+    }
+}
+

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterTest.cs
@@ -117,7 +117,7 @@ public sealed class FileIndexItemWithIdJsonConverterTest
 
 		var json = Encoding.UTF8.GetString(ms.ToArray());
 		// with camelCase naming policy, properties should be camel-cased
-		Assert.IsTrue(json.Contains("\"id\":11"), json);
+		Assert.Contains("\"id\":11", json, json);
 		Assert.IsTrue(json.Contains("\"fileName\"") || json.Contains("\"FileName\""), json);
 	}
 

--- a/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/JsonConverters/FileIndexItemWithIdJsonConverterTest.cs
@@ -120,4 +120,68 @@ public sealed class FileIndexItemWithIdJsonConverterTest
 		Assert.IsTrue(json.Contains("\"id\":11"), json);
 		Assert.IsTrue(json.Contains("\"fileName\"") || json.Contains("\"FileName\""), json);
 	}
+
+	[TestMethod]
+	public void Write_SkipsSelfAndFactoryInSafeOptions()
+	{
+		var conv = new FileIndexItemWithIdJsonConverter();
+		var item = new FileIndexItem { Id = 21, FileName = "g.jpg", ParentDirectory = "/" };
+
+		var options = new JsonSerializerOptions();
+		// include this converter instance and factory to ensure they are skipped when building safeOptions
+		options.Converters.Add(conv);
+		options.Converters.Add(new FileIndexItemWithIdJsonConverterFactory());
+
+		using var ms = new MemoryStream();
+		using ( var writer = new Utf8JsonWriter(ms) )
+		{
+			conv.Write(writer, item, options);
+		}
+
+		var json = Encoding.UTF8.GetString(ms.ToArray());
+		using var doc = JsonDocument.Parse(json);
+		var root = doc.RootElement;
+
+		Assert.IsTrue(root.TryGetProperty("id", out var idProp) && idProp.GetInt32() == 21, json);
+	}
+
+	[TestMethod]
+	public void Read_SkipsSelfAndFactoryInReadOptions()
+	{
+		var conv = new FileIndexItemWithIdJsonConverter();
+		var json = "{\"id\":33,\"FileName\":\"h.jpg\",\"ParentDirectory\":\"/\"}";
+		var bytes = Encoding.UTF8.GetBytes(json);
+		var reader = new Utf8JsonReader(bytes);
+		reader.Read();
+
+		var options = new JsonSerializerOptions();
+		// include this converter and factory so the read logic will skip adding them to readOptions
+		options.Converters.Add(conv);
+		options.Converters.Add(new FileIndexItemWithIdJsonConverterFactory());
+
+		var result = conv.Read(ref reader, typeof(FileIndexItem), options);
+
+		Assert.IsNotNull(result);
+		Assert.AreEqual(33, result.Id);
+		Assert.AreEqual("h.jpg", result.FileName);
+	}
+
+	[TestMethod]
+	public void Read_NoIdProperty_ReturnsDefaultId()
+	{
+		var conv = new FileIndexItemWithIdJsonConverter();
+		var json = "{\"FileName\":\"noid.jpg\",\"ParentDirectory\":\"/\"}";
+		var bytes = Encoding.UTF8.GetBytes(json);
+		var reader = new Utf8JsonReader(bytes);
+		reader.Read();
+
+		var options = new JsonSerializerOptions();
+		options.Converters.Add(new FileIndexItemWithIdJsonConverterFactory());
+
+		var result = conv.Read(ref reader, typeof(FileIndexItem), options);
+
+		Assert.IsNotNull(result);
+		Assert.AreEqual(0, result.Id);
+		Assert.AreEqual("noid.jpg", result.FileName);
+	}
 }

--- a/starsky/starskytest/starsky.foundation.mountwatch/Services/MountWatcherCliTest.cs
+++ b/starsky/starskytest/starsky.foundation.mountwatch/Services/MountWatcherCliTest.cs
@@ -246,10 +246,14 @@ public sealed class MountWatcherCliTest
 			new FakeMountWatcherFactory(),
 			new FakeServiceInstaller());
 
-		// Act: trigger mount detected event
+		// Act: trigger mount detected event and await handling completion
 		sut.OnMountDetected(null,
 			new MountDetectedEventArgs { MountPath = mountPath, DetectedAt = DateTime.Now });
-		await Task.Delay(50, TestContext.CancellationToken);
+		// Await the internal task responsible for handling the mount event to make the test deterministic
+		if ( sut.LastHandleMountTask != null )
+		{
+			await sut.LastHandleMountTask;
+		}
 
 		// Assert
 		Assert.IsNotEmpty(fakeImport.Calls, "Importer was not called");
@@ -273,10 +277,13 @@ public sealed class MountWatcherCliTest
 			new FakeMountWatcherFactory(),
 			new FakeServiceInstaller());
 
-		// Act: trigger mount detected event
+		// Act: trigger mount detected event and await handling completion
 		sut.OnMountDetected(null,
 			new MountDetectedEventArgs { MountPath = mountPath, DetectedAt = DateTime.Now });
-		await Task.Delay(50, TestContext.CancellationToken);
+		if ( sut.LastHandleMountTask != null )
+		{
+			await sut.LastHandleMountTask;
+		}
 
 		// Assert: importer not called and debug logged
 		Assert.IsEmpty(fakeImport.Calls);

--- a/starsky/starskytest/starsky.foundation.sync/WatcherBackgroundService/DiskWatcherBackgroundTaskQueueTest.cs
+++ b/starsky/starskytest/starsky.foundation.sync/WatcherBackgroundService/DiskWatcherBackgroundTaskQueueTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.Metrics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,12 +31,15 @@ public sealed class DiskWatcherBackgroundTaskQueueTest
 		var queue = new DiskWatcherBackgroundTaskQueue(_scopeFactory);
 		await queue.QueueJobAsync(new BackgroundTaskQueueJob
 		{
-			JobType = "Test.DiskWatcherQueue.v1", PayloadJson = "{}", MetaData = string.Empty
+			JobType = "Test.DiskWatcherQueue.v1",
+			PayloadJson = "{}",
+			// example
+			MetaData = string.Empty
 		});
 
 		Assert.AreEqual(1, queue.Count());
 
-		var token = new CancellationToken();
+		var token = CancellationToken.None;
 		await queue.DequeueJobAsync(token);
 
 		Assert.AreEqual(0, queue.Count());
@@ -57,7 +61,7 @@ public sealed class DiskWatcherBackgroundTaskQueueTest
 	public async Task QueueJobAsync_JobTypeRequired_ArgumentException()
 	{
 		var backgroundQueue = new DiskWatcherBackgroundTaskQueue(_scopeFactory);
-		await Assert.ThrowsExactlyAsync<System.ArgumentException>(async () =>
+		await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
 		{
 			await backgroundQueue.QueueJobAsync(new BackgroundTaskQueueJob());
 		});

--- a/starsky/starskytest/starskytest.csproj
+++ b/starsky/starskytest/starskytest.csproj
@@ -44,6 +44,7 @@
         <ProjectReference Include="..\starsky.feature.settings\starsky.feature.settings.csproj"/>
         <ProjectReference Include="..\starsky.feature.thumbnail\starsky.feature.thumbnail.csproj"/>
         <ProjectReference Include="..\starsky.feature.webhtmlpublish\starsky.feature.webhtmlpublish.csproj"/>
+        <ProjectReference Include="..\starsky.feature.trash\starsky.feature.trash.csproj"/>
         <ProjectReference Include="..\starsky.foundation.database\starsky.foundation.database.csproj"/>
         <ProjectReference Include="..\starsky.foundation.injection\starsky.foundation.injection.csproj"/>
         <ProjectReference Include="..\starsky.foundation.platform\starsky.foundation.platform.csproj"/>


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request introduces a new custom JSON converter for `FileIndexItem` that ensures the `Id` property is always included during serialization and deserialization. This converter is applied across several payload models and background job handlers, standardizing how `FileIndexItem` objects are handled in JSON throughout the codebase. The changes also include updates to tests and dependency injection to support the new converter.

**Introduction of custom JSON converter and application across the codebase:**

* Added `FileIndexItemWithIdJsonConverter` and `FileIndexItemWithIdJsonConverterFactory` to always serialize/deserialize the `Id` property for `FileIndexItem` objects, even if it's marked with `[JsonIgnore]`. Also introduced `DefaultJsonFileIndexJsonSerializer.WithIdConverter` for consistent options. [[1]](diffhunk://#diff-d658b27307b7189fbff1629e550ff60dad52279d252f6bfd0be26631dc780750R1-R109) [[2]](diffhunk://#diff-1c049519debb8718f99bf819baf90a73174ea5ce637243f97d18bb43329c26d1R1-R163) [[3]](diffhunk://#diff-2e69188c09e25f72e64166a38b66a6ed8ac6f5b6bde8cb87bb61c6546e8a0c56R1-R22)
* Updated payload models such as `MoveToTrashPayload`, `MetaReplaceBackgroundPayload`, `MetaUpdateBackgroundPayload`, and `ExifTimezoneCorrectionResult` to use `[JsonConverter(typeof(FileIndexItemWithIdJsonConverterFactory))]` on relevant `FileIndexItem` and collection properties, ensuring the new converter is used. [[1]](diffhunk://#diff-243413dcdc836ace9e7748f3cd1d3fabb06d834f058f9281fe5d7f24c9a7ace6R1-R22) [[2]](diffhunk://#diff-cd37b993421915e9c6a2b0fcf58a0119c73640af18db5eb958b8911643c1819cR19) [[3]](diffhunk://#diff-de4bc08b2018429667a9f5c5d8d2531cea047105161dd087703338382dc9f0a5R1-R13) [[4]](diffhunk://#diff-771d4028e48a8f0fffe14d74d6d53c0b9ec0c363afc1c79eb9da8ea4e08974c1R42)

**Integration into background jobs and controllers:**

* Modified background job handlers and the `MetaUpdateController` to use the custom serializer options (`DefaultJsonFileIndexJsonSerializer.WithIdConverter`) when serializing and deserializing payloads, guaranteeing that the `Id` field is preserved in background processing. [[1]](diffhunk://#diff-ae8d4b579f0f6815111307795a3b2544c698dc75473e93eff4ec716f7cd529ccL24-R26) [[2]](diffhunk://#diff-1f6cdc9bc490a87cdbf34208a7be9b1e65c24467b292becaf28f2530f3a36cf0L96-R105)

**Codebase cleanup and refactoring:**

* Moved `MoveToTrashPayload` from `MoveToTrashService.cs` to its own file in the `Models` folder, and updated all relevant `using` statements and dependencies to reference the new location. [[1]](diffhunk://#diff-fe82a76b4834b08321234fef23b691741fea4174aa3a5eaf2da6bdd2f8e38900L201-L210) [[2]](diffhunk://#diff-4a7555d2d46bc8c574c6f2db18f8ff7197ca0e5650ccc14bf2a33f05db8c556cL1-R1) [[3]](diffhunk://#diff-8aef67a423f6a3ecbaf3e11b503ffc20d6f8b9dc22ca29154b749cb1e7d6c4dfR1-R5) [[4]](diffhunk://#diff-dbaf1a982bda344a691acdd436ac5d1dd68c6c773d27babab443d0dc670daaf7R11) [[5]](diffhunk://#diff-3a93e2bf3500bd226b0d79b641cfd2066c36cd924087d3e794719ebd5c7f6e83R3) [[6]](diffhunk://#diff-fe82a76b4834b08321234fef23b691741fea4174aa3a5eaf2da6bdd2f8e38900R6)

**Testing improvements:**

* Added a new test `MoveToTrashPayloadJsonTest` to verify that the custom converter correctly includes the `Id` property in all relevant serialized objects.

**Minor improvements:**

* Cleaned up exception throwing in `FakeIMoveToTrashService` and other minor code style changes.

These changes ensure consistent and correct handling of the `Id` property for `FileIndexItem` objects throughout serialization processes, improving reliability and maintainability of the codebase.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
