### PR TITLE
add quotes

### DIFF
--- a/history.md
+++ b/history.md
@@ -43,6 +43,8 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## version 0.7.17 - _(Unreleased)_ - 2026-?-? {#v0.7.17}
 
+- [x] (Fixed) _Back-end_ MozJpeg Quoting `outputInputPath` issues with spaces in paths (PR #3015)
+- [x] (Fixed) _Back-end_ Local File System Copy Logic copy `CopyAllContent` (PR #3015)
 - [x] (Fixed) _Back-end_ Improving test reliability and diagnostics (PR #3014)
 - [x] (Fixed) _Back-end_ Add directory scan limit starskyMountWatchercli to avoid issues (PR #3013)
 - [x] (Fixed) _Back-end_ Add tests for ImportIgnore (PR #3013)

--- a/starsky/starsky.feature.webftppublish/Services/LocalFileSystemPublishService.cs
+++ b/starsky/starsky.feature.webftppublish/Services/LocalFileSystemPublishService.cs
@@ -107,7 +107,7 @@ public class LocalFileSystemPublishService(
 		// Create subdirectories
 		var selectedCopyContent = SelectContentToCopy(
 			copyContent,
-			setting);
+			setting).ToList();
 
 		foreach ( var copyItem in selectedCopyContent )
 		{
@@ -130,9 +130,7 @@ public class LocalFileSystemPublishService(
 		}
 
 		// Copy files
-		var filesToCopy = copyContent.Where(p => p.Value)
-			.Select(p => p.Key).ToList();
-		foreach ( var fileSubPath in filesToCopy )
+		foreach ( var fileSubPath in selectedCopyContent.Select(p => p.Key) )
 		{
 			var sourcePath = Path.Combine(sourceDirectory, fileSubPath);
 			var destPath = Path.Combine(destinationBasePath, fileSubPath);

--- a/starsky/starsky.foundation.optimisation/Services/MozJpegService.cs
+++ b/starsky/starsky.foundation.optimisation/Services/MozJpegService.cs
@@ -180,7 +180,7 @@ public class MozJpegService : IMozJpegService
 		List<string> arguments =
 		[
 			"-quality", optimizer.Options.Quality.ToString(),
-			"-optimize", outputInputPath
+			"-optimize", $"\"{outputInputPath}\""
 		];
 
 		var command = Default.Run(

--- a/starsky/starskytest/starsky.foundation.mountwatch/MountWatcher/BaseMountWatcherTest.cs
+++ b/starsky/starskytest/starsky.foundation.mountwatch/MountWatcher/BaseMountWatcherTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -39,13 +40,15 @@ public sealed class BaseMountWatcherTest
 		};
 		var detected = new List<string>();
 		var detectedLock = new object();
-		var detectedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var detectedTcs =
+			new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 		sut.MountDetected += (_, args) =>
 		{
 			lock ( detectedLock )
 			{
 				detected.Add(args.MountPath);
 			}
+
 			detectedTcs.TrySetResult(true);
 		};
 		sut.SetRunning(true);
@@ -54,7 +57,8 @@ public sealed class BaseMountWatcherTest
 		bool hasDetectedMount;
 		try
 		{
-			await detectedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+			await detectedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5),
+				TestContext.CancellationToken);
 			hasDetectedMount = true;
 		}
 		catch ( TimeoutException )
@@ -89,16 +93,20 @@ public sealed class BaseMountWatcherTest
 		sut.SetRunning(true);
 
 		var pollingTask = Task.Run(sut.RunPollingFallbackForTest, TestContext.CancellationToken);
-		bool reachedSecondRead;
+		var reachedSecondRead = false;
 		try
 		{
-			await sut.WaitForCallCountAsync(2, TimeSpan.FromSeconds(3),
-				TestContext.CancellationToken);
-			reachedSecondRead = true;
-		}
-		catch ( TimeoutException )
-		{
-			reachedSecondRead = false;
+			var sw = Stopwatch.StartNew();
+			while ( sw.Elapsed < TimeSpan.FromSeconds(3) )
+			{
+				if ( sut.GetMountedVolumesCallCount >= 2 )
+				{
+					reachedSecondRead = true;
+					break;
+				}
+
+				await Task.Delay(10, TestContext.CancellationToken);
+			}
 		}
 		finally
 		{
@@ -113,16 +121,15 @@ public sealed class BaseMountWatcherTest
 
 	private sealed class TestBaseMountWatcher : BaseMountWatcher
 	{
-		private readonly TaskCompletionSource<int> _readsObserved =
-			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private int _getMountedVolumesCallCount;
 
-		public TestBaseMountWatcher() : base(new FakeIWebLogger(),10)
+		public TestBaseMountWatcher() : base(new FakeIWebLogger(), 10)
 		{
 		}
 
 		public Queue<List<string>> Snapshots { get; set; } = new();
 		public int ThrowOnReadNumber { get; set; }
-		public int GetMountedVolumesCallCount { get; private set; }
+		public int GetMountedVolumesCallCount => Volatile.Read(ref _getMountedVolumesCallCount);
 
 		public override void Start()
 		{
@@ -134,13 +141,9 @@ public sealed class BaseMountWatcherTest
 
 		public override List<string> GetMountedVolumes()
 		{
-			GetMountedVolumesCallCount++;
-			if ( GetMountedVolumesCallCount >= 2 )
-			{
-				_readsObserved.TrySetResult(GetMountedVolumesCallCount);
-			}
+			var callCount = Interlocked.Increment(ref _getMountedVolumesCallCount);
 
-			if ( ThrowOnReadNumber > 0 && GetMountedVolumesCallCount == ThrowOnReadNumber )
+			if ( ThrowOnReadNumber > 0 && callCount == ThrowOnReadNumber )
 			{
 				throw new InvalidOperationException("simulated");
 			}
@@ -166,17 +169,6 @@ public sealed class BaseMountWatcherTest
 		public void RaiseMount(string mountPath)
 		{
 			OnMountDetected(mountPath);
-		}
-
-		public async Task WaitForCallCountAsync(int expectedCount, TimeSpan timeout,
-			CancellationToken cancellationToken)
-		{
-			if ( GetMountedVolumesCallCount >= expectedCount )
-			{
-				return;
-			}
-
-			await _readsObserved.Task.WaitAsync(timeout, cancellationToken);
 		}
 	}
 }


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request contains improvements and refactoring in both the `LocalFileSystemPublishService` and the `BaseMountWatcherTest` classes, as well as a small fix in the `MozJpegService`. The most significant changes focus on simplifying and making the mount watcher test code more robust and thread-safe, as well as minor bug fixes and code cleanup.

**Test and Thread Safety Improvements:**

* Refactored the `TestBaseMountWatcher` class in `BaseMountWatcherTest.cs` to use an atomic integer (`Interlocked.Increment` and `Volatile.Read`) for tracking the call count to `GetMountedVolumes`, improving thread safety and reliability of test assertions. Removed the now-unnecessary `WaitForCallCountAsync` method and related `TaskCompletionSource`. [[1]](diffhunk://#diff-e7d1d4ebdf2e1e5b2646910482d81dcf9cb122378c22b4a8b7526635dd654fc9L116-R132) [[2]](diffhunk://#diff-e7d1d4ebdf2e1e5b2646910482d81dcf9cb122378c22b4a8b7526635dd654fc9L137-R146) [[3]](diffhunk://#diff-e7d1d4ebdf2e1e5b2646910482d81dcf9cb122378c22b4a8b7526635dd654fc9L170-L180)
* Rewrote the polling logic in `BaseMountWatcher_RunPollingFallback_HandlesReadExceptions` to use a manual polling loop with a stopwatch instead of relying on the removed `WaitForCallCountAsync`, making the test more robust and explicit.

**Local File System Copy Logic:**

* Updated `CopyToLocalFileSystem` in `LocalFileSystemPublishService.cs` to ensure `SelectContentToCopy` returns a list, and refactored the file copying loop to iterate directly over the selected content, simplifying the logic and avoiding redundant filtering. [[1]](diffhunk://#diff-54c9f420e05dcf9f264631de26805cf19d28e46ab72f3611f4c76c601873a249L110-R110) [[2]](diffhunk://#diff-54c9f420e05dcf9f264631de26805cf19d28e46ab72f3611f4c76c601873a249L133-R133)

**Bug Fixes:**

* Fixed a bug in `MozJpegService.cs` by quoting the `outputInputPath` argument when invoking the optimizer command, ensuring correct handling of paths with spaces.

**Minor Code Cleanup:**

* Added a missing `using System.Diagnostics;` directive in `BaseMountWatcherTest.cs` to support the use of `Stopwatch`.
* Minor formatting improvements for readability in test code. [[1]](diffhunk://#diff-e7d1d4ebdf2e1e5b2646910482d81dcf9cb122378c22b4a8b7526635dd654fc9L42-R51) [[2]](diffhunk://#diff-e7d1d4ebdf2e1e5b2646910482d81dcf9cb122378c22b4a8b7526635dd654fc9L57-R61)

These changes collectively enhance code safety, clarity, and maintainability, especially in the test suite.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
