### PR TITLE
The root cause is clear: the fake Windows ExifTool exits immediately …

### DIFF
--- a/history.md
+++ b/history.md
@@ -42,6 +42,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## version 0.9.0-beta.1 - _(Unreleased)_ - 2026-?-? {#0.9.0-beta.1}
 
+- [x] (Fixed) _Front-end_ Pipeline handling for exiftool and closing (PR #3262)
 - [x] (Fixed) _Front-end_ Read-only path setting in preferences (PR #3259)
 - [x] (Fixed) _App_ Silence when pressing a key and no NSBeep in macOS client (PR #3259)
 - [x] (Fixed) _Back-end_ Improve CompareStringDictionary (PR #3259)

--- a/starsky/starsky.foundation.writemeta/Helpers/ExifToolStreamToStreamRunner.cs
+++ b/starsky/starsky.foundation.writemeta/Helpers/ExifToolStreamToStreamRunner.cs
@@ -65,6 +65,17 @@ public class ExifToolStreamToStreamRunner
 
 			return memoryStream;
 		}
+		catch ( IOException ex ) when (
+			ex.Message.Contains("pipe is being closed", StringComparison.OrdinalIgnoreCase) ||
+			ex.Message.Contains("Broken pipe", StringComparison.OrdinalIgnoreCase) )
+		{
+			// Process exited before stdin was fully consumed — normal when a fast-exit process
+			// ignores remaining input. The stdout data already written to memoryStream is valid.
+			_logger.LogDebug(
+				$"[ExifToolRunProcessAsync] Stdin pipe closed early for {referenceInfoAndPath}");
+			memoryStream.Seek(0, SeekOrigin.Begin);
+			return memoryStream;
+		}
 		catch ( Win32Exception exception )
 		{
 			throw new ArgumentException("Error when trying to start the exifTool process.  " +

--- a/starsky/starsky.foundation.writemeta/Helpers/ExifToolStreamToStreamRunner.cs
+++ b/starsky/starsky.foundation.writemeta/Helpers/ExifToolStreamToStreamRunner.cs
@@ -46,20 +46,12 @@ public class ExifToolStreamToStreamRunner
 
 		try
 		{
-			// run with pipes
-			var command = Default.Run(_appSettings.ExifToolPath,
-					options: opts =>
-					{
-						opts.StartInfo(si =>
-							si.Arguments = argumentsWithPipeEnd);
-					})
-				< sourceStream > memoryStream;
+			var resultSuccess = await RunCommandAsync(sourceStream, memoryStream,
+				argumentsWithPipeEnd).ConfigureAwait(false);
 
-			var result = await command.Task.ConfigureAwait(false);
-
-			_logger.LogInformation($"[ExifToolRunProcessAsync] {result.Success} ~ exifTool " +
+			_logger.LogInformation($"[ExifToolRunProcessAsync] {resultSuccess} ~ exifTool " +
 			                       $"{referenceInfoAndPath} {exifToolInputArguments} " +
-			                       $"run with result: {result.Success}  ~ ");
+			                       $"run with result: {resultSuccess}  ~ ");
 
 			memoryStream.Seek(0, SeekOrigin.Begin);
 
@@ -82,5 +74,19 @@ public class ExifToolStreamToStreamRunner
 			                            "Please make sure exifTool is installed, and its path is properly " +
 			                            "specified in the options.", exception);
 		}
+	}
+
+	protected virtual async Task<bool> RunCommandAsync(Stream sourceStream, Stream outputStream,
+		string arguments)
+	{
+		var command = Default.Run(_appSettings.ExifToolPath,
+				options: opts =>
+				{
+					opts.StartInfo(si => si.Arguments = arguments);
+				})
+			< sourceStream > outputStream;
+
+		var result = await command.Task.ConfigureAwait(false);
+		return result.Success;
 	}
 }

--- a/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolStreamToStreamRunnerTests.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolStreamToStreamRunnerTests.cs
@@ -145,6 +145,30 @@ public class ExifToolStreamToStreamRunnerTests
 	}
 
 	[TestMethod]
+	public async Task ExifTool_RunProcessAsync_PipeClosedEarly_ReturnsStream()
+	{
+		// The fake exiftool (bash echo on Unix, NASM stub on Windows) exits immediately
+		// without reading stdin. A stream larger than the OS pipe buffer (Windows ~4 KB,
+		// Unix ~64 KB) reliably triggers IOException "pipe is being closed" / "Broken pipe"
+		// before the write completes. The catch block should absorb the error and return
+		// whatever stdout was captured.
+		await SetupFakeExifToolExecutable();
+
+		var largeData = new byte[1024 * 1024]; // 1 MB — larger than any OS pipe buffer
+		var sourceStream = new MemoryStream(largeData);
+
+		var sut = new ExifToolStreamToStreamRunner(_appSettingsWithExifTool,
+			new FakeIWebLogger());
+
+		var stream = await sut.RunProcessAsync(sourceStream, "arg1", "reference");
+
+		Assert.IsNotNull(stream);
+
+		await sourceStream.DisposeAsync();
+		await stream.DisposeAsync();
+	}
+
+	[TestMethod]
 	public async Task ExifTool_RunProcessAsync_ExitCode()
 	{
 		if ( new AppSettings().IsWindows )

--- a/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolStreamToStreamRunnerTests.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolStreamToStreamRunnerTests.cs
@@ -147,22 +147,14 @@ public class ExifToolStreamToStreamRunnerTests
 	[TestMethod]
 	public async Task ExifTool_RunProcessAsync_PipeClosedEarly_ReturnsStream()
 	{
-		// The fake exiftool (bash echo on Unix, NASM stub on Windows) exits immediately
-		// without reading stdin. A stream larger than the OS pipe buffer (Windows ~4 KB,
-		// Unix ~64 KB) reliably triggers IOException "pipe is being closed" / "Broken pipe"
-		// before the write completes. The catch block should absorb the error, log a debug
-		// message, and return whatever stdout was captured.
-		await SetupFakeExifToolExecutable();
-
-		var largeData = new byte[1024 * 1024]; // 1 MB — larger than any OS pipe buffer
-		var sourceStream = new MemoryStream(largeData);
 		var logger = new FakeIWebLogger();
-
-		var sut = new ExifToolStreamToStreamRunner(_appSettingsWithExifTool, logger);
+		var sourceStream = new MemoryStream();
+		var sut = new PipeClosedExifToolStreamToStreamRunner(_appSettingsWithExifTool, logger);
 
 		var stream = await sut.RunProcessAsync(sourceStream, "arg1", "reference");
 
 		Assert.IsNotNull(stream);
+		Assert.AreEqual(0, stream.Position);
 		Assert.IsTrue(
 			logger.TrackedDebug.Exists(x =>
 				x.Item2?.Contains("pipe closed early", StringComparison.OrdinalIgnoreCase) == true),
@@ -291,4 +283,18 @@ public class ExifToolStreamToStreamRunnerTests
 	// 		}
 	// 	}
 	// }
+
+	private sealed class PipeClosedExifToolStreamToStreamRunner : ExifToolStreamToStreamRunner
+	{
+		public PipeClosedExifToolStreamToStreamRunner(AppSettings appSettings, FakeIWebLogger logger)
+			: base(appSettings, logger)
+		{
+		}
+
+		protected override Task<bool> RunCommandAsync(Stream sourceStream, Stream outputStream,
+			string arguments)
+		{
+			throw new IOException("pipe is being closed");
+		}
+	}
 }

--- a/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolStreamToStreamRunnerTests.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolStreamToStreamRunnerTests.cs
@@ -150,19 +150,23 @@ public class ExifToolStreamToStreamRunnerTests
 		// The fake exiftool (bash echo on Unix, NASM stub on Windows) exits immediately
 		// without reading stdin. A stream larger than the OS pipe buffer (Windows ~4 KB,
 		// Unix ~64 KB) reliably triggers IOException "pipe is being closed" / "Broken pipe"
-		// before the write completes. The catch block should absorb the error and return
-		// whatever stdout was captured.
+		// before the write completes. The catch block should absorb the error, log a debug
+		// message, and return whatever stdout was captured.
 		await SetupFakeExifToolExecutable();
 
 		var largeData = new byte[1024 * 1024]; // 1 MB — larger than any OS pipe buffer
 		var sourceStream = new MemoryStream(largeData);
+		var logger = new FakeIWebLogger();
 
-		var sut = new ExifToolStreamToStreamRunner(_appSettingsWithExifTool,
-			new FakeIWebLogger());
+		var sut = new ExifToolStreamToStreamRunner(_appSettingsWithExifTool, logger);
 
 		var stream = await sut.RunProcessAsync(sourceStream, "arg1", "reference");
 
 		Assert.IsNotNull(stream);
+		Assert.IsTrue(
+			logger.TrackedDebug.Exists(x =>
+				x.Item2?.Contains("pipe closed early", StringComparison.OrdinalIgnoreCase) == true),
+			"Expected the pipe-closed catch block to log a debug message");
 
 		await sourceStream.DisposeAsync();
 		await stream.DisposeAsync();


### PR DESCRIPTION
…after printing "Fake ExifTool" without reading stdin. When Medallion.Shell tries to pipe sourceStream into the process, the pipe is already closed, causing IOException: The pipe is being closed.

This is also a real-world scenario — ExifTool could exit before consuming all stdin. The fix is to catch the broken-pipe IOException in RunProcessAsync and return the already-captured stdout.

The fix catches IOException for both the Windows message ("The pipe is being closed") and the Unix equivalent ("Broken pipe"). In both cases the process has already written its stdout to memoryStream, so we seek back to the start and return it — same behavior as the success path.

The race: fake ExifTool on Windows exits immediately without reading stdin → Medallion.Shell's stdin-piping task throws IOException as it tries to write [0x01, 0x02, 0x03] to the now-closed pipe → previously this propagated as an unhandled exception → now it's caught and treated as a normal early-exit.

This pull request improves the robustness of the `ExifToolStreamToStreamRunner` by handling cases where the external process closes its input pipe early, and adds a test to verify this behavior.

**Error handling improvements:**

* Updated `RunProcessAsync` in `ExifToolStreamToStreamRunner.cs` to catch `IOException` with messages indicating the pipe was closed early (e.g., "pipe is being closed", "Broken pipe"). It now logs the event and returns the valid data already written to the output stream, instead of failing the operation.

**Testing enhancements:**

* Added the test `ExifTool_RunProcessAsync_PipeClosedEarly_ReturnsStream` in `ExifToolStreamToStreamRunnerTests.cs` to ensure that when the process closes its pipe early, the method still returns the captured output stream without throwing an error.


# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
