### PR TITLE
Feature/202608 image stabilization

### DIFF
--- a/history.md
+++ b/history.md
@@ -40,7 +40,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## List of versions
 
-## version 0.9.0-beta.3 - _(Unreleased)_ - 2026-?-? {#0.9.0-beta.3}
+## version 0.9.0-beta.4 - _(Unreleased)_ - 2026-?-? {#0.9.0-beta.4}
 
 - nothing yet
 

--- a/history.md
+++ b/history.md
@@ -42,7 +42,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## version 0.9.0-beta.4 - _(Unreleased)_ - 2026-?-? {#0.9.0-beta.4}
 
-- nothing yet
+- [x] (Fixed) _Back-end_ Read and Write XMP tag for ImageStabilization (PR #3290)
 
 ## version 0.9.0-beta.3 - 2026-09-03 {#0.9.0-beta.3}
 

--- a/starsky/starsky.foundation.readmeta/ReadMetaHelpers/ReadMetaExif.cs
+++ b/starsky/starsky.foundation.readmeta/ReadMetaHelpers/ReadMetaExif.cs
@@ -156,6 +156,17 @@ public sealed class ReadMetaExif
 		{
 			item.ImageClassificationGeneratedAt = parsedGeneratedAt;
 		}
+
+		var imageStabilization = GetXmpData(xmpDirectory, "qdraw:ImageStabilization");
+		if ( !string.IsNullOrWhiteSpace(imageStabilization) )
+		{
+			item.ImageStabilisation = imageStabilization switch
+			{
+				"On" => ImageStabilisationType.On,
+				"Off" => ImageStabilisationType.Off,
+				_ => ImageStabilisationType.Unknown
+			};
+		}
 	}
 
 	private static void SetArrayBasedItemsArtist(List<Directory> allExifItems, FileIndexItem item)
@@ -1397,5 +1408,11 @@ public sealed class ReadMetaExif
 		int.TryParse(isoSpeedString, NumberStyles.Number, CultureInfo.InvariantCulture,
 			out var isoSpeed);
 		return isoSpeed;
+	}
+
+	internal static void SetArrayBasedItemsAiClassificationTest(List<Directory> allExifItems,
+		FileIndexItem item)
+	{
+		SetArrayBasedItemsAiClassification(allExifItems, item);
 	}
 }

--- a/starsky/starsky.foundation.readmeta/ReadMetaHelpers/ReadMetaXmp.cs
+++ b/starsky/starsky.foundation.readmeta/ReadMetaHelpers/ReadMetaXmp.cs
@@ -386,6 +386,16 @@ public sealed class ReadMetaXmp
 		{
 			item.ImageClassificationGeneratedAt = generatedAt;
 		}
+
+		if ( property.Path == "qdraw:ImageStabilization" )
+		{
+			item.ImageStabilisation = property.Value switch
+			{
+				"On" => ImageStabilisationType.On,
+				"Off" => ImageStabilisationType.Off,
+				_ => ImageStabilisationType.Unknown
+			};
+		}
 	}
 
 	private static string AddCommaSeparatedUnique(string? current, string value)

--- a/starsky/starsky.foundation.writemeta/Helpers/ExifToolCmdHelper.cs
+++ b/starsky/starsky.foundation.writemeta/Helpers/ExifToolCmdHelper.cs
@@ -165,7 +165,8 @@ public sealed class ExifToolCmdHelper
 			{
 				nameof(FileIndexItem.SuggestedTags), nameof(FileIndexItem.RejectedTags),
 				nameof(FileIndexItem.ImageClassificationModel),
-				nameof(FileIndexItem.ImageClassificationGeneratedAt)
+				nameof(FileIndexItem.ImageClassificationGeneratedAt),
+				nameof(FileIndexItem.ImageStabilisation)
 			}
 			.Select(x => x.ToLowerInvariant());
 
