### PR TITLE
NSBeep, CompareStringDictionary, readonly paths UI

### DIFF
--- a/history.md
+++ b/history.md
@@ -42,7 +42,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## version 0.9.0-beta.1 - _(Unreleased)_ - 2026-?-? {#0.9.0-beta.1}
 
-- [x] (Fixed) _Front-end_ Read-only setting in preferences (PR #3259)
+- [x] (Fixed) _Front-end_ Read-only path setting in preferences (PR #3259)
 - [x] (Fixed) _App_ Silence when pressing a key and no NSBeep in macOS client (PR #3259)
 - [x] (Fixed) _Back-end_ Improve CompareStringDictionary (PR #3259)
 - [x] (Fixed) _Front-end_ Moving file client side (PR #3245)

--- a/history.md
+++ b/history.md
@@ -42,6 +42,9 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## version 0.9.0-beta.1 - _(Unreleased)_ - 2026-?-? {#0.9.0-beta.1}
 
+- [x] (Fixed) _Front-end_ Read-only setting in preferences (PR #3259)
+- [x] (Fixed) _App_ Silence when pressing a key and no NSBeep in macOS client (PR #3259)
+- [x] (Fixed) _Back-end_ Improve CompareStringDictionary (PR #3259)
 - [x] (Fixed) _Front-end_ Moving file client side (PR #3245)
 - [x] (Added) _Front-end_ Next and Previous by keyboard in Archive (PR #3244)
 - [x] (Fixed) _App_ Use new macOS/windows client in Azure Devops pipeline (PR #3250)

--- a/mac/starsky.xcodeproj/project.pbxproj
+++ b/mac/starsky.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		BE1D04448F507D0906FD281C /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554B5849A45556FFAA970085 /* WindowManager.swift */; };
 		BFBFB40FD03988FBE83B078B /* MainWindowOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68DD5D1A07ED134B0EFAF8FC /* MainWindowOptions.swift */; };
 		C2E9E314DDA263E53F6916B9 /* FakeStarskyBin.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAE0772661C728F9918A8A0E /* FakeStarskyBin.swift */; };
+		C5488518F01646AB2D55FA35 /* SilentWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F51DA46919A291FBFD8783F /* SilentWebViewTests.swift */; };
 		CB8DF2DE1B545794DA93F7BF /* PortFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF10CDC7C7FA47BA0423D288 /* PortFinder.swift */; };
 		CBEF11ACD5AB1701C013AB54 /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A29613611956A9065F7D03E /* MainWindowController.swift */; };
 		CD33C23C28C1A210E724C207 /* BackendService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2CA83403E3576F4DDF6AA3F /* BackendService.swift */; };
@@ -140,6 +141,7 @@
 		9248F5FF3749CE13D7710CC5 /* BackendServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendServiceTests.swift; sourceTree = "<group>"; };
 		97B29EC047ED7E17B1E0563A /* starsky.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = starsky.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9851583918F3426A017184E8 /* RuntimeModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeModeTests.swift; sourceTree = "<group>"; };
+		9F51DA46919A291FBFD8783F /* SilentWebViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SilentWebViewTests.swift; sourceTree = "<group>"; };
 		A1B288A8995FE028D4694CC1 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A220D2CCADAAE29E222E32FA /* NavigationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationServiceTests.swift; sourceTree = "<group>"; };
 		A9A194174E0CB13CE48986CA /* UpdateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateService.swift; sourceTree = "<group>"; };
@@ -232,6 +234,14 @@
 				D81768EC3E7595819B8FEF0E /* CreateFakeStarskyBin */,
 			);
 			path = FakeCreateAn;
+			sourceTree = "<group>";
+		};
+		3FF16225403A5BDB4E25E59A /* Windows */ = {
+			isa = PBXGroup;
+			children = (
+				9F51DA46919A291FBFD8783F /* SilentWebViewTests.swift */,
+			);
+			path = Windows;
 			sourceTree = "<group>";
 		};
 		4548884DE610F3D1FE7E5B8D /* Presentation */ = {
@@ -357,6 +367,7 @@
 				66C4FC2A2BEA8C3BD2C16D52 /* Models */,
 				4548884DE610F3D1FE7E5B8D /* Presentation */,
 				0D202E738D9534764ECBD4E8 /* Services */,
+				3FF16225403A5BDB4E25E59A /* Windows */,
 			);
 			path = starskyTests;
 			sourceTree = "<group>";
@@ -595,6 +606,7 @@
 				ABABCE907574E0BCC0EF2522 /* SettingsService.swift in Sources */,
 				19267496699CFB79FC4477F3 /* SettingsServiceTests.swift in Sources */,
 				0A2B5A1F9B4930D1E2517AE4 /* SettingsWindowController.swift in Sources */,
+				C5488518F01646AB2D55FA35 /* SilentWebViewTests.swift in Sources */,
 				D2DC9D761B2B3C68FB4385CF /* SplashWindowController.swift in Sources */,
 				5A54A8C8CEA8383DCE53A6D6 /* UpdateService.swift in Sources */,
 				528B639F38E2E709539232C4 /* UpdateServiceTests.swift in Sources */,

--- a/mac/starsky/Windows/MainWindowController.swift
+++ b/mac/starsky/Windows/MainWindowController.swift
@@ -15,23 +15,25 @@ private class SilentWindow: NSWindow {
 
 // MARK: - Key-event handling design
 //
-// WKWebView on macOS has two problematic default behaviours for navigation keys
-// (Backspace, arrows, Page Up/Down, Home, End) when no editable element has focus:
-//   1. Backspace triggers WKWebView's native go-back navigation.
-//   2. Other nav keys that are not consumed by the page cause an NSBeep().
+// WKWebView on macOS beeps (NSBeep) for any keydown that isn't consumed by the
+// page and reaches AppKit's responder chain unhandled. This affects:
+//   1. Backspace — triggers WKWebView's native go-back navigation.
+//   2. Navigation keys (arrows, Page Up/Down, Home, End) not consumed by the page.
+//   3. Letter/number keys used as app shortcuts when the React layer handles them
+//      but does not call e.preventDefault().
 //
-// We fix both in JavaScript rather than Swift because the JS layer can inspect
+// We suppress beeps in JavaScript because the JS layer can inspect
 // document.activeElement and the current selection synchronously, which is not
 // possible from keyDown(with:) without an async JS evaluation round-trip.
 //
 // How it works:
-//   - suppressNavigationKeysSource is injected at document-start.
-//   - For every nav key, if the event target (or any ancestor via the selection)
-//     is editable (INPUT, TEXTAREA, or contenteditable), the handler returns early
-//     and the browser handles the key normally — text is deleted, cursors move, etc.
-//   - Otherwise, e.preventDefault() is called. When WebKit sees a prevented
-//     keydown it marks the event as handled and skips the AppKit interpretKeyEvents
-//     path, so doCommand(by:) is never called and no beep or goBack fires.
+//   - suppressKeysSource is injected at document-start.
+//   - For every plain key (no Cmd/Ctrl/Alt modifier), if the event target (or any
+//     ancestor via the selection) is editable (INPUT, TEXTAREA, contenteditable),
+//     the handler returns early and the browser handles the key normally.
+//   - Otherwise e.preventDefault() is called, which tells WebKit the event was
+//     handled so it never reaches AppKit's interpretKeyEvents path and no beep fires.
+//   - Modifier-based shortcuts (Cmd+R, Cmd+C, etc.) are always let through.
 //
 // The selection-walk fallback is needed because WKWebView sometimes reports
 // document.body as document.activeElement even when a contenteditable div has
@@ -41,12 +43,10 @@ private class SilentWindow: NSWindow {
 // for any key that somehow makes it to the responder chain without a handler.
 class SilentWebView: WKWebView {
     // Exported as a static so tests can assert on the script content.
-    static let suppressNavigationKeysSource = """
+    static let suppressKeysSource = """
         window.addEventListener('keydown', function(e) {
             if (e.defaultPrevented) return;
-            var nav = ['Backspace','ArrowLeft','ArrowRight','ArrowUp','ArrowDown',
-                       'PageUp','PageDown','Home','End'];
-            if (nav.indexOf(e.key) === -1) return;
+            if (e.metaKey || e.ctrlKey || e.altKey) return;
             var el = document.activeElement;
             if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' ||
                        el.isContentEditable ||
@@ -133,7 +133,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate, WKNavigationDe
         config.userContentController.addUserScript(middleClickScript)
 
         let suppressBeepScript = WKUserScript(
-            source: SilentWebView.suppressNavigationKeysSource,
+            source: SilentWebView.suppressKeysSource,
             injectionTime: .atDocumentStart,
             forMainFrameOnly: false
         )

--- a/mac/starskyTests/Windows/SilentWebViewTests.swift
+++ b/mac/starskyTests/Windows/SilentWebViewTests.swift
@@ -3,28 +3,29 @@ import WebKit
 
 final class SilentWebViewTests: XCTestCase {
 
-    // MARK: - suppressNavigationKeysSource
-
-    func testSuppressScriptIncludesBackspace() {
-        XCTAssertTrue(
-            SilentWebView.suppressNavigationKeysSource.contains("'Backspace'"),
-            "Script must include Backspace so WKWebView doesn't trigger go-back navigation"
-        )
-    }
+    // MARK: - suppressKeysSource
 
     func testSuppressScriptCallsPreventDefault() {
-        XCTAssertTrue(SilentWebView.suppressNavigationKeysSource.contains("e.preventDefault()"))
+        XCTAssertTrue(SilentWebView.suppressKeysSource.contains("e.preventDefault()"))
+    }
+
+    func testSuppressScriptGuardsModifierKeys() {
+        let src = SilentWebView.suppressKeysSource
+        // Cmd/Ctrl/Alt shortcuts must never be suppressed.
+        XCTAssertTrue(src.contains("e.metaKey"))
+        XCTAssertTrue(src.contains("e.ctrlKey"))
+        XCTAssertTrue(src.contains("e.altKey"))
     }
 
     func testSuppressScriptGuardsEditableElements() {
-        let src = SilentWebView.suppressNavigationKeysSource
+        let src = SilentWebView.suppressKeysSource
         XCTAssertTrue(src.contains("INPUT"))
         XCTAssertTrue(src.contains("TEXTAREA"))
         XCTAssertTrue(src.contains("isContentEditable"))
     }
 
     func testSuppressScriptGuardsSelectionInContentEditable() {
-        let src = SilentWebView.suppressNavigationKeysSource
+        let src = SilentWebView.suppressKeysSource
         // WKWebView can report document.body as activeElement even when a
         // contenteditable div has focus; the selection-walk fallback catches that.
         XCTAssertTrue(src.contains("getSelection"))

--- a/starsky/starsky.foundation.platform/Helpers/AppSettingsCompareHelper.cs
+++ b/starsky/starsky.foundation.platform/Helpers/AppSettingsCompareHelper.cs
@@ -562,20 +562,27 @@ public static class AppSettingsCompareHelper
 		Dictionary<string, string>? oldDictionaryValue,
 		Dictionary<string, string>? newDictionaryValue, List<string> differenceList)
 	{
-		if ( oldDictionaryValue == null )
+		if ( oldDictionaryValue == null || newDictionaryValue == null ||
+		     newDictionaryValue.Count == 0 )
 		{
 			return;
 		}
 
+		var merged = new Dictionary<string, string>(oldDictionaryValue);
+		foreach ( var kvp in newDictionaryValue )
+		{
+			merged[kvp.Key] = kvp.Value;
+		}
+
 		if ( JsonSerializer.Serialize(oldDictionaryValue,
-			    DefaultJsonSerializer.CamelCase) == JsonSerializer.Serialize(newDictionaryValue,
+			    DefaultJsonSerializer.CamelCase) == JsonSerializer.Serialize(merged,
 			    DefaultJsonSerializer.CamelCase) )
 		{
 			return;
 		}
 
 		sourceIndexItem.GetType().GetProperty(propertyName)
-			?.SetValue(sourceIndexItem, newDictionaryValue, null);
+			?.SetValue(sourceIndexItem, merged, null);
 		differenceList.Add(propertyName.ToLowerInvariant());
 	}
 

--- a/starsky/starsky.foundation.platform/Models/AppSettingsTransferObject.cs
+++ b/starsky/starsky.foundation.platform/Models/AppSettingsTransferObject.cs
@@ -21,5 +21,7 @@ namespace starsky.foundation.platform.Models
 			CollectionsOpenType.RawJpegMode.Default;
 
 		public Dictionary<string, string> StorageFolderMappings { get; set; } = new();
+
+		public List<string> ReadOnlyFolders { get; set; } = [];
 	}
 }

--- a/starsky/starsky/clientapp/src/components/organisms/preferences-app-settings-readonly-folders/preferences-app-settings-readonly-folders.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/preferences-app-settings-readonly-folders/preferences-app-settings-readonly-folders.spec.tsx
@@ -1,0 +1,431 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react";
+import * as useFetch from "../../../hooks/use-fetch";
+import { IConnectionDefault, newIConnectionDefault } from "../../../interfaces/IConnectionDefault";
+import * as FetchPost from "../../../shared/fetch/fetch-post";
+import { UrlQuery } from "../../../shared/url/url-query";
+import PreferencesAppSettingsReadonlyFolders, {
+  ChangeSettingReadOnlyFolders
+} from "./preferences-app-settings-readonly-folders";
+
+describe("PreferencesAppSettingsReadonlyFolders", () => {
+  it("renders without crashing", () => {
+    const component = render(<PreferencesAppSettingsReadonlyFolders />);
+    expect(component).toBeTruthy();
+    act(() => {
+      component.unmount();
+    });
+  });
+
+  describe("context", () => {
+    it("renders existing folders as rows", () => {
+      const permissions = {
+        statusCode: 200,
+        data: ["AppSettingsWrite"]
+      } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: ["/2024", "/2023"] }
+      } as IConnectionDefault;
+
+      jest
+        .spyOn(useFetch, "default")
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings)
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings);
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      expect(screen.queryAllByTestId("readonly-folder-row")).toHaveLength(2);
+
+      act(() => {
+        component.unmount();
+      });
+    });
+
+    it("shows none-message when no folders and user has no permission", () => {
+      const permissions = { statusCode: 200, data: [] } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: [] }
+      } as IConnectionDefault;
+
+      jest
+        .spyOn(useFetch, "default")
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings)
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings);
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      expect(screen.getByTestId("readonly-folders-none")).toBeTruthy();
+
+      act(() => {
+        component.unmount();
+      });
+    });
+
+    it("shows add button when user has AppSettingsWrite permission", () => {
+      const permissions = {
+        statusCode: 200,
+        data: ["AppSettingsWrite"]
+      } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: [] }
+      } as IConnectionDefault;
+
+      jest
+        .spyOn(useFetch, "default")
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings)
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings);
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      expect(screen.getByTestId("readonly-folder-add")).toBeTruthy();
+
+      act(() => {
+        component.unmount();
+      });
+    });
+
+    it("does not show add button without permission", () => {
+      const permissions = { statusCode: 200, data: [] } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: [] }
+      } as IConnectionDefault;
+
+      jest
+        .spyOn(useFetch, "default")
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings)
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings);
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      expect(screen.queryByTestId("readonly-folder-add")).toBeNull();
+
+      act(() => {
+        component.unmount();
+      });
+    });
+
+    it("adds a new row when add button is clicked", () => {
+      const permissions = {
+        statusCode: 200,
+        data: ["AppSettingsWrite"]
+      } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: [] }
+      } as IConnectionDefault;
+
+      jest.spyOn(useFetch, "default").mockImplementation((url) => {
+        if (url === new UrlQuery().UrlAccountPermissions()) return permissions;
+        return appSettings;
+      });
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      act(() => {
+        fireEvent.click(screen.getByTestId("readonly-folder-add"));
+      });
+
+      expect(screen.queryAllByTestId("readonly-folder-row")).toHaveLength(1);
+
+      act(() => {
+        component.unmount();
+      });
+    });
+
+    it("does not show remove buttons without permission", () => {
+      const permissions = { statusCode: 200, data: [] } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: ["/2024"] }
+      } as IConnectionDefault;
+
+      jest
+        .spyOn(useFetch, "default")
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings)
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings);
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      expect(screen.queryByTestId("readonly-folder-remove-0")).toBeNull();
+
+      act(() => {
+        component.unmount();
+      });
+    });
+
+    it("shows remove buttons when user has permission", () => {
+      const permissions = {
+        statusCode: 200,
+        data: ["AppSettingsWrite"]
+      } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: ["/2024"] }
+      } as IConnectionDefault;
+
+      jest
+        .spyOn(useFetch, "default")
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings)
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings);
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      expect(screen.getByTestId("readonly-folder-remove-0")).toBeTruthy();
+
+      act(() => {
+        component.unmount();
+      });
+    });
+
+    it("removes a row when remove button is clicked and posts updated folders", async () => {
+      const permissions = {
+        statusCode: 200,
+        data: ["AppSettingsWrite"]
+      } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: ["/2024"] }
+      } as IConnectionDefault;
+
+      jest
+        .spyOn(useFetch, "default")
+        .mockImplementation(() => permissions)
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings)
+        .mockImplementationOnce(() => permissions)
+        .mockImplementationOnce(() => appSettings);
+
+      const mockResult: Promise<IConnectionDefault> = Promise.resolve(newIConnectionDefault());
+      const fetchPostSpy = jest
+        .spyOn(FetchPost, "default")
+        .mockImplementationOnce(() => mockResult);
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("readonly-folder-remove-0"));
+        await mockResult;
+      });
+
+      expect(fetchPostSpy).toHaveBeenCalled();
+      expect(screen.queryAllByTestId("readonly-folder-row")).toHaveLength(0);
+
+      act(() => {
+        component.unmount();
+      });
+    });
+
+    it("saves on blur and shows re-sync warning", async () => {
+      const permissions = {
+        statusCode: 200,
+        data: ["AppSettingsWrite"]
+      } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: ["/2024"] }
+      } as IConnectionDefault;
+
+      jest.spyOn(useFetch, "default").mockImplementation((url) => {
+        if (url === new UrlQuery().UrlAccountPermissions()) return permissions;
+        return appSettings;
+      });
+
+      const mockResult: Promise<IConnectionDefault> = Promise.resolve({
+        statusCode: 200,
+        data: null
+      });
+      const fetchPostSpy = jest
+        .spyOn(FetchPost, "default")
+        .mockImplementationOnce(() => mockResult);
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      const formControl = screen.getByTestId("form-control");
+      formControl.innerText = "/renamed";
+      await act(async () => {
+        fireEvent.focusOut(formControl);
+        await mockResult;
+      });
+
+      expect(fetchPostSpy).toHaveBeenCalled();
+      expect(screen.getByTestId("readonly-folders-changed")).toBeTruthy();
+
+      act(() => {
+        component.unmount();
+      });
+    });
+  });
+
+  describe("error handling", () => {
+    it("shows error box when server returns non-200", async () => {
+      const permissions = {
+        statusCode: 200,
+        data: ["AppSettingsWrite"]
+      } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: ["/2024"] }
+      } as unknown as IConnectionDefault;
+
+      jest
+        .spyOn(useFetch, "default")
+        .mockImplementation((url: string) =>
+          url.includes("permissions") ? permissions : appSettings
+        );
+
+      jest
+        .spyOn(FetchPost, "default")
+        .mockImplementation(() =>
+          Promise.resolve({ statusCode: 403, data: null } as IConnectionDefault)
+        );
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      const formControl = await screen.findByTestId("form-control");
+      fireEvent.blur(formControl, { target: { innerText: "/etc/shadow" } });
+
+      await screen.findByTestId("readonly-folders-error");
+      expect(screen.queryByTestId("readonly-folders-changed")).toBeNull();
+
+      act(() => {
+        component.unmount();
+      });
+    });
+
+    it("shows error box when saving fails with a rejected request", async () => {
+      const permissions = {
+        statusCode: 200,
+        data: ["AppSettingsWrite"]
+      } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: ["/2024"] }
+      } as unknown as IConnectionDefault;
+
+      jest
+        .spyOn(useFetch, "default")
+        .mockImplementation((url: string) =>
+          url.includes("permissions") ? permissions : appSettings
+        );
+
+      jest.spyOn(FetchPost, "default").mockRejectedValue(new Error("network failure"));
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      const formControl = await screen.findByTestId("form-control");
+      fireEvent.blur(formControl, { target: { innerText: "/renamed" } });
+
+      await screen.findByTestId("readonly-folders-error");
+      expect(screen.queryByTestId("readonly-folders-changed")).toBeNull();
+
+      act(() => {
+        component.unmount();
+      });
+    });
+
+    it("does not show error box when server returns 200", async () => {
+      const permissions = {
+        statusCode: 200,
+        data: ["AppSettingsWrite"]
+      } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: ["/2024"] }
+      } as unknown as IConnectionDefault;
+
+      jest
+        .spyOn(useFetch, "default")
+        .mockImplementation((url: string) =>
+          url.includes("permissions") ? permissions : appSettings
+        );
+
+      jest
+        .spyOn(FetchPost, "default")
+        .mockImplementation(() =>
+          Promise.resolve({ statusCode: 200, data: null } as IConnectionDefault)
+        );
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      const formControl = await screen.findByTestId("form-control");
+      fireEvent.blur(formControl, { target: { innerText: "/2024" } });
+
+      await screen.findByTestId("readonly-folders-changed");
+      expect(screen.queryByTestId("readonly-folders-error")).toBeNull();
+
+      act(() => {
+        component.unmount();
+      });
+    });
+  });
+
+  describe("ChangeSettingReadOnlyFolders", () => {
+    it("should post folders as indexed form-urlencoded", async () => {
+      const mockResult: Promise<IConnectionDefault> = Promise.resolve({
+        statusCode: 200,
+        data: null
+      });
+      const fetchPostSpy = jest
+        .spyOn(FetchPost, "default")
+        .mockImplementationOnce(() => mockResult);
+
+      const statusCode = await ChangeSettingReadOnlyFolders([{ id: 0, folder: "/2024" }]);
+
+      expect(statusCode).toBe(200);
+      expect(fetchPostSpy).toHaveBeenCalledWith(
+        new UrlQuery().UrlApiAppSettings(),
+        "ReadOnlyFolders%5B0%5D=%2F2024"
+      );
+    });
+
+    it("should skip rows with empty folder", async () => {
+      const mockResult: Promise<IConnectionDefault> = Promise.resolve({
+        statusCode: 200,
+        data: null
+      });
+      const fetchPostSpy = jest
+        .spyOn(FetchPost, "default")
+        .mockImplementationOnce(() => mockResult);
+
+      await ChangeSettingReadOnlyFolders([
+        { id: 0, folder: "" },
+        { id: 1, folder: "/2023" }
+      ]);
+
+      expect(fetchPostSpy).toHaveBeenCalledWith(
+        new UrlQuery().UrlApiAppSettings(),
+        "ReadOnlyFolders%5B0%5D=%2F2023"
+      );
+    });
+
+    it("should post empty body when all rows are empty", async () => {
+      const mockResult: Promise<IConnectionDefault> = Promise.resolve({
+        statusCode: 200,
+        data: null
+      });
+      const fetchPostSpy = jest
+        .spyOn(FetchPost, "default")
+        .mockImplementationOnce(() => mockResult);
+
+      await ChangeSettingReadOnlyFolders([{ id: 0, folder: "" }]);
+
+      expect(fetchPostSpy).toHaveBeenCalledWith(new UrlQuery().UrlApiAppSettings(), "");
+    });
+  });
+});

