### PR TITLE
update csp

### DIFF
--- a/starsky/starsky.foundation.platform/Middleware/ContentSecurityPolicyMiddleware.cs
+++ b/starsky/starsky.foundation.platform/Middleware/ContentSecurityPolicyMiddleware.cs
@@ -84,7 +84,7 @@ public sealed class ContentSecurityPolicyMiddleware
 		if ( string.IsNullOrEmpty(httpContext.Response.Headers["Referrer-Policy"]) )
 		{
 			httpContext.Response.Headers
-				.Append("Referrer-Policy", "no-referrer");
+				.Append("Referrer-Policy", "strict-origin-when-cross-origin");
 		}
 
 		if ( string.IsNullOrEmpty(httpContext.Response.Headers.XFrameOptions) )

--- a/starsky/starskytest/starsky.foundation.platform/Middleware/ContentSecurityPolicyMiddlewareTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Middleware/ContentSecurityPolicyMiddlewareTest.cs
@@ -122,7 +122,7 @@ public sealed class ContentSecurityPolicyMiddlewareTest
 
 		// test
 		var referrerPolicy = httpContext.Response.Headers["Referrer-Policy"].ToString();
-		Assert.AreEqual("no-referrer", referrerPolicy);
+		Assert.AreEqual("strict-origin-when-cross-origin", referrerPolicy);
 
 		var frameOptions = httpContext.Response.Headers.XFrameOptions.ToString();
 		Assert.AreEqual("DENY", frameOptions);


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request updates the default value for the `Referrer-Policy` HTTP header in the content security policy middleware to use a stricter policy. The associated test has also been updated to reflect this change.

Security policy update:

* Changed the default `Referrer-Policy` header value from `"no-referrer"` to `"strict-origin-when-cross-origin"` in `ContentSecurityPolicyMiddleware.cs` to enhance privacy and security.

Test update:

* Updated the corresponding test in `ContentSecurityPolicyMiddlewareTest.cs` to expect the new `Referrer-Policy` value.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