@@ -776,8 +777,8 @@ public sealed class ExifToolCmdHelper
 			     .ToLowerInvariant()) &&
 		     updateModel.ImageStabilisation != ImageStabilisationType.Unknown )
 		{
-			// there is no XMP version of the name
-			command += $" -ImageStabilization=\"{updateModel.ImageStabilisation}\" ";
+			command += $" -ImageStabilization=\"{updateModel.ImageStabilisation}\" " +
+			           $"-XMP-qdraw:ImageStabilization=\"{updateModel.ImageStabilisation}\" ";
 		}
 
 		return command;

--- a/starsky/starsky.foundation.writemeta/Helpers/ExifToolCmdHelper.cs
+++ b/starsky/starsky.foundation.writemeta/Helpers/ExifToolCmdHelper.cs
@@ -93,7 +93,7 @@ public sealed class ExifToolCmdHelper
 		var command = string.Empty;
 
 		// Update AI config needed first to be working
-		command = UpdateAiConfig(command, comparedNames);
+		command = UpdateAiConfig(command, comparedNames, updateModel);
 
 		const string initCommand = "-json -overwrite_original"; // to check if nothing
 		command += initCommand;
@@ -159,18 +159,24 @@ public sealed class ExifToolCmdHelper
 		return configPath;
 	}
 
-	private string UpdateAiConfig(string command, List<string> comparedNames)
+	private string UpdateAiConfig(string command, List<string> comparedNames,
+		FileIndexItem updateModel)
 	{
-		var required = new[]
+		var required = new List<string>
 			{
 				nameof(FileIndexItem.SuggestedTags), nameof(FileIndexItem.RejectedTags),
 				nameof(FileIndexItem.ImageClassificationModel),
-				nameof(FileIndexItem.ImageClassificationGeneratedAt),
-				nameof(FileIndexItem.ImageStabilisation)
-			}
-			.Select(x => x.ToLowerInvariant());
+				nameof(FileIndexItem.ImageClassificationGeneratedAt)
+			};
 
-		if ( !comparedNames.Intersect(required).Any() )
+		if ( updateModel.ImageStabilisation != ImageStabilisationType.Unknown )
+		{
+			required.Add(nameof(FileIndexItem.ImageStabilisation));
+		}
+
+		var requiredLower = required.Select(x => x.ToLowerInvariant());
+
+		if ( !comparedNames.Intersect(requiredLower).Any() )
 		{
 			return command;
 		}

--- a/starsky/starsky/exiftool.config
+++ b/starsky/starsky/exiftool.config
@@ -5,6 +5,11 @@
     TagTable => 'Image::ExifTool::UserDefined::ai'
     },
     },
+    qdraw => {
+    SubDirectory => {
+    TagTable => 'Image::ExifTool::UserDefined::qdraw'
+    },
+    },
     },
     );
 
@@ -28,6 +33,20 @@
     ImageClassificationGeneratedAt => {
     Writable => 'date',
     },
+    );
+
+
+    %Image::ExifTool::UserDefined::qdraw = (
+    GROUPS => {
+    0 => 'XMP',
+    1 => 'XMP-qdraw',
+    2 => 'Image',
+    },
+    NAMESPACE => {
+    qdraw => 'https://qdraw.nl/ns/qdraw/1.0/',
+    },
+    WRITABLE => 'string',
+    ImageStabilization => {},
     );
 
     1;

--- a/starsky/starskytest/starsky.foundation.readmeta/Services/ReadMeta_ExifReadTest.cs
+++ b/starsky/starskytest/starsky.foundation.readmeta/Services/ReadMeta_ExifReadTest.cs
@@ -1099,4 +1099,46 @@ public sealed class ExifReadTest
 		// Assert
 		Assert.AreEqual(19.881148, result, 0.0000000001);
 	}
