### PR TITLE
Feature/202608 backspace macos

### DIFF
--- a/history.md
+++ b/history.md
@@ -40,9 +40,13 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## List of versions
 
-## version 0.9.0-beta.0 - _(Unreleased)_ - 2026-?-? {#0.9.0-beta.0}
+## version 0.9.0-beta.1 - _(Unreleased)_ - 2026-?-? {#0.9.0-beta.1}
 
-- [x] (Added) _App_ Swift-based MacOS desktop app instead of Electron (PR #3238)
+- [x] (Fixed) _App_ prevent accidental navigation when the backspace key (PR #3251)
+
+## version 0.9.0-beta.0 - 2026-08-31 {#0.9.0-beta.0}
+
+- [x] (Added) _App_ Swift-based macOS desktop app instead of Electron (PR #3238)
 - [x] (Added) _App_ WPF-based Windows desktop app instead of Electron (PR #3234)
 
 ## version 0.8.2 - 2026-08-27 {#v0.8.2}

--- a/history.md
+++ b/history.md
@@ -42,6 +42,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## version 0.9.0-beta.1 - _(Unreleased)_ - 2026-?-? {#0.9.0-beta.1}
 
+- [x] (Added) _App_ Align menu's in Windows with macOS (PR #3243)
 - [x] (Fixed) _App_ prevent accidental navigation when the backspace key (PR #3251)
 
 ## version 0.9.0-beta.0 - 2026-08-31 {#0.9.0-beta.0}

--- a/mac/starsky/App/AppCore.swift
+++ b/mac/starsky/App/AppCore.swift
@@ -107,7 +107,6 @@ class AppCore {
             return
         }
 
-        await splashStatus("Checking version compatibility…")
         let compatible = await checkVersionCompatibility(baseUrl: baseUrl)
         NSLog("[startup] version compatible=\(compatible)")
         guard compatible else {

--- a/mac/starsky/Windows/MainWindowController.swift
+++ b/mac/starsky/Windows/MainWindowController.swift
@@ -27,16 +27,20 @@ class SilentWebView: WKWebView {
             if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' ||
                        el.isContentEditable ||
                        el.getAttribute('contenteditable') === 'true')) return;
+            var sel = window.getSelection && window.getSelection();
+            if (sel && sel.rangeCount > 0) {
+                var node = sel.getRangeAt(0).commonAncestorContainer;
+                if (node.nodeType === 3) node = node.parentElement;
+                while (node) {
+                    if (node.isContentEditable) return;
+                    node = node.parentElement;
+                }
+            }
             e.preventDefault();
         }, false);
         """
 
     override func noResponder(for _: Selector) {}
-
-    override func doCommand(by _: Selector) {
-        // Unhandled nav keys come back through interpretKeyEvents → doCommand.
-        // Calling super beeps; doing nothing silences it.
-    }
 }
 
 class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDelegate, WKUIDelegate, MainWindowView { // NOSONAR swift:S7485

--- a/mac/starsky/Windows/MainWindowController.swift
+++ b/mac/starsky/Windows/MainWindowController.swift
@@ -13,7 +13,7 @@ private class SilentWindow: NSWindow {
     }
 }
 
-private class SilentWebView: WKWebView {
+class SilentWebView: WKWebView {
     override func noResponder(for _: Selector) {
         // Intentionally empty: suppresses the default NSBeep() emitted when no responder handles an event. (comment should be inside the override, not outside)
     }

--- a/mac/starsky/Windows/MainWindowController.swift
+++ b/mac/starsky/Windows/MainWindowController.swift
@@ -14,27 +14,28 @@ private class SilentWindow: NSWindow {
 }
 
 class SilentWebView: WKWebView {
-    override func noResponder(for _: Selector) {
-        // Intentionally empty: suppresses the default NSBeep() emitted when no responder handles an event. (comment should be inside the override, not outside)
-    }
+    // Injected at document-start to prevent Backspace from triggering WKWebView's
+    // native go-back navigation and to suppress the NSBeep for unhandled nav keys.
+    // Exported as a static so tests can assert on the script source.
+    static let suppressNavigationKeysSource = """
+        window.addEventListener('keydown', function(e) {
+            if (e.defaultPrevented) return;
+            var nav = ['Backspace','ArrowLeft','ArrowRight','ArrowUp','ArrowDown',
+                       'PageUp','PageDown','Home','End'];
+            if (nav.indexOf(e.key) === -1) return;
+            var el = document.activeElement;
+            if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' ||
+                       el.isContentEditable ||
+                       el.getAttribute('contenteditable') === 'true')) return;
+            e.preventDefault();
+        }, false);
+        """
+
+    override func noResponder(for _: Selector) {}
 
     override func doCommand(by _: Selector) {
-        // Arrow keys and other navigation commands that the web content doesn't
-        // consume go through interpretKeyEvents → doCommand, which beeps by default.
-        // Calling super here triggers NSBeep(); doing nothing silences it.
-    }
-
-    override func keyDown(with event: NSEvent) {
-        // Bare backspace would otherwise trigger WKWebView's go-back navigation
-        // when no editable element has focus. Route it through interpretKeyEvents
-        // so text inputs still receive it; doCommand (above) then discards it
-        // instead of calling goBack().
-        if event.charactersIgnoringModifiers == "\u{08}",
-           event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty {
-            interpretKeyEvents([event])
-            return
-        }
-        super.keyDown(with: event)
+        // Unhandled nav keys come back through interpretKeyEvents → doCommand.
+        // Calling super beeps; doing nothing silences it.
     }
 }
 
@@ -101,24 +102,11 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
             """, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
         config.userContentController.addUserScript(middleClickScript)
 
-        // Suppress the macOS system beep that WebKit emits when navigation keys
-        // (arrows, page up/down, etc.) aren't consumed by the page. We listen at
-        // the bubble phase so app-level handlers fire first; if nothing called
-        // preventDefault() and no editable element is focused, we do so ourselves,
-        // which makes WebKit treat the event as handled and skip the NSBeep() call.
-        let suppressBeepScript = WKUserScript(source: """
-            window.addEventListener('keydown', function(e) {
-                if (e.defaultPrevented) return;
-                var nav = ['ArrowLeft','ArrowRight','ArrowUp','ArrowDown',
-                           'PageUp','PageDown','Home','End'];
-                if (nav.indexOf(e.key) === -1) return;
-                var el = document.activeElement;
-                if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' ||
-                           el.isContentEditable ||
-                           el.getAttribute('contenteditable') === 'true')) return;
-                e.preventDefault();
-            }, false);
-            """, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        let suppressBeepScript = WKUserScript(
+            source: SilentWebView.suppressNavigationKeysSource,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: false
+        )
         config.userContentController.addUserScript(suppressBeepScript)
 
         webView = SilentWebView(frame: .zero, configuration: config)

--- a/mac/starsky/Windows/MainWindowController.swift
+++ b/mac/starsky/Windows/MainWindowController.swift
@@ -23,6 +23,19 @@ private class SilentWebView: WKWebView {
         // consume go through interpretKeyEvents → doCommand, which beeps by default.
         // Calling super here triggers NSBeep(); doing nothing silences it.
     }
+
+    override func keyDown(with event: NSEvent) {
+        // Bare backspace would otherwise trigger WKWebView's go-back navigation
+        // when no editable element has focus. Route it through interpretKeyEvents
+        // so text inputs still receive it; doCommand (above) then discards it
+        // instead of calling goBack().
+        if event.charactersIgnoringModifiers == "\u{08}",
+           event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty {
+            interpretKeyEvents([event])
+            return
+        }
+        super.keyDown(with: event)
+    }
 }
 
 class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDelegate, WKUIDelegate, MainWindowView { // NOSONAR swift:S7485

--- a/mac/starsky/Windows/MainWindowController.swift
+++ b/mac/starsky/Windows/MainWindowController.swift
@@ -9,14 +9,38 @@ import OSLog
 
 private class SilentWindow: NSWindow {
     override func noResponder(for _: Selector) {
-        // Intentionally empty: suppresses the default NSBeep() emitted when no responder handles an event. (comment should be inside the override, not outside)
+        // Suppresses the NSBeep() emitted when no responder handles an event.
     }
 }
 
+// MARK: - Key-event handling design
+//
+// WKWebView on macOS has two problematic default behaviours for navigation keys
+// (Backspace, arrows, Page Up/Down, Home, End) when no editable element has focus:
+//   1. Backspace triggers WKWebView's native go-back navigation.
+//   2. Other nav keys that are not consumed by the page cause an NSBeep().
+//
+// We fix both in JavaScript rather than Swift because the JS layer can inspect
+// document.activeElement and the current selection synchronously, which is not
+// possible from keyDown(with:) without an async JS evaluation round-trip.
+//
+// How it works:
+//   - suppressNavigationKeysSource is injected at document-start.
+//   - For every nav key, if the event target (or any ancestor via the selection)
+//     is editable (INPUT, TEXTAREA, or contenteditable), the handler returns early
+//     and the browser handles the key normally — text is deleted, cursors move, etc.
+//   - Otherwise, e.preventDefault() is called. When WebKit sees a prevented
+//     keydown it marks the event as handled and skips the AppKit interpretKeyEvents
+//     path, so doCommand(by:) is never called and no beep or goBack fires.
+//
+// The selection-walk fallback is needed because WKWebView sometimes reports
+// document.body as document.activeElement even when a contenteditable div has
+// keyboard focus; walking from the selection's commonAncestorContainer catches that.
+//
+// noResponder(for:) on SilentWebView is kept as a last-resort beep suppressor
+// for any key that somehow makes it to the responder chain without a handler.
 class SilentWebView: WKWebView {
-    // Injected at document-start to prevent Backspace from triggering WKWebView's
-    // native go-back navigation and to suppress the NSBeep for unhandled nav keys.
-    // Exported as a static so tests can assert on the script source.
+    // Exported as a static so tests can assert on the script content.
     static let suppressNavigationKeysSource = """
         window.addEventListener('keydown', function(e) {
             if (e.defaultPrevented) return;

--- a/mac/starsky/Windows/MainWindowController.swift
+++ b/mac/starsky/Windows/MainWindowController.swift
@@ -64,7 +64,9 @@ class SilentWebView: WKWebView {
         }, false);
         """
 
-    override func noResponder(for _: Selector) {}
+    override func noResponder(for _: Selector) {
+        // Suppresses the NSBeep() emitted when no responder handles an event.
+    }
 }
 
 class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDelegate, WKUIDelegate, MainWindowView { // NOSONAR swift:S7485

--- a/mac/starskyTests/Helpers/FakeURLProtocol.swift
+++ b/mac/starskyTests/Helpers/FakeURLProtocol.swift
@@ -4,6 +4,10 @@ class FakeURLProtocol: URLProtocol {
     private static let lock = NSLock()
     // Keyed by URL path (scheme/host/port/query ignored) so dynamic ports and query
     // parameters don't break matching, while distinct API endpoints remain isolated.
+    //
+    // IMPORTANT: each per-path queue MUST remain FIFO (append at tail, removeFirst at head).
+    // Several tests rely on enqueue order matching request order.  Do NOT change to a
+    // dictionary keyed by index, a stack (removeLast), or any other non-FIFO structure.
     private static var _responses: [String: [(Data, HTTPURLResponse)]] = [:]
     private static var _capturedRequests: [URLRequest] = []
 

--- a/mac/starskyTests/Services/FileDownloadServiceTests.swift
+++ b/mac/starskyTests/Services/FileDownloadServiceTests.swift
@@ -282,6 +282,12 @@ final class FileDownloadServiceTests: XCTestCase {
             return []
         })
 
+        // Drain the watcher queue so any FSEvents callback that fired concurrently
+        // during the download has fully completed before we read providerCallCount.
+        await withCheckedContinuation { continuation in
+            service.watcherQueue.async { continuation.resume() }
+        }
+
         // Provider should not have been called yet (only called on change)
         XCTAssertEqual(providerCallCount, 0)
         let destFile = tempDir.appendingPathComponent("photos/test.jpg")

--- a/mac/starskyTests/Windows/SilentWebViewTests.swift
+++ b/mac/starskyTests/Windows/SilentWebViewTests.swift
@@ -23,12 +23,13 @@ final class SilentWebViewTests: XCTestCase {
         XCTAssertTrue(src.contains("isContentEditable"))
     }
 
-    // MARK: - doCommand
-
-    @MainActor
-    func testDoCommandDoesNotCrash() {
-        let webView = SilentWebView(frame: .zero, configuration: WKWebViewConfiguration())
-        // deleteBackward: via doCommand must be a no-op, not a crash or a goBack call.
-        webView.doCommand(by: #selector(NSResponder.deleteBackward(_:)))
+    func testSuppressScriptGuardsSelectionInContentEditable() {
+        let src = SilentWebView.suppressNavigationKeysSource
+        // WKWebView can report document.body as activeElement even when a
+        // contenteditable div has focus; the selection-walk fallback catches that.
+        XCTAssertTrue(src.contains("getSelection"))
+        XCTAssertTrue(src.contains("commonAncestorContainer"))
+        XCTAssertTrue(src.contains("parentElement"))
     }
+
 }

--- a/mac/starskyTests/Windows/SilentWebViewTests.swift
+++ b/mac/starskyTests/Windows/SilentWebViewTests.swift
@@ -1,62 +1,34 @@
 import XCTest
 import WebKit
-@MainActor
+
 final class SilentWebViewTests: XCTestCase {
 
-    // Spy that records whether goBack() was called.
-    private class SpySilentWebView: SilentWebView {
-        var goBackCalled = false
-        @discardableResult override func goBack() -> WKNavigation? {
-            goBackCalled = true
-            return nil
-        }
+    // MARK: - suppressNavigationKeysSource
+
+    func testSuppressScriptIncludesBackspace() {
+        XCTAssertTrue(
+            SilentWebView.suppressNavigationKeysSource.contains("'Backspace'"),
+            "Script must include Backspace so WKWebView doesn't trigger go-back navigation"
+        )
     }
 
-    private func makeBackspaceEvent() -> NSEvent {
-        NSEvent.keyEvent(
-            with: .keyDown,
-            location: .zero,
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            characters: "\u{08}",
-            charactersIgnoringModifiers: "\u{08}",
-            isARepeat: false,
-            keyCode: 51
-        )!
+    func testSuppressScriptCallsPreventDefault() {
+        XCTAssertTrue(SilentWebView.suppressNavigationKeysSource.contains("e.preventDefault()"))
     }
 
-    func testBackspaceDoesNotCallGoBack() {
-        let webView = SpySilentWebView(frame: .zero, configuration: WKWebViewConfiguration())
-        webView.keyDown(with: makeBackspaceEvent())
-        XCTAssertFalse(webView.goBackCalled, "Bare backspace must not trigger go-back navigation")
+    func testSuppressScriptGuardsEditableElements() {
+        let src = SilentWebView.suppressNavigationKeysSource
+        XCTAssertTrue(src.contains("INPUT"))
+        XCTAssertTrue(src.contains("TEXTAREA"))
+        XCTAssertTrue(src.contains("isContentEditable"))
     }
 
-    func testBackspaceWithModifierCallsSuper() {
-        // Cmd+backspace (or any modified backspace) should not be swallowed by the override.
-        let webView = SpySilentWebView(frame: .zero, configuration: WKWebViewConfiguration())
-        let event = NSEvent.keyEvent(
-            with: .keyDown,
-            location: .zero,
-            modifierFlags: [.command],
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            characters: "\u{08}",
-            charactersIgnoringModifiers: "\u{08}",
-            isARepeat: false,
-            keyCode: 51
-        )!
-        // Should reach super.keyDown — what matters is our early-return guard doesn't fire.
-        // WKWebView with no loaded page won't go back, but goBackCalled stays false.
-        webView.keyDown(with: event)
-        XCTAssertFalse(webView.goBackCalled)
-    }
+    // MARK: - doCommand
 
+    @MainActor
     func testDoCommandDoesNotCrash() {
         let webView = SilentWebView(frame: .zero, configuration: WKWebViewConfiguration())
-        // Calling deleteBackward: through doCommand must be a no-op, not a crash.
+        // deleteBackward: via doCommand must be a no-op, not a crash or a goBack call.
         webView.doCommand(by: #selector(NSResponder.deleteBackward(_:)))
     }
 }

--- a/mac/starskyTests/Windows/SilentWebViewTests.swift
+++ b/mac/starskyTests/Windows/SilentWebViewTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import WebKit
+@MainActor
+final class SilentWebViewTests: XCTestCase {
+
+    // Spy that records whether goBack() was called.
+    private class SpySilentWebView: SilentWebView {
+        var goBackCalled = false
+        @discardableResult override func goBack() -> WKNavigation? {
+            goBackCalled = true
+            return nil
+        }
+    }
+
+    private func makeBackspaceEvent() -> NSEvent {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{08}",
+            charactersIgnoringModifiers: "\u{08}",
+            isARepeat: false,
+            keyCode: 51
+        )!
+    }
+
+    func testBackspaceDoesNotCallGoBack() {
+        let webView = SpySilentWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        webView.keyDown(with: makeBackspaceEvent())
+        XCTAssertFalse(webView.goBackCalled, "Bare backspace must not trigger go-back navigation")
+    }
+
+    func testBackspaceWithModifierCallsSuper() {
+        // Cmd+backspace (or any modified backspace) should not be swallowed by the override.
+        let webView = SpySilentWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{08}",
+            charactersIgnoringModifiers: "\u{08}",
+            isARepeat: false,
+            keyCode: 51
+        )!
+        // Should reach super.keyDown — what matters is our early-return guard doesn't fire.
+        // WKWebView with no loaded page won't go back, but goBackCalled stays false.
+        webView.keyDown(with: event)
+        XCTAssertFalse(webView.goBackCalled)
+    }
+
+    func testDoCommandDoesNotCrash() {
+        let webView = SilentWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        // Calling deleteBackward: through doCommand must be a no-op, not a crash.
+        webView.doCommand(by: #selector(NSResponder.deleteBackward(_:)))
+    }
+}


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request improves the behavior of the `SilentWebView` class to prevent accidental navigation when the backspace key is pressed outside of editable elements, and adds comprehensive tests to ensure this behavior. The most important changes are as follows:

### WebView Behavior Improvements

* Modified `SilentWebView` to override `keyDown(with:)`, routing bare backspace key events through `interpretKeyEvents` to prevent the default WKWebView "go back" navigation when no editable element is focused. This ensures that pressing backspace does not unexpectedly navigate away from the current page.
* Changed the visibility of `SilentWebView` from `private` to `internal` (by removing the `private` modifier) to allow it to be accessed by the new test suite.

### Test Coverage

* Added a new test file, `SilentWebViewTests.swift`, which includes tests to verify that pressing backspace does not trigger navigation, that modified backspace keys are handled correctly, and that the custom command handler does not crash.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
