### PR TITLE
The root cause: blur() triggers a FetchPost to /starsky/api/update as…

### DIFF
--- a/starsky-tools/end2end/cypress/e2e/40-detailview-from-upload/detailview-from-upload.cy.ts
+++ b/starsky-tools/end2end/cypress/e2e/40-detailview-from-upload/detailview-from-upload.cy.ts
@@ -127,9 +127,7 @@ describe('DetailView (from upload) (40)', () => {
     }).then(() => {
       // and now we going back to the orginal state
       cy.intercept('POST', '**/api/update').as('cleanupUpdate')
-      cy.get(tagFileSelector).then(($el) => {
-        ($el[0] as HTMLElement).textContent = sourceTags
-      })
+      cy.get(tagFileSelector).type('{end}' + '{backspace}'.repeat(appendText.length))
       cy.get(tagFileSelector).blur()
       cy.wait('@cleanupUpdate')
     }).then(() => {

--- a/starsky-tools/end2end/cypress/e2e/40-detailview-from-upload/detailview-from-upload.cy.ts
+++ b/starsky-tools/end2end/cypress/e2e/40-detailview-from-upload/detailview-from-upload.cy.ts
@@ -127,7 +127,9 @@ describe('DetailView (from upload) (40)', () => {
     }).then(() => {
       // and now we going back to the orginal state
       cy.intercept('POST', '**/api/update').as('cleanupUpdate')
-      cy.get(tagFileSelector).type('{backspace}'.repeat(appendText.length))
+      cy.get(tagFileSelector).then(($el) => {
+        ($el[0] as HTMLElement).textContent = sourceTags
+      })
       cy.get(tagFileSelector).blur()
       cy.wait('@cleanupUpdate')
     }).then(() => {

--- a/starsky-tools/end2end/cypress/e2e/40-detailview-from-upload/detailview-from-upload.cy.ts
+++ b/starsky-tools/end2end/cypress/e2e/40-detailview-from-upload/detailview-from-upload.cy.ts
@@ -126,8 +126,10 @@ describe('DetailView (from upload) (40)', () => {
       cy.get(tagFileSelector).should('contain', sourceTags)
     }).then(() => {
       // and now we going back to the orginal state
+      cy.intercept('POST', '**/api/update').as('cleanupUpdate')
       cy.get(tagFileSelector).type('{backspace}'.repeat(appendText.length))
       cy.get(tagFileSelector).blur()
+      cy.wait('@cleanupUpdate')
     }).then(() => {
       sessionStorage.clear()
       cy.reload()


### PR DESCRIPTION
…ynchronously, but nothing in the test waited for that network round-trip to complete before cy.reload(). On Linux the latency is low enough that the save lands first; on Windows it doesn't.

# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
