### PR TITLE
add longer timeout

### DIFF
--- a/starsky-tools/end2end/cypress/e2e/60-multi-file-move/60-multi-file-move.cy.ts
+++ b/starsky-tools/end2end/cypress/e2e/60-multi-file-move/60-multi-file-move.cy.ts
@@ -130,7 +130,7 @@ describe("Delete file from upload (50)", () => {
     cy.get("[data-test=parent]").click();
    cy.get("[data-test=modal-move-file-btn-default]").click();
 
-    cy.url().should('match', /\?f=\/starsky-end2end-test\/20200822_134151.jpg$/);
+    cy.url({ timeout: 10000 }).should('match', /\?f=\/starsky-end2end-test\/20200822_134151.jpg$/);
   });
 
 


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request makes a small improvement to the end-to-end test for deleting a file from upload. The test now waits up to 10 seconds for the URL to update, increasing reliability in case of slow responses.

* Increased the timeout for the URL assertion in the `Delete file from upload (50)` test to 10 seconds by passing a `{ timeout: 10000 }` option to `cy.url()`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
