### PR TITLE
Feature/202608 update errors

### DIFF
--- a/history.md
+++ b/history.md
@@ -46,6 +46,10 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## version 0.9.0-beta.3 - 2026-09-03 {#0.9.0-beta.3}
 
+- [x] (Added) _App_ Windows Detailed logging to UpdateService.CheckAsync (PR #3282)
+- [x] (Fixed) _App_ macOS AppCast add monotonically-increasing build number (PR #3282)
+- [x] (Fixed) _Back-end_ Timeout GetAllRecursiveAsync recognize CommandTimeoutExpired (PR #3282)
+- [x] (Fixed) _Back-end_ SQLite unique constraint violations (error code 19) (PR #3282)
 - [x] (Fixed) _App_ macOS For updates add CFBundleVersion (PR #3281)
 
 ## version 0.9.0-beta.2 - 2026-09-02 {#0.9.0-beta.2}

--- a/mac/scripts/publish-appcast.sh
+++ b/mac/scripts/publish-appcast.sh
@@ -20,6 +20,37 @@ OUTPUT_PATH="${3:-appcast-macos.xml}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_FILE="$SCRIPT_DIR/../project.yml"
 
+# Derives a monotonically-increasing integer from a semver string, mirroring
+# the formula in starsky-tools/build-tools/app-version-update.js:
+#   major * 1_000_000 + minor * 10_000 + patch * 100 + preType * 30 + preNumber
+#   preType: alpha=0, beta=1, rc=2, stable=3  (preNumber must be < 30)
+#   Stable: preType=3, preNumber=9  →  always above any pre-release for same x.y.z
+compute_build_number() {
+  local version="$1"
+  local major minor patch pre_type pre_num
+  major="$(echo "$version" | sed 's/^\([0-9]*\)\..*/\1/')"
+  minor="$(echo "$version" | sed 's/^[0-9]*\.\([0-9]*\)\..*/\1/')"
+  patch="$(echo "$version" | sed 's/^[0-9]*\.[0-9]*\.\([0-9]*\).*/\1/')"
+  local pre_label
+  pre_label="$(echo "$version" | sed -n 's/^[0-9]*\.[0-9]*\.[0-9]*-\(.*\)/\1/p')"
+  if [[ -z "$pre_label" ]]; then
+    pre_type=3; pre_num=9
+  elif [[ "$pre_label" == alpha.* ]]; then
+    pre_type=0; pre_num="${pre_label#alpha.}"
+  elif [[ "$pre_label" == beta.* ]]; then
+    pre_type=1; pre_num="${pre_label#beta.}"
+  elif [[ "$pre_label" == rc.* ]]; then
+    pre_type=2; pre_num="${pre_label#rc.}"
+  else
+    echo "Warning: unrecognised pre-release label '$pre_label', treating as stable." >&2
+    pre_type=3; pre_num=9
+  fi
+  echo $(( major * 1000000 + minor * 10000 + patch * 100 + pre_type * 30 + pre_num ))
+}
+
+BUILD_NUMBER="$(compute_build_number "$VERSION")"
+echo "==> sparkle:version (CFBundleVersion) = $BUILD_NUMBER"
+
 SPARKLE_VERSION="$(awk '
   $0 == "  Sparkle:" { in_sparkle = 1; next }
   in_sparkle && /^[^[:space:]]/ { exit }
@@ -78,7 +109,7 @@ cat > "$OUTPUT_PATH" <<XML
     <item>
       <title>${VERSION}</title>
       <pubDate>${PUB_DATE}</pubDate>
-      <sparkle:version>${VERSION}</sparkle:version>
+      <sparkle:version>${BUILD_NUMBER}</sparkle:version>
       <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>13.0.0</sparkle:minimumSystemVersion>
       <enclosure

--- a/starsky/starsky.foundation.database/Query/QueryGetAllRecursive.cs
+++ b/starsky/starsky.foundation.database/Query/QueryGetAllRecursive.cs
@@ -52,7 +52,8 @@ public partial class Query
 		{
 			// https://github.com/qdraw/starsky/issues/1243
 			// https://github.com/qdraw/starsky/issues/1628
-			if ( exception.ErrorCode is not (MySqlErrorCode.QueryTimeout or
+			if ( exception.ErrorCode is not (MySqlErrorCode.CommandTimeoutExpired or
+			    MySqlErrorCode.QueryTimeout or
 			    MySqlErrorCode.LockWaitTimeout or
 			    MySqlErrorCode.QueryInterrupted) )
 			{

--- a/starsky/starsky.foundation.database/Thumbnails/ThumbnailQuery.cs
+++ b/starsky/starsky.foundation.database/Thumbnails/ThumbnailQuery.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Data.Sqlite;
 using MySqlConnector;
 using starsky.foundation.database.Data;
 using starsky.foundation.database.Helpers;
@@ -259,6 +260,15 @@ public class ThumbnailQuery : IThumbnailQuery
 				_logger.LogInformation(
 					"[SaveChangesDuplicate] OK Duplicate entry error occurred: " +
 					$"{mySqlException.Message}");
+				return;
+			}
+
+			// SQLite UNIQUE constraint violation (error code 19)
+			if ( exception.InnerException is SqliteException { SqliteErrorCode: 19 } sqliteException )
+			{
+				_logger.LogInformation(
+					"[SaveChangesDuplicate] OK SQLite unique constraint error occurred: " +
+					$"{sqliteException.Message}");
 				return;
 			}
 

--- a/starsky/starskytest/starsky.foundation.database/QueryTest/QueryGetAllRecursiveTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/QueryTest/QueryGetAllRecursiveTest.cs
@@ -98,6 +98,7 @@ public sealed class QueryGetAllRecursiveTest
 	}
 
 	[TestMethod] // [Theory]
+	[DataRow(MySqlErrorCode.CommandTimeoutExpired)]
 	[DataRow(MySqlErrorCode.QueryTimeout)]
 	[DataRow(MySqlErrorCode.QueryInterrupted)]
 	public async Task Retry_When_HitTimeout(MySqlErrorCode code)

--- a/starsky/starskytest/starsky.foundation.database/Thumbnails/ThumbnailQueryTest.cs
+++ b/starsky/starskytest/starsky.foundation.database/Thumbnails/ThumbnailQueryTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -1025,6 +1026,37 @@ public class ThumbnailQueryTest
 		public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
 		{
 			throw new DbUpdateConcurrencyException();
+		}
+	}
+
+	[TestMethod]
+	public async Task AddThumbnailRangeAsync_SqliteUniqueConstraintException()
+	{
+		var addedItems = new List<ThumbnailResultDataTransferModel> { new("test123", null, true) };
+
+		var serviceScopeFactory =
+			CreateNewScope(nameof(AddThumbnailRangeAsync_SqliteUniqueConstraintException));
+		var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+			.UseInMemoryDatabase(nameof(AddThumbnailRangeAsync_SqliteUniqueConstraintException))
+			.Options;
+		var dbContext = new SqliteUniqueConstraintApplicationDbContext(options);
+
+		var webLogger = new FakeIWebLogger();
+		var importQuery = new ThumbnailQuery(dbContext, serviceScopeFactory, webLogger);
+
+		await importQuery.AddThumbnailRangeAsync(addedItems);
+
+		Assert.IsTrue(webLogger.TrackedInformation.Exists(x =>
+			x.Item2?.StartsWith("[SaveChangesDuplicate] OK SQLite unique constraint") == true));
+	}
+
+	private sealed class SqliteUniqueConstraintApplicationDbContext(DbContextOptions options)
+		: ApplicationDbContext(options)
+	{
+		public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+		{
+			var sqliteException = new SqliteException("SQLite Error 19: 'UNIQUE constraint failed'", 19);
+			throw new DbUpdateException("unique constraint", sqliteException);
 		}
 	}
 }

--- a/windows/Services/UpdateService.cs
+++ b/windows/Services/UpdateService.cs
@@ -40,8 +40,6 @@ public class UpdateService
 
     public async Task<bool> CheckAsync()
     {
-        _logger.LogInformation("[UpdateService] CheckAsync started");
-
         if (!_settings.Current.UpdateCheckEnabled)
         {
             _logger.LogInformation("[UpdateService] Update check is disabled in settings");

--- a/windows/Services/UpdateService.cs
+++ b/windows/Services/UpdateService.cs
@@ -40,22 +40,30 @@ public class UpdateService
 
     public async Task<bool> CheckAsync()
     {
+        _logger.LogInformation("[UpdateService] CheckAsync started");
+
         if (!_settings.Current.UpdateCheckEnabled)
         {
-	        return false;
+            _logger.LogInformation("[UpdateService] Update check is disabled in settings");
+            return false;
         }
 
         if ( !_settings.Current.LastUpdateWarningShown.HasValue )
         {
-	        return await CheckWithVelopackAsync();
+            _logger.LogInformation("[UpdateService] No previous check recorded; running check now");
+            return await CheckWithVelopackAsync();
         }
 
         var minutesSince = (DateTime.UtcNow - _settings.Current.LastUpdateWarningShown.Value).TotalMinutes;
+        _logger.LogInformation("[UpdateService] Minutes since last update warning: {MinutesSince} (suppress threshold: {SuppressMinutes})", minutesSince, SuppressMinutes);
+
         if (minutesSince < SuppressMinutes)
         {
-	        return false;
+            _logger.LogInformation("[UpdateService] Suppressing update check (within suppress window)");
+            return false;
         }
 
+        _logger.LogInformation("[UpdateService] Suppress window elapsed; running check now");
         return await CheckWithVelopackAsync();
     }
 
@@ -81,14 +89,27 @@ public class UpdateService
     {
         if (!IsVelopackAvailable)
         {
-	        return false;
+            _logger.LogInformation("[UpdateService] Velopack is not available; skipping update check");
+            return false;
         }
+
+        _logger.LogInformation("[UpdateService] Querying GitHub for updates (pre-release: {PreRelease})", _settings.Current.UpdatePreRelease);
 
         try
         {
             _updateManager = new UpdateManager(
                 new GithubSource(GithubRepoUrl, null, _settings.Current.UpdatePreRelease));
             _pendingUpdate = await _updateManager.CheckForUpdatesAsync();
+
+            if (_pendingUpdate != null)
+            {
+                _logger.LogInformation("[UpdateService] Update available: {Version}", _pendingUpdate.TargetFullRelease.Version);
+            }
+            else
+            {
+                _logger.LogInformation("[UpdateService] No update available; already on latest version");
+            }
+
             return _pendingUpdate != null;
         }
         catch (Exception ex)

--- a/windows/build-velopack.ps1
+++ b/windows/build-velopack.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
     Steps:
       1. (Optional) Build the Starsky backend for win-x64 using the NUKE build system.
-         Skip with -SkipBackendBuild if starsky\win-x64\ already exists.
+         Skip with -SkipBackend if starsky\win-x64\ already exists.
       2. dotnet publish the WPF app (also copies runtime-starsky-win-x64 into publish dir).
       3. Install the Velopack CLI (vpk) if not already present.
       4. vpk pack to produce the installer and update feed.
@@ -25,17 +25,25 @@
     .\build-velopack.ps1
 
     # Skip the slow backend build if you already have starsky\win-x64\:
-    .\build-velopack.ps1 -SkipBackendBuild
+    .\build-velopack.ps1 -SkipBackend
 
     # Override version:
-    .\build-velopack.ps1 -Version 0.8.2 -SkipBackendBuild
+    .\build-velopack.ps1 -Version 0.8.2 -SkipBackend
 #>
 [CmdletBinding()]
 param(
+    [Alias('h')]
+    [switch] $Help,
     [string] $Version,
+    [Alias('skip-backend', 'SkipBackend')]
     [switch] $SkipBackendBuild,
     [string] $OutputDir
 )
+
+if ($Help) {
+    Get-Help $MyInvocation.MyCommand.Path -Detailed
+    exit 0
+}
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request introduces several improvements across the codebase, primarily focused on more robust error handling for database operations, improved logging for update checks, and enhancements to versioning for macOS appcast publishing. The most significant changes include adding support for SQLite unique constraint violations, refining MySQL timeout error handling, increasing logging detail in the Windows update service, and updating the versioning scheme in the macOS appcast script.

**Database error handling improvements:**

* Added explicit handling for SQLite unique constraint violations (error code 19) in `ThumbnailQuery.SaveChangesDuplicate`, logging them as expected and non-fatal events. This is supported by a new unit test simulating the exception. [[1]](diffhunk://#diff-d8062d869767e1966fe1b1919a5db2055fe6e2d7b04ee8560a846b1d7236c787R266-R274) [[2]](diffhunk://#diff-d2bec61135c62cc6e01e18277d7d2501d1417b6daadf931fe7216002def8327dR1031-R1061)
* Updated MySQL timeout error handling in `QueryGetAllRecursiveAsync` to also recognize `CommandTimeoutExpired` as a retriable error, and extended test coverage accordingly. [[1]](diffhunk://#diff-e2d8c531d87610e582957148b038dd50409e3ca8b90c9d63221310d5b1041514L55-R56) [[2]](diffhunk://#diff-79bd2ee926042283d9146491e1902872e0d71200b02f58f90972fa30055e056cR101)

**Logging enhancements:**

* Added detailed informational logging to `UpdateService.CheckAsync` and `CheckWithVelopackAsync` in the Windows client, making update check behavior and outcomes more transparent for diagnostics. [[1]](diffhunk://#diff-d2dc4fee790186d83faa9cd90cade2a630e45b1e599d1b15b3f847ea6123ca96R43-R66) [[2]](diffhunk://#diff-d2dc4fee790186d83faa9cd90cade2a630e45b1e599d1b15b3f847ea6123ca96R92-R112)

**Versioning and appcast publishing:**

* Introduced a new function in `publish-appcast.sh` to compute a monotonically-increasing build number from a semantic version string, ensuring correct version ordering in Sparkle appcasts. The appcast now publishes this build number as the `sparkle:version`. [[1]](diffhunk://#diff-1f72d1e9841f20ee326d8986609eabfb69da4565ded4cb116e023ab5c1292d86R23-R53) [[2]](diffhunk://#diff-1f72d1e9841f20ee326d8986609eabfb69da4565ded4cb116e023ab5c1292d86L81-R112)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
