### PR TITLE
Feature/202608 exiftool guard

### DIFF
--- a/history.md
+++ b/history.md
@@ -42,6 +42,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## version 0.8.0-beta.1 - _(Unreleased)_ 2026-?-? {#v0.8.0-beta.1}
 
+- [x] (Changed) _Back-end_ Add guard around Exiftool to auto download (PR #3223)
 - [x] (Changed) _Back-end_ Add IOException AppSettings (PR #3222)
 
 ## version 0.8.0-beta.0 - 2026-08-20 {#v0.8.0-beta.0}

--- a/starsky/starsky.foundation.writemeta/Services/ExifToolService.cs
+++ b/starsky/starsky.foundation.writemeta/Services/ExifToolService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using starsky.foundation.injection;
@@ -14,11 +15,18 @@ namespace starsky.foundation.writemeta.Services;
 [Service(typeof(IExifTool), InjectionLifetime = InjectionLifetime.Scoped)]
 public sealed class ExifToolService : IExifTool
 {
+	private readonly AppSettings _appSettings;
+	private readonly IExifToolDownload _exifToolDownload;
 	private readonly ExifTool _exifTool;
+	private readonly IWebLogger _logger;
 
 	public ExifToolService(ISelectorStorage selectorStorage,
-		AppSettings appSettings, IWebLogger logger)
+		AppSettings appSettings, IWebLogger logger,
+		IExifToolDownload exifToolDownload)
 	{
+		_appSettings = appSettings;
+		_exifToolDownload = exifToolDownload;
+		_logger = logger;
 		var iStorage =
 			selectorStorage.Get(SelectorStorage.StorageServices.SubPath);
 		var thumbnailStorage =
@@ -29,7 +37,15 @@ public sealed class ExifToolService : IExifTool
 
 	public async Task<bool> WriteTagsAsync(string subPath, string command)
 	{
-		return await _exifTool.WriteTagsAsync(subPath, command);
+		try
+		{
+			return await _exifTool.WriteTagsAsync(subPath, command);
+		}
+		catch ( ArgumentException )
+		{
+			await RunSetupAsync();
+			return await _exifTool.WriteTagsAsync(subPath, command);
+		}
 	}
 
 	public async Task<ExifToolWriteTagsAndRenameThumbnailModel>
@@ -37,13 +53,36 @@ public sealed class ExifToolService : IExifTool
 			string? beforeFileHash, string command,
 			CancellationToken cancellationToken = default)
 	{
-		return await _exifTool.WriteTagsAndRenameThumbnailAsync(subPath,
-			beforeFileHash, command, cancellationToken);
+		try
+		{
+			return await _exifTool.WriteTagsAndRenameThumbnailAsync(subPath,
+				beforeFileHash, command, cancellationToken);
+		}
+		catch ( ArgumentException )
+		{
+			await RunSetupAsync();
+			return await _exifTool.WriteTagsAndRenameThumbnailAsync(subPath,
+				beforeFileHash, command, cancellationToken);
+		}
 	}
 
 	public async Task<bool> WriteTagsThumbnailAsync(string fileHash,
 		string command)
 	{
-		return await _exifTool.WriteTagsThumbnailAsync(fileHash, command);
+		try
+		{
+			return await _exifTool.WriteTagsThumbnailAsync(fileHash, command);
+		}
+		catch ( ArgumentException )
+		{
+			await RunSetupAsync();
+			return await _exifTool.WriteTagsThumbnailAsync(fileHash, command);
+		}
+	}
+
+	private async Task RunSetupAsync()
+	{
+		_logger.LogInformation("[ExifToolService] ExifTool binary missing — re-running setup");
+		await _exifToolDownload.DownloadExifTool(_appSettings.IsWindows);
 	}
 }

--- a/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolTest.cs
@@ -72,7 +72,7 @@ public sealed class ExifToolTest
 			new List<byte[]> { CreateAnImage.Bytes.ToArray() });
 
 		var sut = new ExifToolService(new FakeSelectorStorage(fakeStorage), appSettings,
-			new FakeIWebLogger());
+			new FakeIWebLogger(), new FakeExifToolDownload());
 
 		await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
 			await sut.WriteTagsAsync("/test.jpg", "-Software=\"Qdraw 2.0\""));
