### PR TITLE
Microsoft Testing Platform (MTP) 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,6 +27,9 @@
 *.md text eol=lf
 *.xml text eol=lf
 
+# Verify.MSTest — snapshot files must have LF so VerifiedLineEndingException is not thrown on Windows
+*.verified.txt text eol=lf
+
 # windows specific files
 *.{cmd,[cC][mM][dD]} text eol=crlf
 *.{bat,[bB][aA][tT]} text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -404,6 +404,7 @@ starsky-netframework-msbuild.zip
 **/coverage-report/*
 **/coverage-report.zip
 **/netcore-coverage.opencover.xml
+**/netcore-coverage.cobertura.xml
 **/jest-coverage.cobertura.xml
 **/coverage-merge-report/*
 

--- a/starsky/build.vstest.runsettings
+++ b/starsky/build.vstest.runsettings
@@ -9,15 +9,4 @@
   <RunConfiguration>
       <MaxCpuCount>0</MaxCpuCount>
   </RunConfiguration>
-  <DataCollectionRunSettings>
-    <DataCollectors>
-      <DataCollector friendlyName="XPlat code coverage">
-        <Configuration>
-          <Format>opencover</Format>
-          <Exclude>[MySqlConnector]*,[starsky.Views]*,[*]starsky.foundation.database.Migrations.*</Exclude> <!-- [Assembly-Filter]Type-Filter -->
-          <ExcludeByFile>**/*.Generator.RegexGenerator/**,**/Migrations/**</ExcludeByFile>
-        </Configuration>
-      </DataCollector>
-    </DataCollectors>
-  </DataCollectionRunSettings>
 </RunSettings>

--- a/starsky/build/_build.csproj
+++ b/starsky/build/_build.csproj
@@ -14,13 +14,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10"/>
-        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.10"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11"/>
+        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.11"/>
         <PackageReference Include="Nuke.Common" Version="10.1.0"/>
         <PackageReference Include="NuGet.Packaging" Version="7.6.0"/>
         <PackageReference Include="ReportGenerator.Core" Version="5.5.11"/>
         <PackageReference Include="SimpleExec" Version="13.0.0"/>
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10"/>
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.11" />
     </ItemGroup>
 
     <ItemGroup>

--- a/starsky/build/helpers/DotnetTestHelper.cs
+++ b/starsky/build/helpers/DotnetTestHelper.cs
@@ -62,18 +62,25 @@ public static class DotnetTestHelper
 				"TestResults",
 				"test_results.trx");
 
+			// MTP (Microsoft.Testing.Platform) args — coverage file lands in testResultsFolder
+			var mtpArgs = string.Join(" ",
+				"--coverage",
+				"--coverage-output coverage.cobertura.xml",
+				"--coverage-output-format cobertura",
+				$"--results-directory \"{testResultsFolder}\"",
+				"--report-trx",
+				"--report-trx-filename test_results.trx",
+				$"--settings \"{runSettingsFile}\"");
+
 			try
 			{
-				// search for: dotnet test
-				DotNetTest(p => p
-					.SetConfiguration(configuration)
-					.EnableNoRestore()
-					.EnableNoBuild()
-					.SetVerbosity(DotNetVerbosity.normal)
-					.SetLoggers("trx;LogFileName=test_results.trx")
-					.SetDataCollector("XPlat Code Coverage")
-					.SetSettingsFile(runSettingsFile)
-					.SetProjectFile(projectFullPath));
+				// dotnet msbuild -t:Test routes through Microsoft.Testing.Platform
+				// (VSTest target removed on .NET 10 SDK for MTP projects)
+				DotNetMSBuild(p => p
+					.SetTargets("Test")
+					.SetTargetPath(projectFullPath)
+					.SetProperty("Configuration", configuration.ToString())
+					.SetProperty("TestingPlatformCommandLineArguments", mtpArgs));
 			}
 			catch ( ProcessException )
 			{
@@ -85,21 +92,14 @@ public static class DotnetTestHelper
 				TrxParserHelper.DisplaySlowestTests(trxFullFilePath);
 			}
 
-			var coverageEnum = GetFilesHelper.GetFiles("**/coverage.opencover.xml");
-
-			foreach ( var coverageItem in coverageEnum )
-			{
-				Log.Information("coverageItem: {CoverageItem}", coverageItem);
-			}
-
-			// Get the FirstOrDefault() but there is no LINQ here
-			var coverageFilePath =
-				Path.Combine(testParentPath, "netcore-coverage.opencover.xml");
+			// Coverage file is written directly to testResultsFolder with a fixed name
+			var coverageSourcePath = Path.Combine(testResultsFolder, "coverage.cobertura.xml");
+			var coverageFilePath = Path.Combine(testParentPath, "netcore-coverage.cobertura.xml");
 			Log.Information("next copy: coverageFilePath {CoverageFilePath}", coverageFilePath);
 
