### PR TITLE
StackCollections drops non-thumbnail collections

### DIFF
--- a/history.md
+++ b/history.md
@@ -43,6 +43,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 ## version 0.7.22 - _(Unreleased)_ - 2026-?-? {#v0.7.22}
 
 - [x] (Changed) _Back-end_ Switch TinyIcon format from PNG to WebP for better compression (PR #3188)
+- [x] (Fixed) _Back-end_ StackCollections drops non-thumbnail collections (PR #3196)
 
 ## version 0.7.21 - 2026-07-22 {#v0.7.21}
 

--- a/starsky/starsky.foundation.database/Query/QueryCollections.cs
+++ b/starsky/starsky.foundation.database/Query/QueryCollections.cs
@@ -30,11 +30,25 @@ public partial class Query // QueryCollections
 			var duplicateItems = databaseSubFolderList.Where(p =>
 				p.FileCollectionName == stackItemByName.FileCollectionName).ToList();
 
-			// The idea to pick thumbnail based images first, followed by non-thumb supported
-			// when not pick alphabetically
+			// Pick thumbnail based images first; fall back to first alphabetically so that
+			// collections with no thumbnail-supported member (e.g. ARW+DNG) are not dropped.
+			var thumbnailItems = duplicateItems
+				.Where(item =>
+					ExtensionRolesHelper.IsExtensionImageSharpThumbnailSupported(item.FileName))
+				.ToList();
 
-			querySubFolderList.AddRange(duplicateItems.Where(item =>
-				ExtensionRolesHelper.IsExtensionImageSharpThumbnailSupported(item.FileName)));
+			if ( thumbnailItems.Count != 0 )
+			{
+				querySubFolderList.AddRange(thumbnailItems);
+			}
+			else
+			{
+				var fallback = duplicateItems.MinBy(item => item.FileName);
+				if ( fallback != null )
+				{
+					querySubFolderList.Add(fallback);
+				}
+			}
 		}
 
 		return AddNonDuplicateBackToList(databaseSubFolderList, stackItemsByFileCollectionName,

--- a/starsky/starskytest/starsky.foundation.database/QueryTest/QueryCollectionsTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/QueryTest/QueryCollectionsTest.cs
@@ -27,4 +27,27 @@ public class QueryCollectionsTest
 		Assert.HasCount(1, result);
 		Assert.AreEqual("/test.jpg", result[0].FilePath);
 	}
+
+	[TestMethod]
+	public void QueryCollections_StackCollections_NoThumbnailSupported_FallsBackToFirst()
+	{
+		// Both ARW and DNG are RAW — neither is IsExtensionImageSharpThumbnailSupported.
+		// Previously the whole group was silently dropped; now the alphabetically first is kept.
+		var input = new List<FileIndexItem> { new("/test.arw"), new("/test.dng") };
+		var result = Query.StackCollections(input);
+
+		Assert.HasCount(1, result);
+		Assert.AreEqual("/test.arw", result[0].FilePath);
+	}
+
+	[TestMethod]
+	public void QueryCollections_StackCollections_SingleRaw_PassesThrough()
+	{
+		// A lone RAW file (no collection partner) should always pass through unchanged.
+		var input = new List<FileIndexItem> { new("/test.arw") };
+		var result = Query.StackCollections(input);
+
+		Assert.HasCount(1, result);
+		Assert.AreEqual("/test.arw", result[0].FilePath);
+	}
 }


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request improves the handling of file collections in the `StackCollections` method to ensure that collections without thumbnail-supported images are not dropped, and adds corresponding tests to verify this behavior.

### Improvements to collection stacking logic

* Updated `StackCollections` in `QueryCollections.cs` to select the alphabetically first file when no thumbnail-supported image is present in a collection, ensuring collections like ARW+DNG are not omitted.

### Test coverage

* Added tests in `QueryCollectionsTest.cs` to verify that collections with only non-thumbnail-supported files retain the alphabetically first file, and that single RAW files pass through unchanged.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
