### PR TITLE
feature/202608-SearchSuggestionsService fix

### DIFF
--- a/starsky/starsky.feature.search/Services/SearchSuggestionsService.cs
+++ b/starsky/starsky.feature.search/Services/SearchSuggestionsService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -40,11 +39,6 @@ public class SearchSuggestionsService : ISearchSuggest
 	///     All keywords are stored lowercase
 	/// </summary>
 	/// <returns></returns>
-	[SuppressMessage("Performance",
-		"CA1827:Do not use Count() or LongCount() when Any() can be used")]
-	[SuppressMessage("Performance",
-		"S1155:Do not use Count() or LongCount() when Any() can be used",
-		Justification = "ANY is not supported by EF Core")]
 	public async Task<List<KeyValuePair<string, int>>> Inflate()
 	{
 		if ( _cache == null )
@@ -57,18 +51,24 @@ public class SearchSuggestionsService : ISearchSuggest
 			return new Dictionary<string, int>().ToList();
 		}
 
-		var allFilesList = new List<KeyValuePair<string, int>>();
+		// Select only Tags and stream via AsAsyncEnumerable so EF Core's internal buffer
+		// holds one column instead of full rows, and no extra List<string> is allocated.
+		var suggestions = new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase);
 		try
 		{
-			allFilesList = await _context.FileIndex
-				.AsNoTracking()
-				.Where(p => !string.IsNullOrEmpty(p.Tags))
-				.GroupBy(i => i.Tags)
-				// ReSharper disable once UseMethodAny.1
-				.Where(x => x.Count() >= 1) // .ANY is not supported by EF Core
-				.TagWith("Inflate SearchSuggestionsService")
-				.Select(val =>
-					new KeyValuePair<string, int>(val.Key!, val.Count())).ToListAsync();
+			await foreach ( var tagsString in _context.FileIndex
+				               .AsNoTracking()
+				               .Where(p => !string.IsNullOrEmpty(p.Tags))
+				               .Select(p => p.Tags!)
+				               .TagWith("Inflate SearchSuggestionsService")
+				               .AsAsyncEnumerable() )
+			{
+				foreach ( var keyword in HashSetHelper.StringToHashSet(tagsString.Trim()) )
+				{
+					suggestions.TryGetValue(keyword, out var count);
+					suggestions[keyword] = count + 1;
+				}
+			}
 		}
 		catch ( Exception exception )
 		{
@@ -78,32 +78,7 @@ public class SearchSuggestionsService : ISearchSuggest
 					$"[SearchSuggestionsService] exception catch-ed {exception.Message} {exception.StackTrace}");
 			}
 
-			return allFilesList;
-		}
-
-		var suggestions =
-			new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase);
-
-		foreach ( var tag in allFilesList )
-		{
-			if ( string.IsNullOrEmpty(tag.Key) )
-			{
-				continue;
-			}
-
-			var keywordsHashSet = HashSetHelper.StringToHashSet(tag.Key.Trim());
-
-			foreach ( var keyword in keywordsHashSet )
-			{
-				if ( suggestions.ContainsKey(keyword) )
-				{
-					suggestions[keyword] += tag.Value;
-				}
-				else
-				{
-					suggestions.Add(keyword, tag.Value);
-				}
-			}
+			return [];
 		}
 
 		var suggestionsFiltered = suggestions

--- a/starsky/starsky.feature.search/Services/SearchSuggestionsService.cs
+++ b/starsky/starsky.feature.search/Services/SearchSuggestionsService.cs
@@ -63,6 +63,11 @@ public class SearchSuggestionsService : ISearchSuggest
 				               .TagWith("Inflate SearchSuggestionsService")
 				               .AsAsyncEnumerable() )
 			{
+				if ( string.IsNullOrEmpty(tagsString) )
+				{
+					continue;
+				}
+
 				foreach ( var keyword in HashSetHelper.StringToHashSet(tagsString.Trim()) )
 				{
 					suggestions.TryGetValue(keyword, out var count);


### PR DESCRIPTION
…before grouping — same problem, different shape. The correct approach is to stream with AsAsyncEnumerable() and write directly into the suggestions dictionary, skipping the intermediate list entirely. EF Core's BufferedDataReader still buffers the raw column data internally, but at least we avoid the second allocation (the List<string> + the GroupBy structure on top).

This also lets us collapse the two-phase loop (build allFilesList, then iterate it) into one pass:

Read and edited SearchSuggestionsService.cs
+17
-41
Now we can also drop the unused Microsoft.EntityFrameworkCore (for ToListAsync) — but AsAsyncEnumerable is in the same namespace, so it stays. Let's verify the build:

Built to check for compile errors
Let me run the existing tests to confirm no regressions:

Ran SearchSuggestionsServiceTest tests
All 8 tests pass. Here's what the final version does:

What changed: The entire allFilesList intermediate structure is gone. We now stream Tags strings from EF Core with AsAsyncEnumerable() and fold each one directly into the suggestions dictionary in a single pass.

Memory profile:

Original: EF Core buffer (full rows × 300k) + List<KVP<string,int>> (allFilesList) + Dictionary<string,int> (suggestions) — three copies alive simultaneously Previous fix: EF Core buffer (Tags column × 300k) + List<string> (tagStrings) + LINQ GroupBy structure + List<KVP> + dictionary — still a lot Now: EF Core buffer (Tags column × 300k, internal/opaque) + the suggestions dictionary only — two things instead of five, and the dictionary grows to a few thousand unique keywords, not 300k entries The EF Core BufferedDataReader still reads all rows before yielding the first one (that's an EF Core internal detail for thread safety), but the raw column buffer is much smaller than full rows and no .NET-managed list is layered on top of it.

# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