+
+	[TestMethod]
+	public void ExifRead_QdrawImageStabilization_On()
+	{
+		const string xmpData = "<x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF " +
+		                       "xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Description " +
+		                       "rdf:about='' xmlns:qdraw='https://qdraw.nl/ns/qdraw/1.0/'>" +
+		                       "<qdraw:ImageStabilization>On</qdraw:ImageStabilization>" +
+		                       "</rdf:Description></rdf:RDF></x:xmpmeta>";
+
+		var xmpMeta = XmpMetaFactory.ParseFromString(xmpData);
+		var container = new List<Directory>();
+		var dir = new XmpDirectory();
+		dir.SetXmpMeta(xmpMeta);
+		container.Add(dir);
+
+		var item = new FileIndexItem();
+		ReadMetaExif.SetArrayBasedItemsAiClassificationTest(container, item);
+
+		Assert.AreEqual(ImageStabilisationType.On, item.ImageStabilisation);
+	}
+
+	[TestMethod]
+	public void ExifRead_QdrawImageStabilization_Off()
+	{
+		const string xmpData = "<x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF " +
+		                       "xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Description " +
+		                       "rdf:about='' xmlns:qdraw='https://qdraw.nl/ns/qdraw/1.0/'>" +
+		                       "<qdraw:ImageStabilization>Off</qdraw:ImageStabilization>" +
+		                       "</rdf:Description></rdf:RDF></x:xmpmeta>";
+
+		var xmpMeta = XmpMetaFactory.ParseFromString(xmpData);
+		var container = new List<Directory>();
+		var dir = new XmpDirectory();
+		dir.SetXmpMeta(xmpMeta);
+		container.Add(dir);
+
+		var item = new FileIndexItem();
+		ReadMetaExif.SetArrayBasedItemsAiClassificationTest(container, item);
+
+		Assert.AreEqual(ImageStabilisationType.Off, item.ImageStabilisation);
+	}
 }

--- a/starsky/starskytest/starsky.foundation.readmeta/Services/ReadMeta_XmpReadHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.readmeta/Services/ReadMeta_XmpReadHelperTest.cs
@@ -326,4 +326,34 @@ public sealed class XmpReadHelperTest
 		Assert.AreEqual(new DateTime(2026, 4, 21, 10, 20, 30, DateTimeKind.Utc),
 			data.ImageClassificationGeneratedAt);
 	}
+
+	[TestMethod]
+	public void XmpReadHelperTest_GetData_QdrawImageStabilizationOn()
+	{
+		const string xmpData = "<x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF " +
+		                       "xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Description " +
+		                       "rdf:about='' xmlns:qdraw='https://qdraw.nl/ns/qdraw/1.0/'>" +
+		                       "<qdraw:ImageStabilization>On</qdraw:ImageStabilization>" +
+		                       "</rdf:Description></rdf:RDF></x:xmpmeta>";
+
+		var data =
+			new ReadMetaXmp(new FakeIStorage(), new FakeIWebLogger()).GetDataFromString(xmpData);
+
+		Assert.AreEqual(ImageStabilisationType.On, data.ImageStabilisation);
+	}
+
+	[TestMethod]
+	public void XmpReadHelperTest_GetData_QdrawImageStabilizationOff()
+	{
+		const string xmpData = "<x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF " +
+		                       "xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Description " +
+		                       "rdf:about='' xmlns:qdraw='https://qdraw.nl/ns/qdraw/1.0/'>" +
+		                       "<qdraw:ImageStabilization>Off</qdraw:ImageStabilization>" +
+		                       "</rdf:Description></rdf:RDF></x:xmpmeta>";
+
+		var data =
+			new ReadMetaXmp(new FakeIStorage(), new FakeIWebLogger()).GetDataFromString(xmpData);
+
+		Assert.AreEqual(ImageStabilisationType.Off, data.ImageStabilisation);
+	}
 }

--- a/starsky/starskytest/starsky.foundation.readmeta/Services/ReadMeta_XmpReadHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.readmeta/Services/ReadMeta_XmpReadHelperTest.cs
@@ -356,4 +356,19 @@ public sealed class XmpReadHelperTest
 
 		Assert.AreEqual(ImageStabilisationType.Off, data.ImageStabilisation);
 	}