@@ -88,7 +88,7 @@ public sealed class ExifToolTest
 			new List<byte[]> { CreateAnImage.Bytes.ToArray() });
 
 		var sut = new ExifToolService(new FakeSelectorStorage(fakeStorage), appSettings,
-			new FakeIWebLogger());
+			new FakeIWebLogger(), new FakeExifToolDownload());
 
 		await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
 			await sut.WriteTagsAsync("/test.jpg", "-Software=\"Qdraw 2.0\""));

--- a/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolServiceTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolServiceTest.cs
@@ -21,10 +21,13 @@ public class ExifToolServiceTest
 {
 	private static readonly string ExifToolPath =
 		Path.Join(new CreateAnImage().BasePath, "exiftool-service-test-tmp");
+
 	private static readonly string RetryExifToolPath =
 		Path.Join(new CreateAnImage().BasePath, "exiftool-service-retry-test-tmp");
+
 	private static readonly string WriteTagsRetryExifToolPath =
 		Path.Join(new CreateAnImage().BasePath, "exiftool-service-write-tags-retry-test-tmp");
+
 	private static readonly string ThumbnailRetryExifToolPath =
 		Path.Join(new CreateAnImage().BasePath, "exiftool-service-thumbnail-retry-test-tmp");
 
@@ -37,6 +40,8 @@ public class ExifToolServiceTest
 
 		CreateFile();
 	}
+
+	public TestContext TestContext { get; set; }
 
 	private static void CreateFile(string? path = null)
 	{
@@ -182,7 +187,7 @@ public class ExifToolServiceTest
 			download);
 
 		var result = await service.WriteTagsAndRenameThumbnailAsync("/image.jpg",
-			null, "");
+			null, "", TestContext.CancellationToken);
 
 		Assert.IsTrue(result.IsSuccess);
 		Assert.AreEqual(1, download.Called);

--- a/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolServiceTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolServiceTest.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using starsky.foundation.platform.Models;
 using starsky.foundation.storage.Helpers;
 using starsky.foundation.storage.Storage;
+using starsky.foundation.writemeta.Interfaces;
 using starsky.foundation.writemeta.Services;
 using starskytest.FakeCreateAn;
 using starskytest.FakeMocks;
@@ -20,6 +21,8 @@ public class ExifToolServiceTest
 {
 	private static readonly string ExifToolPath =
 		Path.Join(new CreateAnImage().BasePath, "exiftool-service-test-tmp");
+	private static readonly string RetryExifToolPath =
+		Path.Join(new CreateAnImage().BasePath, "exiftool-service-retry-test-tmp");
 
 	public ExifToolServiceTest()
 	{
@@ -31,14 +34,28 @@ public class ExifToolServiceTest
 		CreateFile();
 	}
 
-	private static void CreateFile()
+	private static void CreateFile(string? path = null)
 	{
+		path ??= ExifToolPath;
 		var stream = StringToStreamHelper.StringToStream("#!/bin/bash\necho Fake ExifTool");
-		new StorageHostFullPathFilesystem(new FakeIWebLogger()).WriteStream(stream,
-			ExifToolPath);
+		new StorageHostFullPathFilesystem(new FakeIWebLogger()).WriteStream(stream, path);
 
 		var result = Command.Run("chmod", "+x",
-			ExifToolPath).Task.Result;
+			path).Task.Result;
+		if ( !result.Success )
+		{
+			throw new FileNotFoundException(result.StandardError);
+		}
+	}
+
+	private static void CreatePassingFile(string? path = null)
+	{
+		path ??= ExifToolPath;
+		var stream = StringToStreamHelper.StringToStream("#!/bin/bash\ncat");
+		new StorageHostFullPathFilesystem(new FakeIWebLogger()).WriteStream(stream, path);
+
+		var result = Command.Run("chmod", "+x",
+			path).Task.Result;
 		if ( !result.Success )
 		{
 			throw new FileNotFoundException(result.StandardError);
@@ -51,6 +68,11 @@ public class ExifToolServiceTest
 		if ( File.Exists(ExifToolPath) )
 		{
 			File.Delete(ExifToolPath);
+		}
+
+		if ( File.Exists(RetryExifToolPath) )
+		{
+			File.Delete(RetryExifToolPath);
 		}
 	}
 
@@ -125,5 +147,54 @@ public class ExifToolServiceTest
 		{
 			await service.WriteTagsAndRenameThumbnailAsync("/image.jpg", null, "", token);
 		});