--- a/starsky/starsky/clientapp/src/components/organisms/preferences-app-settings-readonly-folders/preferences-app-settings-readonly-folders.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/preferences-app-settings-readonly-folders/preferences-app-settings-readonly-folders.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useRef, useState } from "react";
+import useFetch from "../../../hooks/use-fetch";
+import useGlobalSettings from "../../../hooks/use-global-settings";
+import { IAppSettings } from "../../../interfaces/IAppSettings";
+import localization from "../../../localization/localization.json";
+import FetchPost from "../../../shared/fetch/fetch-post";
+import { Language } from "../../../shared/language";
+import { UrlQuery } from "../../../shared/url/url-query";
+import FormControl from "../../atoms/form-control/form-control";
+
+type FolderRow = { id: number; folder: string };
+
+export async function ChangeSettingReadOnlyFolders(folders: FolderRow[]): Promise<number> {
+  const bodyParams = new URLSearchParams();
+  folders
+    .filter((r) => r.folder)
+    .forEach((r, idx) => {
+      bodyParams.append(`ReadOnlyFolders[${idx}]`, r.folder);
+    });
+  const result = await FetchPost(new UrlQuery().UrlApiAppSettings(), bodyParams.toString());
+  return result?.statusCode;
+}
+
+const PreferencesAppSettingsReadonlyFolders: React.FunctionComponent = () => {
+  const settings = useGlobalSettings();
+  const language = new Language(settings.language);
+  const MessageAppSettingsReadOnlyFolders = language.key(
+    localization.MessageAppSettingsReadOnlyFolders
+  );
+  const MessageAppSettingsReadOnlyFoldersNone = language.key(
+    localization.MessageAppSettingsReadOnlyFoldersNone
+  );
+  const MessageAppSettingsReadOnlyFoldersAdd = language.key(
+    localization.MessageAppSettingsReadOnlyFoldersAdd
+  );
+  const MessageAppSettingsReadOnlyFoldersRemove = language.key(
+    localization.MessageAppSettingsReadOnlyFoldersRemove
+  );
+  const MessageAppSettingsReadOnlyFoldersError = language.key(
+    localization.MessageAppSettingsReadOnlyFoldersError
+  );
+  const MessageChangeNeedReSync = language.key(localization.MessageChangeNeedReSync);
+  const MessageReadMoreHere = language.key(localization.MessageReadMoreHere);
+
+  const permissionsData = useFetch(new UrlQuery().UrlAccountPermissions(), "get");
+  const [isEnabled, setIsEnabled] = useState(false);
+
+  useEffect(() => {
+    const data = permissionsData?.data as string[];
+    if (!data?.includes || permissionsData?.statusCode !== 200) {
+      setIsEnabled(false);
+      return;
+    }
+    setIsEnabled(data.includes(new UrlQuery().KeyAccountPermissionAppSettingsWrite()));
+  }, [permissionsData]);
+
+  const appSettings = useFetch(new UrlQuery().UrlApiAppSettings(), "get")
+    ?.data as IAppSettings | null;
+
+  const [rows, setRows] = useState<FolderRow[]>([]);
+  const nextId = useRef(0);
+  const [changed, setChanged] = useState(false);
+  const [saveError, setSaveError] = useState(false);
+
+  useEffect(() => {
+    if (!appSettings?.readOnlyFolders) return;
+    setRows(appSettings.readOnlyFolders.map((folder) => ({ id: nextId.current++, folder })));
+  }, [appSettings]);
+
+  async function saveAll(updated: FolderRow[]) {
+    try {
+      const statusCode = await ChangeSettingReadOnlyFolders(updated);
+      if (statusCode === 200) {
+        setSaveError(false);
+        setChanged(true);
+        return;
+      }
+      setSaveError(true);
+      setChanged(false);
+    } catch {
+      setSaveError(true);
+      setChanged(false);
+    }
+  }
+
+  function handleBlur(id: number, value: string) {
+    const updated = rows.map((r) => (r.id === id ? { ...r, folder: value } : r));
+    setRows(updated);
+    saveAll(updated);
+  }
+
+  function addRow() {
+    setRows((prev) => [...prev, { id: nextId.current++, folder: "" }]);
+  }
+
+  function removeRow(id: number) {
+    const updated = rows.filter((r) => r.id !== id);
+    setRows(updated);
+    saveAll(updated);
+  }
+
+  return (
+    <>
+      <div className="content--subheader">{MessageAppSettingsReadOnlyFolders}</div>
+
+      {rows.length === 0 && !isEnabled ? (
+        <p data-test="readonly-folders-none">{MessageAppSettingsReadOnlyFoldersNone}</p>
+      ) : null}
+      {rows.map((row) => (
+        <div
+          key={row.id}
+          className="preferences--readonly-folder-row"
+          data-test="readonly-folder-row"
+        >
+          <FormControl
+            name={`readOnlyFolders-${row.id}`}
+            className="form-control inline-block form-control--half"
+            contentEditable={isEnabled}
+            onBlur={(e) => handleBlur(row.id, e.target.innerText)}
+            spellcheck={false}
+          >
+            {row.folder}
+          </FormControl>
+          {isEnabled ? (
+            <button
+              type="button"
+              className="btn btn--default inline-block"
+              data-test={`readonly-folder-remove-${row.id}`}
+              onClick={() => removeRow(row.id)}
+            >
+              {MessageAppSettingsReadOnlyFoldersRemove}
+            </button>
+          ) : null}
+        </div>
+      ))}
+      {isEnabled ? (
+        <button
+          type="button"
+          className="btn btn--default"
+          data-test="readonly-folder-add"
+          onClick={addRow}
+        >
+          {MessageAppSettingsReadOnlyFoldersAdd}
+        </button>
+      ) : null}
+      {saveError ? (
+        <div className="warning-box warning-box--error" data-test="readonly-folders-error">
+          {MessageAppSettingsReadOnlyFoldersError}
+        </div>
+      ) : null}
+      {changed ? (
+        <div className="warning-box" data-test="readonly-folders-changed">
+          {MessageChangeNeedReSync}{" "}
+          <a target="_blank" href={new UrlQuery().DocsGettingStartedFirstSteps()} rel="noreferrer">
+            {MessageReadMoreHere}
+          </a>
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+export default PreferencesAppSettingsReadonlyFolders;

--- a/starsky/starsky/clientapp/src/components/organisms/preferences-app-settings/preferences-app-settings.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/preferences-app-settings/preferences-app-settings.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import PreferencesAppSettingsDesktop from "../preference-app-settings-desktop/preference-app-settings-desktop";
-import PreferencesAppSettingsStorageFolder from "../preferences-app-settings-storage-folder/preferences-app-settings-storage-folder";
+import PreferencesAppSettingsReadonlyFolders from "../preferences-app-settings-readonly-folders/preferences-app-settings-readonly-folders";
 import PreferencesAppSettingsStorageFolderMappings from "../preferences-app-settings-storage-folder-mappings/preferences-app-settings-storage-folder-mappings";
+import PreferencesAppSettingsStorageFolder from "../preferences-app-settings-storage-folder/preferences-app-settings-storage-folder";
 
 const PreferencesAppSettings: React.FunctionComponent = () => {
   return (
@@ -11,6 +12,7 @@ const PreferencesAppSettings: React.FunctionComponent = () => {
         <PreferencesAppSettingsStorageFolder />
         <PreferencesAppSettingsStorageFolderMappings />
         <PreferencesAppSettingsDesktop />
+        <PreferencesAppSettingsReadonlyFolders />
       </div>
     </div>
   );

--- a/starsky/starsky/clientapp/src/interfaces/IAppSettings.ts
+++ b/starsky/starsky/clientapp/src/interfaces/IAppSettings.ts
@@ -9,4 +9,5 @@ export interface IAppSettings {
   useLocalDesktop: boolean;
   defaultDesktopEditor: IAppSettingsDefaultEditorApplication[];
   desktopCollectionsOpen: RawJpegMode;
+  readOnlyFolders: string[];
 }

--- a/starsky/starsky/clientapp/src/localization/localization.json
+++ b/starsky/starsky/clientapp/src/localization/localization.json
@@ -519,6 +519,31 @@
     "nl": "Koppeling kon niet worden opgeslagen. Het fysieke pad verwijst naar een beperkte systeemmap.",
     "de": "Zuordnung konnte nicht gespeichert werden. Der physische Pfad verweist auf ein eingeschränktes Systemverzeichnis."
   },
+  "MessageAppSettingsReadOnlyFolders": {
+    "en": "Readonly folders",
+    "nl": "Readonly / alleen lezen mappen",
+    "de": "Schreibgeschützte Ordner"
+  },
+  "MessageAppSettingsReadOnlyFoldersNone": {
+    "en": "No readonly folders configured.",
+    "nl": "Geen alleen lezen mappen geconfigureerd.",
+    "de": "Keine schreibgeschützten Ordner konfiguriert."
+  },
+  "MessageAppSettingsReadOnlyFoldersAdd": {
+    "en": "Add folder",
+    "nl": "Map toevoegen",
+    "de": "Ordner hinzufügen"
+  },
+  "MessageAppSettingsReadOnlyFoldersRemove": {
+    "en": "Remove",
+    "nl": "Verwijderen",
+    "de": "Entfernen"
+  },
+  "MessageAppSettingsReadOnlyFoldersError": {
+    "en": "Readonly folders could not be saved.",
+    "nl": "Alleen lezen mappen konden niet worden opgeslagen.",
+    "de": "Schreibgeschützte Ordner konnten nicht gespeichert werden."
+  },
   "MessageSwitchButtonDesktopCollectionsRawOn": {
     "en": "Raw first",
     "nl": "Raw eerst",

--- a/starsky/starsky/clientapp/src/style/css/50-preferences.css
+++ b/starsky/starsky/clientapp/src/style/css/50-preferences.css
@@ -133,3 +133,17 @@
     margin-bottom: 15px;
   }
 }
+
+.preferences--readonly-folder-row .btn {
+  margin-left: 10px;
+}
+
+@media screen and (max-width: 600px) {
+  .preferences--readonly-folder-row .form-control.form-control--half {
+    width: 70%;
+  }
+  .preferences--readonly-folder-row .btn {
+    margin-left: 10px;
+    margin-bottom: 15px;
+  }
+}

--- a/starsky/starskytest/starsky.foundation.platform/Helpers/AppSettingsCompareHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Helpers/AppSettingsCompareHelperTest.cs
@@ -1177,6 +1177,36 @@ public sealed class AppSettingsCompareHelperTest
 	}
 
 	[TestMethod]
+	public void StorageFolderMappings_NullOldValue_DoesNothing()
+	{
+		var source = new AppSettings { StorageFolderMappings = null! };
+
+		var transfer = new AppSettingsTransferObject
+		{
+			StorageFolderMappings = new Dictionary<string, string> { { "/new", "/data/new" } }
+		};
+
+		AppSettingsCompareHelper.Compare(source, transfer);
+
+		Assert.IsNull(source.StorageFolderMappings);
+	}
+
+	[TestMethod]
+	public void StorageFolderMappings_NullNewValue_KeepsExistingMappings()
+	{
+		var source = new AppSettings
+		{
+			StorageFolderMappings = new Dictionary<string, string> { { "/archive", "/data/archive" } }
+		};
+
+		var transfer = new AppSettingsTransferObject { StorageFolderMappings = null! };
+
+		AppSettingsCompareHelper.Compare(source, transfer);
+
+		Assert.IsTrue(source.StorageFolderMappings.ContainsKey("/archive"));
+	}
+
+	[TestMethod]
 	public void StorageFolderMappings_EmptyNewValue_KeepsExistingMappings()
 	{
 		var source = new AppSettings

--- a/starsky/starskytest/starsky.foundation.platform/Helpers/AppSettingsCompareHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.platform/Helpers/AppSettingsCompareHelperTest.cs
@@ -1177,7 +1177,7 @@ public sealed class AppSettingsCompareHelperTest
 	}
 
 	[TestMethod]
-	public void StorageFolderMappings_EmptyNewValue_ClearsExistingMappings()
+	public void StorageFolderMappings_EmptyNewValue_KeepsExistingMappings()
 	{
 		var source = new AppSettings
 		{
@@ -1194,11 +1194,11 @@ public sealed class AppSettingsCompareHelperTest
 
 		AppSettingsCompareHelper.Compare(source, transfer);
 
-		Assert.IsEmpty(source.StorageFolderMappings);
+		Assert.IsTrue(source.StorageFolderMappings.ContainsKey("/archive"));
 	}
 
 	[TestMethod]
-	public void StorageFolderMappings_NewMappingReplacesPrevious()
+	public void StorageFolderMappings_NewMappingMergesWithPrevious()
 	{
 		var source = new AppSettings
 		{
@@ -1218,7 +1218,32 @@ public sealed class AppSettingsCompareHelperTest
 
 		AppSettingsCompareHelper.Compare(source, transfer);
 
-		Assert.IsFalse(source.StorageFolderMappings.ContainsKey("/old"));
+		Assert.IsTrue(source.StorageFolderMappings.ContainsKey("/old"));
 		Assert.IsTrue(source.StorageFolderMappings.ContainsKey("/new"));
+	}
+
+	[TestMethod]
+	public void StorageFolderMappings_NewMappingOverridesExistingKey()
+	{
+		var source = new AppSettings
+		{
+			StorageFolderMappings = new Dictionary<string, string>
+			{
+				{ "/1999", "/mnt/old/1999" }
+			}
+		};
+
+		var transfer = new AppSettingsTransferObject
+		{
+			StorageFolderMappings = new Dictionary<string, string>
+			{
+				{ "/1999", "/mnt/data/storage/100canon/1999" }
+			}
+		};
+
+		AppSettingsCompareHelper.Compare(source, transfer);
+
+		Assert.AreEqual("/mnt/data/storage/100canon/1999",
+			source.StorageFolderMappings["/1999"]);
 	}
 }


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request makes two main sets of improvements: it refines the logic for merging dictionary-based settings in application configuration, and it updates the behavior and tests for suppressing unwanted key events in the macOS WKWebView integration. The changes ensure that new dictionary entries are merged (not replaced or cleared), and that key suppression is more accurate and robust, especially around modifier keys and editable elements.

**App Settings Merge Logic Improvements:**

- The `CompareStringDictionary` method now merges new dictionary values into existing ones, instead of replacing or clearing them, and only updates keys that are present in the new dictionary. This ensures existing mappings are preserved unless explicitly overridden.
- Unit tests for storage folder mappings have been updated and expanded to reflect the new merging behavior, including tests for keeping existing mappings when the new value is empty, merging new mappings, and overriding existing keys. [[1]](diffhunk://#diff-8e81a2e89857983fa65ca47a240f172d4af9ab85efdb12fe194499bdc8a2af9bL1180-R1180) [[2]](diffhunk://#diff-8e81a2e89857983fa65ca47a240f172d4af9ab85efdb12fe194499bdc8a2af9bL1197-R1201) [[3]](diffhunk://#diff-8e81a2e89857983fa65ca47a240f172d4af9ab85efdb12fe194499bdc8a2af9bL1221-R1248)

**Key Suppression and WKWebView Behavior:**

- The suppressing script for unwanted navigation keys has been generalized from `suppressNavigationKeysSource` to `suppressKeysSource`, and now prevents beeps for all plain keys not handled by the page, while always allowing modifier-based shortcuts (Cmd/Ctrl/Alt). [[1]](diffhunk://#diff-ebb1d37e3c912ecfe11c03013c673090b35f1da2921f4c18aca374748b888d25L18-R36) [[2]](diffhunk://#diff-ebb1d37e3c912ecfe11c03013c673090b35f1da2921f4c18aca374748b888d25L44-R49) [[3]](diffhunk://#diff-ebb1d37e3c912ecfe11c03013c673090b35f1da2921f4c18aca374748b888d25L136-R136)
- Associated tests are updated to check for the presence of modifier key guards and to ensure the script's logic is correct and comprehensive.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