+
+	[TestMethod]
+	public void XmpReadHelperTest_GetData_QdrawImageStabilizationUnknown()
+	{
+		const string xmpData = "<x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF " +
+		                       "xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Description " +
+		                       "rdf:about='' xmlns:qdraw='https://qdraw.nl/ns/qdraw/1.0/'>" +
+		                       "<qdraw:ImageStabilization>SomeUnknownValue</qdraw:ImageStabilization>" +
+		                       "</rdf:Description></rdf:RDF></x:xmpmeta>";
+
+		var data =
+			new ReadMetaXmp(new FakeIStorage(), new FakeIWebLogger()).GetDataFromString(xmpData);
+
+		Assert.AreEqual(ImageStabilisationType.Unknown, data.ImageStabilisation);
+	}
 }

--- a/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolCmdHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolCmdHelperTest.cs
@@ -321,9 +321,9 @@ public sealed class ExifToolCmdHelperTest
 			null!, new FakeIWebLogger(), new AppSettings()).ExifToolCommandLineArgs(updateModel,
 			comparedNames, true);
 
-		Assert.IsTrue(result.Contains("-ImageStabilization=\"On\""),
+		Assert.Contains("-ImageStabilization=\"On\"", result,
 			"Expected EXIF ImageStabilization flag");
-		Assert.IsTrue(result.Contains("-XMP-qdraw:ImageStabilization=\"On\""),
+		Assert.Contains("-XMP-qdraw:ImageStabilization=\"On\"", result,
 			"Expected XMP-qdraw ImageStabilization flag");
 	}
 
@@ -346,9 +346,9 @@ public sealed class ExifToolCmdHelperTest
 			new AppSettings());
 		var helperResult = await sut.UpdateAsync(updateModel, comparedNames);
 
-		Assert.IsTrue(helperResult.Command.Contains($"-config \"{sut.GetConfigPath()}\""),
+		Assert.Contains($"-config \"{sut.GetConfigPath()}\"", helperResult.Command,
 			"Expected -config flag when writing ImageStabilisation");
-		Assert.IsTrue(helperResult.Command.Contains("-XMP-qdraw:ImageStabilization=\"On\""),
+		Assert.Contains("-XMP-qdraw:ImageStabilization=\"On\"", helperResult.Command,
 			"Expected XMP-qdraw ImageStabilization flag");
 	}
 

--- a/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolCmdHelperTest.cs
+++ b/starsky/starskytest/starsky.foundation.writemeta/Helpers/ExifToolCmdHelperTest.cs
@@ -318,10 +318,38 @@ public sealed class ExifToolCmdHelperTest
 
 		var result = new ExifToolCmdHelper(null!, null!,
 			null!, null!,
-			null!, null!, new AppSettings()).ExifToolCommandLineArgs(updateModel,
+			null!, new FakeIWebLogger(), new AppSettings()).ExifToolCommandLineArgs(updateModel,
 			comparedNames, true);
 
-		Assert.AreEqual("-json -overwrite_original -ImageStabilization=\"On\" ", result);
+		Assert.IsTrue(result.Contains("-ImageStabilization=\"On\""),
+			"Expected EXIF ImageStabilization flag");
+		Assert.IsTrue(result.Contains("-XMP-qdraw:ImageStabilization=\"On\""),
+			"Expected XMP-qdraw ImageStabilization flag");
+	}
+
+	[TestMethod]
+	public async Task ExifToolCommandLineArgs_ImageStabilisation_InjectsConfig()
+	{
+		var updateModel = new FileIndexItem
+		{
+			ImageStabilisation = ImageStabilisationType.On
+		};
+		var comparedNames = new List<string>
+		{
+			nameof(FileIndexItem.ImageStabilisation).ToLowerInvariant()
+		};
+
+		var storage = new FakeIStorage(["/"], ["/test.jpg"], new List<byte[]>());
+		var fakeExifTool = new FakeExifTool(storage, _appSettings);
+		var sut = new ExifToolCmdHelper(fakeExifTool, storage, storage,
+			new FakeReadMeta(), new FakeIThumbnailQuery(), new FakeIWebLogger(),
+			new AppSettings());
+		var helperResult = await sut.UpdateAsync(updateModel, comparedNames);
+
+		Assert.IsTrue(helperResult.Command.Contains($"-config \"{sut.GetConfigPath()}\""),
+			"Expected -config flag when writing ImageStabilisation");
+		Assert.IsTrue(helperResult.Command.Contains("-XMP-qdraw:ImageStabilization=\"On\""),
+			"Expected XMP-qdraw ImageStabilization flag");
 	}
 
 	[TestMethod]


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request introduces support for reading and writing the custom `qdraw:ImageStabilization` XMP tag, allowing the application to handle image stabilization metadata for images using the Qdraw XMP namespace. The changes include updates to both the metadata reading and writing logic, configuration for ExifTool, and comprehensive tests to ensure correct functionality.