+	}
+
+	[TestMethod]
+	public async Task WriteTagsAndRenameThumbnailAsync_RetriesAfterArgumentException__UnixOnly()
+	{
+		if ( new AppSettings().IsWindows )
+		{
+			Assert.Inconclusive("This test is for Unix Only");
+			return;
+		}
+
+		var storage = new FakeIStorage(["/"],
+			["/image.jpg"],
+			new List<byte[]> { CreateAnImage.Bytes.ToArray() });
+
+		var download = new CreateExifToolOnDownload(RetryExifToolPath);
+		var service = new ExifToolService(new FakeSelectorStorage(storage),
+			new AppSettings { ExifToolPath = RetryExifToolPath }, new FakeIWebLogger(),
+			download);
+
+		var result = await service.WriteTagsAndRenameThumbnailAsync("/image.jpg",
+			null, "");
+
+		Assert.IsTrue(result.IsSuccess);
+		Assert.AreEqual(1, download.Called);
+	}
+
+	private sealed class CreateExifToolOnDownload : IExifToolDownload
+	{
+		private readonly string _exifToolPath;
+
+		public CreateExifToolOnDownload(string exifToolPath)
+		{
+			_exifToolPath = exifToolPath;
+		}
+
+		public int Called { get; private set; }
+
+		public Task<List<bool>> DownloadExifTool(List<string> architectures)
+		{
+			throw new NotImplementedException();
+		}
+
+		public async Task<bool> DownloadExifTool(bool isWindows, int minimumSize = 30)
+		{
+			Called++;
+			CreatePassingFile(_exifToolPath);
+			return await Task.FromResult(true);
+		}
 	}
 }

--- a/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolServiceTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolServiceTest.cs
@@ -23,6 +23,8 @@ public class ExifToolServiceTest
 		Path.Join(new CreateAnImage().BasePath, "exiftool-service-test-tmp");
 	private static readonly string RetryExifToolPath =
 		Path.Join(new CreateAnImage().BasePath, "exiftool-service-retry-test-tmp");
+	private static readonly string ThumbnailRetryExifToolPath =
+		Path.Join(new CreateAnImage().BasePath, "exiftool-service-thumbnail-retry-test-tmp");
 
 	public ExifToolServiceTest()
 	{
@@ -73,6 +75,11 @@ public class ExifToolServiceTest
 		if ( File.Exists(RetryExifToolPath) )
 		{
 			File.Delete(RetryExifToolPath);
+		}
+
+		if ( File.Exists(ThumbnailRetryExifToolPath) )
+		{
+			File.Delete(ThumbnailRetryExifToolPath);
 		}
 	}
 
@@ -171,6 +178,31 @@ public class ExifToolServiceTest
 			null, "");
 
 		Assert.IsTrue(result.IsSuccess);