-			foreach ( var item in coverageEnum )
+			if ( FileExists(coverageSourcePath) )
 			{
-				var fromPath = AbsolutePath.Create(Path.Combine(WorkingDirectory.GetSolutionParentFolder(), item));
+				var fromPath = AbsolutePath.Create(coverageSourcePath);
 				var toPath = AbsolutePath.Create(coverageFilePath);
 				fromPath.Copy(toPath, ExistsPolicy.FileOverwrite);
 			}

--- a/starsky/build/helpers/MergeCoverageFiles.cs
+++ b/starsky/build/helpers/MergeCoverageFiles.cs
@@ -36,7 +36,7 @@ public static class MergeCoverageFiles
 		}
 
 		var netCoreCoverageFile =
-			Path.Combine(rootDirectory, "starskytest/netcore-coverage.opencover.xml");
+			Path.Combine(rootDirectory, "starskytest/netcore-coverage.cobertura.xml");
 		if ( !FileExists(netCoreCoverageFile) )
 		{
 			throw new FileNotFoundException($"Missing .NET coverage file ${netCoreCoverageFile}");

--- a/starsky/starsky.foundation.mountwatch/starsky.foundation.mountwatch.csproj
+++ b/starsky/starsky.foundation.mountwatch/starsky.foundation.mountwatch.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Management" Version="10.0.10" />
+        <PackageReference Include="System.Management" Version="10.0.11" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(noSonar)' == 'true' ">

--- a/starsky/starsky.foundation.webtelemetry/starsky.foundation.webtelemetry.csproj
+++ b/starsky/starsky.foundation.webtelemetry/starsky.foundation.webtelemetry.csproj
@@ -20,15 +20,15 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.11" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.11"/>
         <!--      instead of : Microsoft.AspNetCore.Http.Abstractions 2.2.0-->
-        <PackageReference Include="OpenTelemetry" Version="1.17.0"/>
-        <PackageReference Include="OpenTelemetry.Api" Version="1.17.0"/>
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0"/>
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0"/>
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0"/>
+        <PackageReference Include="OpenTelemetry" Version="1.18.0"/>
+        <PackageReference Include="OpenTelemetry.Api" Version="1.18.0"/>
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0"/>
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0"/>
         <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.11"/>
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0"/>
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(noSonar)' == 'true' ">

--- a/starsky/starskytest/starskytest.csproj
+++ b/starsky/starskytest/starskytest.csproj
@@ -11,6 +11,9 @@
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
+        <EnableMSTestRunner>true</EnableMSTestRunner>
+        <OutputType>Exe</OutputType>
+        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -25,14 +28,11 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
         <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.11" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0"/>
-        <PackageReference Include="MSTest.TestAdapter" Version="4.3.3"/>
-        <PackageReference Include="MSTest.TestFramework" Version="4.3.3"/>
-        <PackageReference Include="Verify.MSTest" Version="31.20.0"/>
-        <PackageReference Include="coverlet.collector" Version="10.0.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="MSTest.TestAdapter" Version="4.4.0"/>
+        <PackageReference Include="MSTest.TestFramework" Version="4.4.0"/>
+        <PackageReference Include="Verify.MSTest" Version="32.0.0"/>
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0"/>
+        <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.4.0"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -73,9 +73,6 @@
         <ProjectReference Include="..\starsky\starsky.csproj"/>
     </ItemGroup>
     <ItemGroup>
-        <DotNetCliToolReference Include="dotnet-reportgenerator-cli" Version="4.6.7"/>
-    </ItemGroup>
-    <ItemGroup>
         <Compile Remove="coverage-report.zip"/>
         <Compile Remove="coverage-report\**"/>
         <Compile Remove="TestResults\**"/>
@@ -89,7 +86,7 @@
         <None Remove="coverage-report\**"/>
         <None Remove="coverage-merge-cobertura.xml"/>
         <None Remove="jest-coverage.cobertura.xml"/>
-        <None Remove="netcore-coverage.opencover.xml"/>
+        <None Remove="netcore-coverage.cobertura.xml"/>
         <None Remove="coverage-report.zip"/>
         <None Remove="TestResults\**"/>
         <None Remove="coverage-merge-sonarqube.xml"/>


### PR DESCRIPTION
starskytest.csproj — MTP enabled, packages upgraded:

Added EnableMSTestRunner, OutputType=Exe, TestingPlatformDotnetTestSupport Removed Microsoft.NET.Test.Sdk and coverlet.collector Added Microsoft.Testing.Extensions.CodeCoverage 18.11.0 and TrxReport 2.4.0 Upgraded MSTest.TestAdapter/TestFramework 4.3.3 → 4.4.0, Verify.MSTest 31.20.0 → 32.0.0 Removed dead DotNetCliToolReference for dotnet-reportgenerator-cli

build.vstest.runsettings — removed the DataCollectionRunSettings/XPlat code coverage block (coverage now driven by MTP CLI flag); parallelization settings kept

DotnetTestHelper.cs — replaced DotNetTest (VSTest, incompatible with .NET 10 MTP) with DotNetMSBuild -t:Test, passing TestingPlatformCommandLineArguments with --coverage, --report-trx, and --results-directory (absolute path); removed the glob-based coverage copy in favour of a direct fixed-name file

MergeCoverageFiles.cs — netcore-coverage.opencover.xml → netcore-coverage.cobertura.xml

Result: 5440 passed, 49 skipped, 0 failed in ~47 s. TRX (7.2 MB) and coverage Cobertura XML (8.9 MB) both land in their expected paths for SonarCloud.

--

This pull request updates the test infrastructure to use the new Microsoft Testing Platform (MTP) for .NET test execution and code coverage, replacing the older VSTest and Coverlet-based approach. The changes include updating build scripts, test project configuration, and dependencies to support MTP and the new coverage output format.

**Migration to Microsoft Testing Platform (MTP) and Coverage Improvements:**

* Switched test execution from `dotnet test` with VSTest and Coverlet to `dotnet msbuild -t:Test` using Microsoft.Testing.Platform, including new command-line arguments for coverage and test results output in Cobertura format (`coverage.cobertura.xml`). (`starsky/build/helpers/DotnetTestHelper.cs`)
* Removed VSTest-specific code coverage settings from `build.vstest.runsettings`, as coverage is now handled by MTP. (`starsky/build.vstest.runsettings`)
* Updated coverage file handling logic to expect and process `coverage.cobertura.xml` instead of `coverage.opencover.xml`, including file copying and merge logic. (`starsky/build/helpers/DotnetTestHelper.cs`, `starsky/build/helpers/MergeCoverageFiles.cs`) [[1]](diffhunk://#diff-af49461275976aec7f53087f3e62311f0b64b2acea80e02d532f48096c2021eaL88-R102) [[2]](diffhunk://#diff-44bbcee6d59b8f1784c2bad0427667cb37a6a82f4faef9df830013853800e8b7L39-R39)

**Test Project Configuration and Dependency Updates:**

* Updated the test project (`starskytest.csproj`) to enable MTP support, set output type to `Exe`, and add new MTP-related properties. Also updated or replaced several test-related NuGet packages to their latest versions and to support MTP. (`starsky/starskytest/starskytest.csproj`) [[1]](diffhunk://#diff-ac79117d5376fd35225bed6780c4bfb08aecc291c0597730e133d9ec8cf6d4e8R14-R16) [[2]](diffhunk://#diff-ac79117d5376fd35225bed6780c4bfb08aecc291c0597730e133d9ec8cf6d4e8L28-R35)
* Removed obsolete references and exclusions related to the old coverage format and tools (e.g., `dotnet-reportgenerator-cli`, `netcore-coverage.opencover.xml`). (`starsky/starskytest/starskytest.csproj`) [[1]](diffhunk://#diff-ac79117d5376fd35225bed6780c4bfb08aecc291c0597730e133d9ec8cf6d4e8L75-L77) [[2]](diffhunk://#diff-ac79117d5376fd35225bed6780c4bfb08aecc291c0597730e133d9ec8cf6d4e8L92-R89)

# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