**Support for Image Stabilization Metadata:**

- **Reading Image Stabilization from XMP:**
  - Added logic to `ReadMetaExif` and `ReadMetaXmp` to read the `qdraw:ImageStabilization` XMP property and map its value (`On`, `Off`, or unknown) to the `ImageStabilisationType` enum in `FileIndexItem`. [[1]](diffhunk://#diff-18bd66894cff36512dc9051e9ddc5f7e3ac0d5664d3d72b2c6f03f9287f53d6aR159-R169) [[2]](diffhunk://#diff-5e67dc6c3d5f80bf73ea0f2be9573ccded45fe3ae79781e5da8ce1a45c78e4efR389-R398)

- **Writing Image Stabilization to XMP and EXIF:**
  - Updated `ExifToolCmdHelper` so that when writing image stabilization, both the standard `ImageStabilization` and the custom `XMP-qdraw:ImageStabilization` tags are set. The property is now included in the list of AI config fields. [[1]](diffhunk://#diff-7ffc78e02fb265216042f5be61833703279aa1a9840fcf0f9db1e792d2d59231L168-R169) [[2]](diffhunk://#diff-7ffc78e02fb265216042f5be61833703279aa1a9840fcf0f9db1e792d2d59231L779-R781)

**ExifTool Configuration:**

- **Custom XMP Namespace:**
  - Updated `exiftool.config` to define the `qdraw` namespace and the `ImageStabilization` tag, enabling ExifTool to read and write this custom XMP property. [[1]](diffhunk://#diff-f9a10a21eff5ed4344e9ccb51aeec863a50803eb6b00ddb076dd56347d963127R8-R12) [[2]](diffhunk://#diff-f9a10a21eff5ed4344e9ccb51aeec863a50803eb6b00ddb076dd56347d963127R38-R51)

**Testing Enhancements:**

- **Unit Tests for Reading:**
  - Added tests to verify correct reading of `qdraw:ImageStabilization` values (`On` and `Off`) from XMP metadata in both `ReadMetaExif` and `ReadMetaXmp`. [[1]](diffhunk://#diff-2e3c6478bb3ec1cba02120e9fa02b48532aa4fa5f886b1aece49b1300a132d81R1102-R1143) [[2]](diffhunk://#diff-3203654799dce10726f85b28525642914657a80b3e591838c3bb638deea8819dR329-R358)

- **Unit Tests for Writing:**
  - Enhanced tests to check that the correct command-line arguments are generated for ExifTool, ensuring both EXIF and XMP-qdraw tags are written, and that the config file is injected when writing.

**Versioning:**

- **History Update:**
  - Bumped the version in `history.md` to `0.9.0-beta.4` to reflect these changes.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