+		Assert.AreEqual(1, download.Called);
+	}
+
+	[TestMethod]
+	public async Task WriteTagsThumbnailAsync_RetriesAfterArgumentException__UnixOnly()
+	{
+		if ( new AppSettings().IsWindows )
+		{
+			Assert.Inconclusive("This test is for Unix Only");
+			return;
+		}
+
+		var storage = new FakeIStorage(["/"],
+			["/hash.jpg"],
+			new List<byte[]> { CreateAnImage.Bytes.ToArray() });
+
+		var download = new CreateExifToolOnDownload(ThumbnailRetryExifToolPath);
+		var service = new ExifToolService(new FakeSelectorStorage(storage),
+			new AppSettings { ExifToolPath = ThumbnailRetryExifToolPath },
+			new FakeIWebLogger(), download);
+
+		var result = await service.WriteTagsThumbnailAsync("/hash.jpg",
+			"-Software=\"Qdraw 2.0\"");
+
+		Assert.IsTrue(result);
 		Assert.AreEqual(1, download.Called);
 	}
 

--- a/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolServiceTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolServiceTest.cs
@@ -63,7 +63,8 @@ public class ExifToolServiceTest
 		CreateFile();
 
 		var service = new ExifToolService(new FakeSelectorStorage(storage),
-			new AppSettings { ExifToolPath = ExifToolPath }, new FakeIWebLogger());
+			new AppSettings { ExifToolPath = ExifToolPath }, new FakeIWebLogger(),
+			new FakeExifToolDownload());
 		var result = await service.WriteTagsAndRenameThumbnailAsync(
 			"/image.jpg",
 			null, "");
@@ -111,7 +112,8 @@ public class ExifToolServiceTest
 		var service = new ExifToolService(
 			new FakeSelectorStorage(storage),
 			new AppSettings { ExifToolPath = ExifToolPath },
-			new FakeIWebLogger()
+			new FakeIWebLogger(),
+			new FakeExifToolDownload()
 		);
 
 		using var cancelSource = new CancellationTokenSource();

--- a/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolServiceTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Services/ExifToolServiceTest.cs
@@ -23,6 +23,8 @@ public class ExifToolServiceTest
 		Path.Join(new CreateAnImage().BasePath, "exiftool-service-test-tmp");
 	private static readonly string RetryExifToolPath =
 		Path.Join(new CreateAnImage().BasePath, "exiftool-service-retry-test-tmp");
+	private static readonly string WriteTagsRetryExifToolPath =
+		Path.Join(new CreateAnImage().BasePath, "exiftool-service-write-tags-retry-test-tmp");
 	private static readonly string ThumbnailRetryExifToolPath =
 		Path.Join(new CreateAnImage().BasePath, "exiftool-service-thumbnail-retry-test-tmp");
 
@@ -75,6 +77,11 @@ public class ExifToolServiceTest
 		if ( File.Exists(RetryExifToolPath) )
 		{
 			File.Delete(RetryExifToolPath);
+		}
+
+		if ( File.Exists(WriteTagsRetryExifToolPath) )
+		{
+			File.Delete(WriteTagsRetryExifToolPath);
 		}
 
 		if ( File.Exists(ThumbnailRetryExifToolPath) )
@@ -178,6 +185,31 @@ public class ExifToolServiceTest
 			null, "");
 
 		Assert.IsTrue(result.IsSuccess);
+		Assert.AreEqual(1, download.Called);
+	}
+
+	[TestMethod]
+	public async Task WriteTagsAsync_RetriesAfterArgumentException__UnixOnly()
+	{
+		if ( new AppSettings().IsWindows )
+		{
+			Assert.Inconclusive("This test is for Unix Only");
+			return;
+		}
+
+		var storage = new FakeIStorage(["/"],
+			["/image.jpg"],
+			new List<byte[]> { CreateAnImage.Bytes.ToArray() });
+
+		var download = new CreateExifToolOnDownload(WriteTagsRetryExifToolPath);
+		var service = new ExifToolService(new FakeSelectorStorage(storage),
+			new AppSettings { ExifToolPath = WriteTagsRetryExifToolPath },
+			new FakeIWebLogger(), download);
+
+		var result = await service.WriteTagsAsync("/image.jpg",
+			"-Software=\"Qdraw 2.0\"");
+
+		Assert.IsTrue(result);
 		Assert.AreEqual(1, download.Called);
 	}
 


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request adds a guard to the `ExifToolService` to automatically download the ExifTool binary if it is missing, improving reliability and user experience. It also updates related unit tests to support and verify this new behavior.

**Enhancements to ExifToolService error handling and recovery:**

* [`ExifToolService`](diffhunk://#diff-bbf09bebef376029d4dd72b9f7e99d9582bee38ab86ca88227d2a10e5fee6241R18-R29): Now catches `ArgumentException` when ExifTool is missing, triggers a download of the binary via `IExifToolDownload`, and retries the operation. This applies to `WriteTagsAsync`, `WriteTagsAndRenameThumbnailAsync`, and `WriteTagsThumbnailAsync` methods. [[1]](diffhunk://#diff-bbf09bebef376029d4dd72b9f7e99d9582bee38ab86ca88227d2a10e5fee6241R18-R29) [[2]](diffhunk://#diff-bbf09bebef376029d4dd72b9f7e99d9582bee38ab86ca88227d2a10e5fee6241R39-R88)
* Introduced a new private method `RunSetupAsync` to handle the download and logging when ExifTool is missing.

**Dependency injection and constructor changes:**

* The `ExifToolService` constructor now requires an `IExifToolDownload` dependency, and this is reflected in all usages and tests. [[1]](diffhunk://#diff-bbf09bebef376029d4dd72b9f7e99d9582bee38ab86ca88227d2a10e5fee6241R18-R29) [[2]](diffhunk://#diff-26fbb7aa534a0d188b8b27a8d3aac167f970e37d079e996278653403fe0852c7L75-R75) [[3]](diffhunk://#diff-26fbb7aa534a0d188b8b27a8d3aac167f970e37d079e996278653403fe0852c7L91-R91) [[4]](diffhunk://#diff-8606d13f08e4ee9a17805f33130661a4c7bd1a58650a01b1f8fd4eac724618f7L66-R89) [[5]](diffhunk://#diff-8606d13f08e4ee9a17805f33130661a4c7bd1a58650a01b1f8fd4eac724618f7L114-R138)

**Unit test updates and additions:**

* Updated existing tests to use a fake implementation of `IExifToolDownload` to support the new constructor and logic. [[1]](diffhunk://#diff-26fbb7aa534a0d188b8b27a8d3aac167f970e37d079e996278653403fe0852c7L75-R75) [[2]](diffhunk://#diff-26fbb7aa534a0d188b8b27a8d3aac167f970e37d079e996278653403fe0852c7L91-R91) [[3]](diffhunk://#diff-8606d13f08e4ee9a17805f33130661a4c7bd1a58650a01b1f8fd4eac724618f7L66-R89) [[4]](diffhunk://#diff-8606d13f08e4ee9a17805f33130661a4c7bd1a58650a01b1f8fd4eac724618f7L114-R138)
* Added a new test, `WriteTagsAndRenameThumbnailAsync_RetriesAfterArgumentException__UnixOnly`, to verify that the service retries and succeeds after recovering from a missing ExifTool binary.
* Added utility methods and cleanup logic to support testing different ExifTool binary states. [[1]](diffhunk://#diff-8606d13f08e4ee9a17805f33130661a4c7bd1a58650a01b1f8fd4eac724618f7R24-R25) [[2]](diffhunk://#diff-8606d13f08e4ee9a17805f33130661a4c7bd1a58650a01b1f8fd4eac724618f7L34-R58) [[3]](diffhunk://#diff-8606d13f08e4ee9a17805f33130661a4c7bd1a58650a01b1f8fd4eac724618f7R72-R76)

**Documentation:**

* Updated `history.md` to document the new auto-download guard feature.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
