### PR TITLE
Windows client use MSTest

### DIFF
--- a/.github/workflows/desktop-windows-pr-build.yml
+++ b/.github/workflows/desktop-windows-pr-build.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Test
         shell: pwsh
         run: |
-          dotnet test windows/starsky.Tests/starsky.Tests.csproj `
-            --no-build `
-            -c Release `
-            --logger "trx;LogFileName=test-results.trx"
+          windows/starsky.Tests/bin/Release/net10.0-windows/starsky.Tests.exe `
+            --report-trx `
+            --report-trx-filename test-results.trx `
+            --results-directory TestResults
 
       - name: Publish test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/desktop-windows-sonarqube-net.yml
+++ b/.github/workflows/desktop-windows-sonarqube-net.yml
@@ -108,6 +108,9 @@ jobs:
             /d:sonar.cs.opencover.reportsPaths="TestResults/**/coverage.opencover.xml" `
             @prArgs
 
+      - name: Install dotnet-coverage
+        run: dotnet tool install --global dotnet-coverage
+
       - name: Build
         shell: pwsh
         run: dotnet build windows/starsky.Tests/starsky.Tests.csproj -c Release
@@ -115,12 +118,10 @@ jobs:
       - name: Test with coverage
         shell: pwsh
         run: |
-          dotnet test windows/starsky.Tests/starsky.Tests.csproj `
-            --no-build `
-            -c Release `
-            --collect:"XPlat Code Coverage" `
-            --results-directory TestResults/ `
-            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+          dotnet-coverage collect `
+            --output TestResults/coverage.opencover.xml `
+            --output-format opencover `
+            "windows/starsky.Tests/bin/Release/net10.0-windows/starsky.Tests.exe"
 
       - name: End SonarQube analysis
         shell: pwsh

--- a/starsky-tools/build-tools/dotnet-sdk-version-update.js
+++ b/starsky-tools/build-tools/dotnet-sdk-version-update.js
@@ -976,19 +976,12 @@ async function updateGlobalJsonFiles(filePathList, sdkVersionInput) {
 			console.log("✖ " + filePath + " - " + error);
 		}
 
-		// the global json needs to have a strictVersion property to be auto-upgraded
-		if (globalJsonFile?.strictVersion !== true) {
-			console.log(
-				"✖ " +
-				filePath +
-				" - strictVersion is not enabled so skip upgrade globalJson file"
-			);
+		if (!globalJsonFile?.sdk?.version) {
+			console.log("✖ " + filePath + " - sdk.version is not present, skipping");
+			continue;
 		}
 
-		if (
-			globalJsonFile?.strictVersion === true &&
-			globalJsonFile?.sdk?.version !== sdkVersion
-		) {
+		if (globalJsonFile.sdk.version !== sdkVersion) {
 			globalJsonFile.sdk.version = sdkVersion;
 			await writeFile(filePath, JSON.stringify(globalJsonFile, null, 4));
 		}

--- a/windows/global.json
+++ b/windows/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.400",
+    "rollForward": "disable",
+    "allowPrerelease": false
+  }
+}

--- a/windows/global.json
+++ b/windows/global.json
@@ -1,4 +1,5 @@
 {
+  "strictVersion": false,
   "sdk": {
     "version": "10.0.400",
     "rollForward": "disable",

--- a/windows/starsky.Tests/GlobalUsings.cs
+++ b/windows/starsky.Tests/GlobalUsings.cs
@@ -5,4 +5,5 @@ global using System.Linq;
 global using System.Net;
 global using System.Net.Sockets;
 global using System.Text.Json;
-global using Xunit;
+global using System.Text.RegularExpressions;
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/windows/starsky.Tests/Models/DesktopSettingsTests.cs
+++ b/windows/starsky.Tests/Models/DesktopSettingsTests.cs
@@ -2,20 +2,21 @@ using Starsky.Desktop.Models;
 
 namespace starsky.Tests.Models;
 
+[TestClass]
 public class DesktopSettingsTests
 {
-    [Fact]
+    [TestMethod]
     public void Defaults_AreCorrect()
     {
         var s = new DesktopSettings();
-        Assert.Equal(RuntimeMode.Local, s.Mode);
-        Assert.Equal(string.Empty, s.RemoteBaseUrl);
-        Assert.True(s.UpdateCheckEnabled);
-        Assert.Null(s.LastUpdateWarningShown);
-        Assert.Empty(s.Windows);
+        Assert.AreEqual(RuntimeMode.Local, s.Mode);
+        Assert.AreEqual(string.Empty, s.RemoteBaseUrl);
+        Assert.IsTrue(s.UpdateCheckEnabled);
+        Assert.IsNull(s.LastUpdateWarningShown);
+        Assert.AreEqual(0, s.Windows.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void RoundTrip_Json_PreservesAllFields()
     {
         var original = new DesktopSettings
@@ -33,13 +34,13 @@ public class DesktopSettingsTests
         var json = JsonSerializer.Serialize(original);
         var restored = JsonSerializer.Deserialize<DesktopSettings>(json)!;
 
-        Assert.Equal(original.Mode, restored.Mode);
-        Assert.Equal(original.RemoteBaseUrl, restored.RemoteBaseUrl);
-        Assert.Equal(original.UpdateCheckEnabled, restored.UpdateCheckEnabled);
-        Assert.Equal(original.LastUpdateWarningShown, restored.LastUpdateWarningShown);
-        Assert.Single(restored.Windows);
-        Assert.Equal("?f=/test", restored.Windows[0].Route);
-        Assert.Equal(50, restored.Windows[0].Left);
-        Assert.True(restored.Windows[0].IsMaximized);
+        Assert.AreEqual(original.Mode, restored.Mode);
+        Assert.AreEqual(original.RemoteBaseUrl, restored.RemoteBaseUrl);
+        Assert.AreEqual(original.UpdateCheckEnabled, restored.UpdateCheckEnabled);
+        Assert.AreEqual(original.LastUpdateWarningShown, restored.LastUpdateWarningShown);
+        Assert.AreEqual(1, restored.Windows.Count);
+        Assert.AreEqual("?f=/test", restored.Windows[0].Route);
+        Assert.AreEqual(50, restored.Windows[0].Left);
+        Assert.IsTrue(restored.Windows[0].IsMaximized);
     }
 }

--- a/windows/starsky.Tests/Models/DesktopSettingsTests.cs
+++ b/windows/starsky.Tests/Models/DesktopSettingsTests.cs
@@ -13,7 +13,7 @@ public class DesktopSettingsTests
         Assert.AreEqual(string.Empty, s.RemoteBaseUrl);
         Assert.IsTrue(s.UpdateCheckEnabled);
         Assert.IsNull(s.LastUpdateWarningShown);
-        Assert.AreEqual(0, s.Windows.Count);
+        Assert.IsEmpty(s.Windows);
     }
 
     [TestMethod]
@@ -38,7 +38,7 @@ public class DesktopSettingsTests
         Assert.AreEqual(original.RemoteBaseUrl, restored.RemoteBaseUrl);
         Assert.AreEqual(original.UpdateCheckEnabled, restored.UpdateCheckEnabled);
         Assert.AreEqual(original.LastUpdateWarningShown, restored.LastUpdateWarningShown);
-        Assert.AreEqual(1, restored.Windows.Count);
+        Assert.HasCount(1, restored.Windows);
         Assert.AreEqual("?f=/test", restored.Windows[0].Route);
         Assert.AreEqual(50, restored.Windows[0].Left);
         Assert.IsTrue(restored.Windows[0].IsMaximized);

--- a/windows/starsky.Tests/Services/AppcastCheckerTests.cs
+++ b/windows/starsky.Tests/Services/AppcastCheckerTests.cs
@@ -2,6 +2,7 @@ using Starsky.Desktop.Services;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public class AppcastCheckerTests
 {
     private const string Ns = "http://www.andymatuschak.org/xml-namespaces/sparkle";
@@ -24,39 +25,39 @@ public class AppcastCheckerTests
         </rss>
         """;
 
-    [Fact]
+    [TestMethod]
     public void FindNewerRelease_ReturnsBeta3_WhenCurrentIsBeta1()
     {
         var xml = BuildAppcast("0.9.0-beta.3");
 
         var result = AppcastChecker.FindNewerRelease(xml, "0.9.0-beta.1");
 
-        Assert.NotNull(result);
-        Assert.Equal("0.9.0-beta.3", result.Value.Version);
-        Assert.Equal("https://github.com/qdraw/starsky/releases/tag/v0.9.0-beta.3", result.Value.HtmlUrl);
+        Assert.IsNotNull(result);
+        Assert.AreEqual("0.9.0-beta.3", result.Value.Version);
+        Assert.AreEqual("https://github.com/qdraw/starsky/releases/tag/v0.9.0-beta.3", result.Value.HtmlUrl);
     }
 
-    [Fact]
+    [TestMethod]
     public void FindNewerRelease_ReturnsNull_WhenAlreadyOnLatest()
     {
         var xml = BuildAppcast("0.9.0-beta.1");
 
         var result = AppcastChecker.FindNewerRelease(xml, "0.9.0-beta.1");
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void FindNewerRelease_ReturnsNull_WhenCurrentIsNewer()
     {
         var xml = BuildAppcast("0.9.0-beta.1");
 
         var result = AppcastChecker.FindNewerRelease(xml, "0.9.0-beta.3");
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void FindNewerRelease_PrefersShortVersionString_OverVersion()
     {
         // shortVersionString = beta.3, sparkle:version = beta.1 (mismatch — shortVersionString wins)
@@ -72,22 +73,22 @@ public class AppcastCheckerTests
 
         var result = AppcastChecker.FindNewerRelease(xml, "0.9.0-beta.1");
 
-        Assert.NotNull(result);
-        Assert.Equal("0.9.0-beta.3", result.Value.Version);
+        Assert.IsNotNull(result);
+        Assert.AreEqual("0.9.0-beta.3", result.Value.Version);
     }
 
-    [Fact]
+    [TestMethod]
     public void FindNewerRelease_FallsBackToVersion_WhenShortVersionStringAbsent()
     {
         var xml = BuildAppcast("0.9.0-beta.3", includeVersion: true, includeShortVersion: false);
 
         var result = AppcastChecker.FindNewerRelease(xml, "0.9.0-beta.1");
 
-        Assert.NotNull(result);
-        Assert.Equal("0.9.0-beta.3", result.Value.Version);
+        Assert.IsNotNull(result);
+        Assert.AreEqual("0.9.0-beta.3", result.Value.Version);
     }
 
-    [Fact]
+    [TestMethod]
     public void FindNewerRelease_ReturnsNull_WhenNoVersionElements()
     {
         const string xml = """
@@ -97,37 +98,37 @@ public class AppcastCheckerTests
 
         var result = AppcastChecker.FindNewerRelease(xml, "0.9.0-beta.1");
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void FindNewerRelease_ReturnsNull_WhenXmlIsInvalid()
     {
         var result = AppcastChecker.FindNewerRelease("not xml at all", "0.9.0");
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void FindNewerRelease_ReturnsNull_WhenXmlIsEmpty()
     {
         var result = AppcastChecker.FindNewerRelease(string.Empty, "0.9.0");
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void FindNewerRelease_StableVersionNewerThanPreRelease()
     {
         var xml = BuildAppcast("0.9.0");
 
         var result = AppcastChecker.FindNewerRelease(xml, "0.9.0-beta.3");
 
-        Assert.NotNull(result);
-        Assert.Equal("0.9.0", result.Value.Version);
+        Assert.IsNotNull(result);
+        Assert.AreEqual("0.9.0", result.Value.Version);
     }
 
-    [Fact]
+    [TestMethod]
     public void FindNewerRelease_UsesFirstItemWithNewerVersion()
     {
         // Two items — first is newer
@@ -143,18 +144,18 @@ public class AppcastCheckerTests
 
         var result = AppcastChecker.FindNewerRelease(xml, "0.9.0-beta.1");
 
-        Assert.NotNull(result);
-        Assert.Equal("0.9.0-beta.3", result.Value.Version);
+        Assert.IsNotNull(result);
+        Assert.AreEqual("0.9.0-beta.3", result.Value.Version);
     }
 
-    [Fact]
+    [TestMethod]
     public void FindNewerRelease_HtmlUrlPointsToGitHubRelease()
     {
         var xml = BuildAppcast("1.0.0");
 
         var result = AppcastChecker.FindNewerRelease(xml, "0.9.0");
 
-        Assert.NotNull(result);
-        Assert.Equal("https://github.com/qdraw/starsky/releases/tag/v1.0.0", result.Value.HtmlUrl);
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://github.com/qdraw/starsky/releases/tag/v1.0.0", result.Value.HtmlUrl);
     }
 }

--- a/windows/starsky.Tests/Services/ApplicationPathsTests.cs
+++ b/windows/starsky.Tests/Services/ApplicationPathsTests.cs
@@ -79,7 +79,7 @@ public class ApplicationPathsTests
     [TestMethod]
     public void ApplicationInfo_Version_MatchesSemver()
     {
-        Assert.MatchesRegex(ApplicationInfo.Version, @"^\d+\.\d+\.\d+");
+        Assert.MatchesRegex(@"^\d+\.\d+\.\d+", ApplicationInfo.Version);
     }
 
     [TestMethod]

--- a/windows/starsky.Tests/Services/ApplicationPathsTests.cs
+++ b/windows/starsky.Tests/Services/ApplicationPathsTests.cs
@@ -3,87 +3,88 @@ using Starsky.Desktop.Services;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public class ApplicationPathsTests
 {
-    [Fact]
+    [TestMethod]
     public void AppData_IsUnderApplicationData()
     {
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-        Assert.StartsWith(appData, ApplicationPaths.AppData, StringComparison.OrdinalIgnoreCase);
+        Assert.IsTrue(ApplicationPaths.AppData.StartsWith(appData, StringComparison.OrdinalIgnoreCase));
     }
 
-    [Fact]
+    [TestMethod]
     public void TempFolder_IsUnderLocalApplicationData()
     {
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        Assert.StartsWith(localAppData, ApplicationPaths.TempFolder, StringComparison.OrdinalIgnoreCase);
+        Assert.IsTrue(ApplicationPaths.TempFolder.StartsWith(localAppData, StringComparison.OrdinalIgnoreCase));
     }
 
-    [Fact]
+    [TestMethod]
     public void AllPaths_ContainStarskySubdirectory()
     {
-        Assert.Contains("starsky", ApplicationPaths.AppData, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("starsky", ApplicationPaths.TempFolder, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("starsky", ApplicationPaths.LogsDir, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("starsky", ApplicationPaths.SettingsFile, StringComparison.OrdinalIgnoreCase);
+        Assert.IsTrue(ApplicationPaths.AppData.Contains("starsky", StringComparison.OrdinalIgnoreCase));
+        Assert.IsTrue(ApplicationPaths.TempFolder.Contains("starsky", StringComparison.OrdinalIgnoreCase));
+        Assert.IsTrue(ApplicationPaths.LogsDir.Contains("starsky", StringComparison.OrdinalIgnoreCase));
+        Assert.IsTrue(ApplicationPaths.SettingsFile.Contains("starsky", StringComparison.OrdinalIgnoreCase));
     }
 
-    [Fact]
+    [TestMethod]
     public void RuntimeDir_IsRelativeToExecutable()
     {
-        Assert.EndsWith("runtime-starsky-win-x64", ApplicationPaths.RuntimeDir, StringComparison.OrdinalIgnoreCase);
+        Assert.IsTrue(ApplicationPaths.RuntimeDir.EndsWith("runtime-starsky-win-x64", StringComparison.OrdinalIgnoreCase));
     }
 
-    [Fact]
+    [TestMethod]
     public void SettingsFile_HasJsonExtension()
     {
-        Assert.EndsWith(".json", ApplicationPaths.SettingsFile, StringComparison.OrdinalIgnoreCase);
+        Assert.IsTrue(ApplicationPaths.SettingsFile.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
     }
 
-    [Fact]
+    [TestMethod]
     public void AllSettingsPaths_HaveJsonExtension()
     {
-        Assert.EndsWith(".json", ApplicationPaths.AppSettingsFile, StringComparison.OrdinalIgnoreCase);
-        Assert.EndsWith(".json", ApplicationPaths.AppSettingsLocalFile, StringComparison.OrdinalIgnoreCase);
+        Assert.IsTrue(ApplicationPaths.AppSettingsFile.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
+        Assert.IsTrue(ApplicationPaths.AppSettingsLocalFile.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
     }
 
-    [Fact]
+    [TestMethod]
     public void DatabaseFile_HasDbExtension()
     {
-        Assert.EndsWith(".db", ApplicationPaths.DatabaseFile, StringComparison.OrdinalIgnoreCase);
+        Assert.IsTrue(ApplicationPaths.DatabaseFile.EndsWith(".db", StringComparison.OrdinalIgnoreCase));
     }
 
-    [Fact]
+    [TestMethod]
     public void WebView2UserData_IsUnderAppData()
     {
-        Assert.StartsWith(ApplicationPaths.AppData, ApplicationPaths.WebView2UserData, StringComparison.OrdinalIgnoreCase);
+        Assert.IsTrue(ApplicationPaths.WebView2UserData.StartsWith(ApplicationPaths.AppData, StringComparison.OrdinalIgnoreCase));
     }
 
-    [Fact]
+    [TestMethod]
     public void ThumbnailTempFolder_ContainsStarsky()
     {
-        Assert.Contains("starsky", ApplicationPaths.ThumbnailTempFolder, StringComparison.OrdinalIgnoreCase);
+        Assert.IsTrue(ApplicationPaths.ThumbnailTempFolder.Contains("starsky", StringComparison.OrdinalIgnoreCase));
     }
 
-    [Fact]
+    [TestMethod]
     public void EnsureDirectories_CreatesRequiredFolders()
     {
         ApplicationPaths.EnsureDirectories();
 
-        Assert.True(Directory.Exists(ApplicationPaths.AppData));
-        Assert.True(Directory.Exists(ApplicationPaths.LogsDir));
-        Assert.True(Directory.Exists(ApplicationPaths.TempFolder));
+        Assert.IsTrue(Directory.Exists(ApplicationPaths.AppData));
+        Assert.IsTrue(Directory.Exists(ApplicationPaths.LogsDir));
+        Assert.IsTrue(Directory.Exists(ApplicationPaths.TempFolder));
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplicationInfo_Version_MatchesSemver()
     {
-        Assert.Matches(@"^\d+\.\d+\.\d+", ApplicationInfo.Version);
+        StringAssert.Matches(ApplicationInfo.Version, new Regex(@"^\d+\.\d+\.\d+"));
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplicationInfo_Version_DoesNotContainBuildMetadata()
     {
-        Assert.DoesNotContain("+", ApplicationInfo.Version);
+        Assert.IsFalse(ApplicationInfo.Version.Contains("+"));
     }
 }

--- a/windows/starsky.Tests/Services/ApplicationPathsTests.cs
+++ b/windows/starsky.Tests/Services/ApplicationPathsTests.cs
@@ -79,12 +79,12 @@ public class ApplicationPathsTests
     [TestMethod]
     public void ApplicationInfo_Version_MatchesSemver()
     {
-        StringAssert.Matches(ApplicationInfo.Version, new Regex(@"^\d+\.\d+\.\d+"));
+        Assert.MatchesRegex(ApplicationInfo.Version, @"^\d+\.\d+\.\d+");
     }
 
     [TestMethod]
     public void ApplicationInfo_Version_DoesNotContainBuildMetadata()
     {
-        Assert.IsFalse(ApplicationInfo.Version.Contains("+"));
+        Assert.DoesNotContain("+", ApplicationInfo.Version);
     }
 }

--- a/windows/starsky.Tests/Services/BackendServiceTests.cs
+++ b/windows/starsky.Tests/Services/BackendServiceTests.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Net.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Starsky.Desktop.Services;
@@ -7,46 +6,49 @@ using starsky.Tests.Helpers;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public class BackendServiceTests
 {
-    [Fact]
+    [TestMethod]
     public async Task StopAsync_WhenNotStarted_DoesNotThrow()
     {
         var svc = new BackendService(NullLogger<BackendService>.Instance);
 
-        var ex = await Record.ExceptionAsync(() => svc.StopAsync());
+        Exception? ex = null;
+        try { await svc.StopAsync(); } catch (Exception e) { ex = e; }
 
-        Assert.Null(ex);
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Dispose_WhenNotStarted_DoesNotThrow()
     {
         var svc = new BackendService(NullLogger<BackendService>.Instance);
 
-        var ex = Record.Exception(() => svc.Dispose());
+        Exception? ex = null;
+        try { svc.Dispose(); } catch (Exception e) { ex = e; }
 
-        Assert.Null(ex);
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetEnvironment_SetsAllRequiredKeys()
     {
         var env = new Dictionary<string, string?>();
 
         BackendService.SetEnvironment(env, 12345);
 
-        Assert.Equal("http://localhost:12345", env["ASPNETCORE_URLS"]);
-        Assert.Equal("true", env["app__NoAccountLocalhost"]);
-        Assert.Equal("true", env["app__UseLocalDesktop"]);
-        Assert.Equal("Administrator", env["app__AccountRegisterDefaultRole"]);
-        Assert.Equal("false", env["app__Verbose"]);
-        Assert.Contains("app__databaseConnection", env.Keys);
-        Assert.Contains("app__tempFolder", env.Keys);
-        Assert.Contains("app__appsettingspath", env.Keys);
+        Assert.AreEqual("http://localhost:12345", env["ASPNETCORE_URLS"]);
+        Assert.AreEqual("true", env["app__NoAccountLocalhost"]);
+        Assert.AreEqual("true", env["app__UseLocalDesktop"]);
+        Assert.AreEqual("Administrator", env["app__AccountRegisterDefaultRole"]);
+        Assert.AreEqual("false", env["app__Verbose"]);
+        CollectionAssert.Contains(env.Keys.ToList(), "app__databaseConnection");
+        CollectionAssert.Contains(env.Keys.ToList(), "app__tempFolder");
+        CollectionAssert.Contains(env.Keys.ToList(), "app__appsettingspath");
     }
 
-    [Fact]
+    [TestMethod]
     public void FindBackendExe_WhenNoExeExists_ReturnsNull()
     {
         var emptyDir = Path.Combine(Path.GetTempPath(), $"starsky-empty-{Guid.NewGuid()}");
@@ -56,7 +58,7 @@ public class BackendServiceTests
         {
             var result = BackendService.FindBackendExe(emptyDir);
 
-            Assert.Null(result);
+            Assert.IsNull(result);
         }
         finally
         {
@@ -64,7 +66,7 @@ public class BackendServiceTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void FindBackendExe_WhenExeExists_ReturnsPath()
     {
         var dir = Path.Combine(Path.GetTempPath(), $"starsky-exe-{Guid.NewGuid()}");
@@ -76,7 +78,7 @@ public class BackendServiceTests
         {
             var result = BackendService.FindBackendExe(dir);
 
-            Assert.Equal(exePath, result);
+            Assert.AreEqual(exePath, result);
         }
         finally
         {
@@ -84,7 +86,7 @@ public class BackendServiceTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void FindBackendExe_WhenLinuxExeExists_ReturnsPath()
     {
         var dir = Path.Combine(Path.GetTempPath(), $"starsky-linux-{Guid.NewGuid()}");
@@ -96,7 +98,7 @@ public class BackendServiceTests
         {
             var result = BackendService.FindBackendExe(dir);
 
-            Assert.Equal(exePath, result);
+            Assert.AreEqual(exePath, result);
         }
         finally
         {
@@ -104,75 +106,80 @@ public class BackendServiceTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Dispose_CalledTwice_DoesNotThrow()
     {
         var svc = new BackendService(NullLogger<BackendService>.Instance);
         svc.Dispose();
 
-        var ex = Record.Exception(() => svc.Dispose());
+        Exception? ex = null;
+        try { svc.Dispose(); } catch (Exception e) { ex = e; }
 
-        Assert.Null(ex);
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetEnvironment_ContainsThumbnailAndSettingsPaths()
     {
         var env = new Dictionary<string, string?>();
 
         BackendService.SetEnvironment(env, 5000);
 
-        Assert.Contains("app__thumbnailTempFolder", env.Keys);
-        Assert.Contains("app__appsettingslocalpath", env.Keys);
-        Assert.Equal("300", env["app__ThumbnailGenerationIntervalInMinutes"]);
+        CollectionAssert.Contains(env.Keys.ToList(), "app__thumbnailTempFolder");
+        CollectionAssert.Contains(env.Keys.ToList(), "app__appsettingslocalpath");
+        Assert.AreEqual("300", env["app__ThumbnailGenerationIntervalInMinutes"]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StartAsync_WhenExeNotFound_Throws()
     {
         // In the test environment ApplicationPaths.RuntimeDir does not contain a starsky.exe,
         // so LaunchAsync cannot find the backend and throws FileNotFoundException.
         if (BackendService.FindBackendExe(ApplicationPaths.RuntimeDir) != null)
         {
-	        return; // Runtime present in test env — skip
+            return; // Runtime present in test env — skip
         }
 
         var svc = new BackendService(NullLogger<BackendService>.Instance);
 
-        await Assert.ThrowsAsync<FileNotFoundException>(() => svc.StartAsync(5000));
+        Exception? caught = null;
+        try { await svc.StartAsync(5000); } catch (FileNotFoundException e) { caught = e; }
+        Assert.IsInstanceOfType<FileNotFoundException>(caught);
     }
 
     // ── WaitForHealthAsync ────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task WaitForHealthAsync_WhenServerReturns200_Returns()
     {
         using var http = new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.OK));
 
         var result = await BackendService.WaitForHealthAsync(http, "http://localhost:5000");
-        
-        Assert.True(result);
+
+        Assert.IsTrue(result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitForHealthAsync_WhenServerNeverSucceeds_ThrowsTimeout()
     {
         using var http = new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.ServiceUnavailable));
 
-        await Assert.ThrowsAsync<TimeoutException>(() =>
-            BackendService.WaitForHealthAsync(http, "http://localhost:5000", timeoutSeconds: 1));
+        Exception? caught = null;
+        try { await BackendService.WaitForHealthAsync(http, "http://localhost:5000", timeoutSeconds: 1); } catch (TimeoutException e) { caught = e; }
+        Assert.IsInstanceOfType<TimeoutException>(caught);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitForHealthAsync_WhenServerThrows_EventuallyTimesOut()
     {
         using var http = new HttpClient(new ThrowingHandler());
 
-        await Assert.ThrowsAsync<TimeoutException>(() =>
-            BackendService.WaitForHealthAsync(http, "http://localhost:5000", timeoutSeconds: 1));
+        Exception? caught = null;
+        try { await BackendService.WaitForHealthAsync(http, "http://localhost:5000", timeoutSeconds: 1); } catch (TimeoutException e) { caught = e; }
+        Assert.IsInstanceOfType<TimeoutException>(caught);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitForHealthAsync_CallsOnWaiting_WhilePolling()
     {
         var messages = new List<string>();
@@ -183,13 +190,13 @@ public class BackendServiceTests
         await BackendService.WaitForHealthAsync(http, "http://localhost:5000",
             onWaiting: msg => messages.Add(msg));
 
-        Assert.Single(messages);
-        Assert.Equal("Waiting for backend…", messages[0]);
+        Assert.AreEqual(1, messages.Count);
+        Assert.AreEqual("Waiting for backend…", messages[0]);
     }
 
     // ── CheckVersionCompatibilityAsync ───────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task CheckVersionCompatibilityAsync_WhenCompatible_DoesNotThrow()
     {
         using var http = new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.OK));
@@ -197,18 +204,19 @@ public class BackendServiceTests
         await BackendService.CheckVersionCompatibilityAsync(http, "http://localhost:5000", "0.8.1");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CheckVersionCompatibilityAsync_WhenIncompatible_Throws()
     {
         using var http = new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.BadRequest));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            BackendService.CheckVersionCompatibilityAsync(http, "http://localhost:5000", "0.8.1"));
+        InvalidOperationException? ex = null;
+        try { await BackendService.CheckVersionCompatibilityAsync(http, "http://localhost:5000", "0.8.1"); } catch (InvalidOperationException e) { ex = e; }
+        Assert.IsNotNull(ex);
 
-        Assert.Contains("0.8.1", ex.Message);
+        Assert.IsTrue(ex.Message.Contains("0.8.1"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CheckVersionCompatibilityAsync_WhenServerReturns404_DoesNotThrow()
     {
         using var http = new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.NotFound));
@@ -218,7 +226,7 @@ public class BackendServiceTests
 
     // ── StartAsync / LaunchAsync (process launch) ────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task StartAsync_WithFakeExe_StartsProcess()
     {
         var fakeExe = new CreateFakeStarskyExe();
@@ -233,7 +241,7 @@ public class BackendServiceTests
             var svc = new BackendService(NullLogger<BackendService>.Instance);
             await svc.StartAsync(19999);
             await svc.StopAsync();
-            Assert.NotNull(svc);
+            Assert.IsNotNull(svc);
             svc.Dispose();
         }
         finally
@@ -246,7 +254,7 @@ public class BackendServiceTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StartAsync_WithFakeExe_StopAsync_DoesNotThrow()
     {
         var fakeExe = new CreateFakeStarskyExe();
@@ -261,9 +269,10 @@ public class BackendServiceTests
             var svc = new BackendService(NullLogger<BackendService>.Instance);
             await svc.StartAsync(19998);
 
-            var ex = await Record.ExceptionAsync(() => svc.StopAsync());
+            Exception? ex = null;
+            try { await svc.StopAsync(); } catch (Exception e) { ex = e; }
 
-            Assert.Null(ex);
+            Assert.IsNull(ex);
             svc.Dispose();
         }
         finally
@@ -276,7 +285,7 @@ public class BackendServiceTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StartAsync_WithFakeExe_Dispose_DoesNotThrow()
     {
         var fakeExe = new CreateFakeStarskyExe();
@@ -291,9 +300,10 @@ public class BackendServiceTests
             var svc = new BackendService(NullLogger<BackendService>.Instance);
             await svc.StartAsync(19997);
 
-            var ex = Record.Exception(() => svc.Dispose());
+            Exception? ex = null;
+            try { svc.Dispose(); } catch (Exception e) { ex = e; }
 
-            Assert.Null(ex);
+            Assert.IsNull(ex);
         }
         finally
         {

--- a/windows/starsky.Tests/Services/BackendServiceTests.cs
+++ b/windows/starsky.Tests/Services/BackendServiceTests.cs
@@ -43,9 +43,9 @@ public class BackendServiceTests
         Assert.AreEqual("true", env["app__UseLocalDesktop"]);
         Assert.AreEqual("Administrator", env["app__AccountRegisterDefaultRole"]);
         Assert.AreEqual("false", env["app__Verbose"]);
-        CollectionAssert.Contains(env.Keys.ToList(), "app__databaseConnection");
-        CollectionAssert.Contains(env.Keys.ToList(), "app__tempFolder");
-        CollectionAssert.Contains(env.Keys.ToList(), "app__appsettingspath");
+        Assert.Contains("app__databaseConnection", env.Keys);
+        Assert.Contains("app__tempFolder", env.Keys);
+        Assert.Contains("app__appsettingspath", env.Keys);
     }
 
     [TestMethod]
@@ -125,8 +125,8 @@ public class BackendServiceTests
 
         BackendService.SetEnvironment(env, 5000);
 
-        CollectionAssert.Contains(env.Keys.ToList(), "app__thumbnailTempFolder");
-        CollectionAssert.Contains(env.Keys.ToList(), "app__appsettingslocalpath");
+        Assert.Contains("app__thumbnailTempFolder", env.Keys);
+        Assert.Contains("app__appsettingslocalpath", env.Keys);
         Assert.AreEqual("300", env["app__ThumbnailGenerationIntervalInMinutes"]);
     }
 
@@ -190,7 +190,7 @@ public class BackendServiceTests
         await BackendService.WaitForHealthAsync(http, "http://localhost:5000",
             onWaiting: msg => messages.Add(msg));
 
-        Assert.AreEqual(1, messages.Count);
+        Assert.HasCount(1, messages);
         Assert.AreEqual("Waiting for backend…", messages[0]);
     }
 
@@ -213,7 +213,7 @@ public class BackendServiceTests
         try { await BackendService.CheckVersionCompatibilityAsync(http, "http://localhost:5000", "0.8.1"); } catch (InvalidOperationException e) { ex = e; }
         Assert.IsNotNull(ex);
 
-        Assert.IsTrue(ex.Message.Contains("0.8.1"));
+        Assert.Contains("0.8.1", ex.Message);
     }
 
     [TestMethod]

--- a/windows/starsky.Tests/Services/DailyFileLoggerProviderTests.cs
+++ b/windows/starsky.Tests/Services/DailyFileLoggerProviderTests.cs
@@ -3,6 +3,7 @@ using Starsky.Desktop.Services;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public sealed class DailyFileLoggerProviderTests : IDisposable
 {
     private readonly string _logDir;
@@ -13,44 +14,44 @@ public sealed class DailyFileLoggerProviderTests : IDisposable
         Directory.CreateDirectory(_logDir);
     }
 
-    [Fact]
+    [TestMethod]
     public void CreateLogger_ReturnsNonNullLogger()
     {
         using var provider = new DailyFileLoggerProvider(_logDir);
         var logger = provider.CreateLogger("TestCategory");
-        Assert.NotNull(logger);
+        Assert.IsNotNull(logger);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsEnabled_InfoAndAbove_ReturnsTrue()
     {
         using var provider = new DailyFileLoggerProvider(_logDir);
         var logger = provider.CreateLogger("Test");
-        Assert.True(logger.IsEnabled(LogLevel.Information));
-        Assert.True(logger.IsEnabled(LogLevel.Warning));
-        Assert.True(logger.IsEnabled(LogLevel.Error));
-        Assert.True(logger.IsEnabled(LogLevel.Critical));
+        Assert.IsTrue(logger.IsEnabled(LogLevel.Information));
+        Assert.IsTrue(logger.IsEnabled(LogLevel.Warning));
+        Assert.IsTrue(logger.IsEnabled(LogLevel.Error));
+        Assert.IsTrue(logger.IsEnabled(LogLevel.Critical));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsEnabled_Debug_ReturnsFalse()
     {
         using var provider = new DailyFileLoggerProvider(_logDir);
         var logger = provider.CreateLogger("Test");
-        Assert.False(logger.IsEnabled(LogLevel.Debug));
-        Assert.False(logger.IsEnabled(LogLevel.Trace));
+        Assert.IsFalse(logger.IsEnabled(LogLevel.Debug));
+        Assert.IsFalse(logger.IsEnabled(LogLevel.Trace));
     }
 
-    [Fact]
+    [TestMethod]
     public void BeginScope_ReturnsNull()
     {
         using var provider = new DailyFileLoggerProvider(_logDir);
         var logger = provider.CreateLogger("Test");
         var scope = logger.BeginScope("state");
-        Assert.Null(scope);
+        Assert.IsNull(scope);
     }
 
-    [Fact]
+    [TestMethod]
     public void Log_WritesMessageToFile()
     {
         using var provider = new DailyFileLoggerProvider(_logDir);
@@ -59,13 +60,13 @@ public sealed class DailyFileLoggerProviderTests : IDisposable
         logger.LogInformation("Hello from test");
 
         var files = Directory.GetFiles(_logDir, "*.log");
-        Assert.Single(files);
+        Assert.AreEqual(1, files.Length);
         var content = File.ReadAllText(files[0]);
-        Assert.Contains("Hello from test", content);
-        Assert.Contains("MyCategory", content);
+        Assert.IsTrue(content.Contains("Hello from test"));
+        Assert.IsTrue(content.Contains("MyCategory"));
     }
 
-    [Fact]
+    [TestMethod]
     public void Log_BelowThreshold_DoesNotWrite()
     {
         using var provider = new DailyFileLoggerProvider(_logDir);
@@ -73,10 +74,10 @@ public sealed class DailyFileLoggerProviderTests : IDisposable
 
         logger.LogDebug("should be ignored");
 
-        Assert.Empty(Directory.GetFiles(_logDir, "*.log"));
+        Assert.AreEqual(0, Directory.GetFiles(_logDir, "*.log").Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Log_WithException_IncludesExceptionInFile()
     {
         using var provider = new DailyFileLoggerProvider(_logDir);
@@ -86,10 +87,10 @@ public sealed class DailyFileLoggerProviderTests : IDisposable
         catch (Exception ex) { logger.LogError(ex, "an error occurred"); }
 
         var content = File.ReadAllText(Directory.GetFiles(_logDir, "*.log")[0]);
-        Assert.Contains("test-exception", content);
+        Assert.IsTrue(content.Contains("test-exception"));
     }
 
-    [Fact]
+    [TestMethod]
     public void Log_MultipleEntries_AllAppended()
     {
         using var provider = new DailyFileLoggerProvider(_logDir);
@@ -99,25 +100,27 @@ public sealed class DailyFileLoggerProviderTests : IDisposable
         logger.LogInformation("second");
 
         var content = File.ReadAllText(Directory.GetFiles(_logDir, "*.log")[0]);
-        Assert.Contains("first", content);
-        Assert.Contains("second", content);
+        Assert.IsTrue(content.Contains("first"));
+        Assert.IsTrue(content.Contains("second"));
     }
 
-    [Fact]
+    [TestMethod]
     public void Dispose_DoesNotThrow()
     {
         var provider = new DailyFileLoggerProvider(_logDir);
-        var ex = Record.Exception(() => provider.Dispose());
-        Assert.Null(ex);
+        Exception? ex = null;
+        try { provider.Dispose(); } catch (Exception e) { ex = e; }
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Dispose_CalledTwice_DoesNotThrow()
     {
         var provider = new DailyFileLoggerProvider(_logDir);
         provider.Dispose();
-        var ex = Record.Exception(() => provider.Dispose());
-        Assert.Null(ex);
+        Exception? ex = null;
+        try { provider.Dispose(); } catch (Exception e) { ex = e; }
+        Assert.IsNull(ex);
     }
 
     public void Dispose()

--- a/windows/starsky.Tests/Services/DailyFileLoggerProviderTests.cs
+++ b/windows/starsky.Tests/Services/DailyFileLoggerProviderTests.cs
@@ -60,10 +60,10 @@ public sealed class DailyFileLoggerProviderTests : IDisposable
         logger.LogInformation("Hello from test");
 
         var files = Directory.GetFiles(_logDir, "*.log");
-        Assert.AreEqual(1, files.Length);
+        Assert.HasCount(1, files);
         var content = File.ReadAllText(files[0]);
-        Assert.IsTrue(content.Contains("Hello from test"));
-        Assert.IsTrue(content.Contains("MyCategory"));
+        Assert.Contains("Hello from test", content);
+        Assert.Contains("MyCategory", content);
     }
 
     [TestMethod]
@@ -74,7 +74,7 @@ public sealed class DailyFileLoggerProviderTests : IDisposable
 
         logger.LogDebug("should be ignored");
 
-        Assert.AreEqual(0, Directory.GetFiles(_logDir, "*.log").Length);
+        Assert.IsEmpty(Directory.GetFiles(_logDir, "*.log"));
     }
 
     [TestMethod]
@@ -87,7 +87,7 @@ public sealed class DailyFileLoggerProviderTests : IDisposable
         catch (Exception ex) { logger.LogError(ex, "an error occurred"); }
 
         var content = File.ReadAllText(Directory.GetFiles(_logDir, "*.log")[0]);
-        Assert.IsTrue(content.Contains("test-exception"));
+        Assert.Contains("test-exception", content);
     }
 
     [TestMethod]
@@ -100,8 +100,8 @@ public sealed class DailyFileLoggerProviderTests : IDisposable
         logger.LogInformation("second");
 
         var content = File.ReadAllText(Directory.GetFiles(_logDir, "*.log")[0]);
-        Assert.IsTrue(content.Contains("first"));
-        Assert.IsTrue(content.Contains("second"));
+        Assert.Contains("first", content);
+        Assert.Contains("second", content);
     }
 
     [TestMethod]

--- a/windows/starsky.Tests/Services/FileDownloadServiceTests.cs
+++ b/windows/starsky.Tests/Services/FileDownloadServiceTests.cs
@@ -5,6 +5,7 @@ using starsky.Tests.Helpers;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public sealed class FileDownloadServiceTests : IDisposable
 {
     private const string StarskyPath = "/test-session/photo.jpg";
@@ -35,7 +36,7 @@ public sealed class FileDownloadServiceTests : IDisposable
     private static TrackingFileDownloadService CreateTracking(params HttpResponseMessage[] responses) =>
         new TrackingFileDownloadService(new HttpClient(new FakeHttpMessageHandler(responses)));
 
-    [Fact]
+    [TestMethod]
     public async Task DownloadAndOpenAsync_ValidPath_WritesFileToDisk()
     {
         var photoBytes = new byte[] { 0xFF, 0xD8, 0xFF }; // minimal JPEG header
@@ -46,11 +47,11 @@ public sealed class FileDownloadServiceTests : IDisposable
 
         await svc.DownloadAndOpenAsync(StarskyPath, "http://localhost:5000", openFile: false);
 
-        Assert.True(File.Exists(_expectedFile));
-        Assert.Equal(photoBytes, await File.ReadAllBytesAsync(_expectedFile));
+        Assert.IsTrue(File.Exists(_expectedFile));
+        CollectionAssert.AreEqual(photoBytes, await File.ReadAllBytesAsync(_expectedFile));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DownloadAndOpenAsync_SidecarFails_StillDownloadsMain()
     {
         var photoBytes = new byte[] { 1, 2, 3 };
@@ -61,10 +62,10 @@ public sealed class FileDownloadServiceTests : IDisposable
 
         await svc.DownloadAndOpenAsync(StarskyPath, "http://localhost:5000", openFile: false);
 
-        Assert.True(File.Exists(_expectedFile));
+        Assert.IsTrue(File.Exists(_expectedFile));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DownloadAndOpenAsync_PhotoDownloadFails_Throws()
     {
         var svc = Create(
@@ -72,11 +73,12 @@ public sealed class FileDownloadServiceTests : IDisposable
             new HttpResponseMessage(HttpStatusCode.NotFound),
             new HttpResponseMessage(HttpStatusCode.InternalServerError));
 
-        await Assert.ThrowsAsync<HttpRequestException>(() =>
-            svc.DownloadAndOpenAsync(StarskyPath, "http://localhost:5000", openFile: false));
+        Exception? caught = null;
+        try { await svc.DownloadAndOpenAsync(StarskyPath, "http://localhost:5000", openFile: false); } catch (HttpRequestException e) { caught = e; }
+        Assert.IsInstanceOfType<HttpRequestException>(caught);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DownloadAndOpenAsync_SidecarReturnsEmptyBytes_SkipsXmpFile()
     {
         var photoBytes = new byte[] { 0xFF, 0xD8, 0xFF };
@@ -87,12 +89,12 @@ public sealed class FileDownloadServiceTests : IDisposable
 
         await svc.DownloadAndOpenAsync(StarskyPath, "http://localhost:5000", openFile: false);
 
-        Assert.True(File.Exists(_expectedFile));
+        Assert.IsTrue(File.Exists(_expectedFile));
         var localDir = Path.GetDirectoryName(_expectedFile)!;
-        Assert.DoesNotContain(Directory.GetFiles(localDir), f => f.EndsWith(".xmp", StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(Directory.GetFiles(localDir).Any(f => f.EndsWith(".xmp", StringComparison.OrdinalIgnoreCase)));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DownloadAndOpenAsync_WhenOpenFileTrue_CallsOpenWithDefaultApp()
     {
         var photoBytes = new byte[] { 0xFF, 0xD8, 0xFF };
@@ -103,11 +105,11 @@ public sealed class FileDownloadServiceTests : IDisposable
 
         await svc.DownloadAndOpenAsync(StarskyPath, "http://localhost:5000", openFile: true);
 
-        Assert.NotNull(svc.OpenedFile);
-        Assert.EndsWith("photo.jpg", svc.OpenedFile, StringComparison.OrdinalIgnoreCase);
+        Assert.IsNotNull(svc.OpenedFile);
+        Assert.IsTrue(svc.OpenedFile.EndsWith("photo.jpg", StringComparison.OrdinalIgnoreCase));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DownloadAndOpenAsync_RootLevelPath_UsesBaseOfTempFolder()
     {
         const string rootPath = "root-photo.jpg";
@@ -120,7 +122,7 @@ public sealed class FileDownloadServiceTests : IDisposable
         await svc.DownloadAndOpenAsync(rootPath, "http://localhost:5000", openFile: false);
 
         var expectedFile = Path.Combine(ApplicationPaths.TempFolder, rootPath);
-        Assert.True(File.Exists(expectedFile));
+        Assert.IsTrue(File.Exists(expectedFile));
         try { File.Delete(expectedFile); } catch { /* best-effort */ }
     }
 

--- a/windows/starsky.Tests/Services/FileDownloadServiceTests.cs
+++ b/windows/starsky.Tests/Services/FileDownloadServiceTests.cs
@@ -11,6 +11,8 @@ public sealed class FileDownloadServiceTests : IDisposable
     private const string StarskyPath = "/test-session/photo.jpg";
     private readonly string _expectedFile;
 
+    public TestContext TestContext { get; set; } = null!;
+
     public FileDownloadServiceTests()
     {
         // Replicate the service's path calculation exactly so the assertion matches on Windows too.
@@ -48,7 +50,7 @@ public sealed class FileDownloadServiceTests : IDisposable
         await svc.DownloadAndOpenAsync(StarskyPath, "http://localhost:5000", openFile: false);
 
         Assert.IsTrue(File.Exists(_expectedFile));
-        CollectionAssert.AreEqual(photoBytes, await File.ReadAllBytesAsync(_expectedFile));
+        Assert.AreSequenceEqual(photoBytes, await File.ReadAllBytesAsync(_expectedFile, TestContext.CancellationToken));
     }
 
     [TestMethod]
@@ -91,7 +93,8 @@ public sealed class FileDownloadServiceTests : IDisposable
 
         Assert.IsTrue(File.Exists(_expectedFile));
         var localDir = Path.GetDirectoryName(_expectedFile)!;
-        Assert.IsFalse(Directory.GetFiles(localDir).Any(f => f.EndsWith(".xmp", StringComparison.OrdinalIgnoreCase)));
+        var xmpFiles = Directory.GetFiles(localDir).Where(f => f.EndsWith(".xmp", StringComparison.OrdinalIgnoreCase));
+        Assert.IsEmpty(xmpFiles);
     }
 
     [TestMethod]

--- a/windows/starsky.Tests/Services/FileWatcherServiceTests.cs
+++ b/windows/starsky.Tests/Services/FileWatcherServiceTests.cs
@@ -10,6 +10,8 @@ public sealed class FileWatcherServiceTests : IDisposable
 {
     private readonly FileWatcherService _sut = new(NullLogger<FileWatcherService>.Instance);
 
+    public TestContext TestContext { get; set; } = null!;
+
     [TestMethod]
     public void Start_DoesNotThrow()
     {
@@ -65,13 +67,12 @@ public sealed class FileWatcherServiceTests : IDisposable
         _sut.Start();
         var path = Path.Combine(ApplicationPaths.TempFolder, $"test-{Guid.NewGuid()}.jpg");
 
-        await File.WriteAllBytesAsync(path, [1, 2, 3]);
+        await File.WriteAllBytesAsync(path, [1, 2, 3], TestContext.CancellationToken);
 
         // Wait for watcher event + debounce timer (500 ms) to fire without throwing
-        await Task.Delay(700);
+        await Task.Delay(700, TestContext.CancellationToken);
 
         try { File.Delete(path); } catch { /* best-effort */ }
-        Assert.IsTrue(true); // reaching here without exception is the assertion
     }
 
     [TestMethod]
@@ -80,11 +81,10 @@ public sealed class FileWatcherServiceTests : IDisposable
         _sut.Start();
         var path = Path.Combine(ApplicationPaths.TempFolder, $"test-{Guid.NewGuid()}.tmp");
 
-        await File.WriteAllBytesAsync(path, [1, 2, 3]);
-        await Task.Delay(200);
+        await File.WriteAllBytesAsync(path, [1, 2, 3], TestContext.CancellationToken);
+        await Task.Delay(200, TestContext.CancellationToken);
 
         try { File.Delete(path); } catch { /* best-effort */ }
-        Assert.IsTrue(true);
     }
 
     [TestMethod]
@@ -103,8 +103,8 @@ public sealed class FileWatcherServiceTests : IDisposable
     {
         var result = FileWatcherService.LocalPathToStarskyPath(@"C:\some\other\file.jpg");
 
-        Assert.IsTrue(result.StartsWith("/"));
-        Assert.IsFalse(result.Contains("\\"));
+        Assert.StartsWith("/", result);
+        Assert.DoesNotContain("\\", result);
     }
 
     [TestMethod]
@@ -141,13 +141,12 @@ public sealed class FileWatcherServiceTests : IDisposable
         sut.SetUploadContext("http://localhost:5000", null);
 
         var path = Path.Combine(ApplicationPaths.TempFolder, $"test-{Guid.NewGuid()}.jpg");
-        await File.WriteAllBytesAsync(path, [0xFF, 0xD8, 0xFF, 0xE0]);
+        await File.WriteAllBytesAsync(path, [0xFF, 0xD8, 0xFF, 0xE0], TestContext.CancellationToken);
 
         // Wait for watcher debounce + background upload to complete
-        await Task.Delay(1200);
+        await Task.Delay(1200, TestContext.CancellationToken);
 
         try { File.Delete(path); } catch { /* best-effort */ }
-        Assert.IsTrue(true); // reaching here without unhandled exception is the assertion
     }
 
     public void Dispose()

--- a/windows/starsky.Tests/Services/FileWatcherServiceTests.cs
+++ b/windows/starsky.Tests/Services/FileWatcherServiceTests.cs
@@ -69,6 +69,8 @@ public sealed class FileWatcherServiceTests : IDisposable
 
         await File.WriteAllBytesAsync(path, [1, 2, 3], TestContext.CancellationToken);
 
+        Assert.IsTrue(File.Exists(path), "Test file should exist after creation");
+
         // Wait for watcher event + debounce timer (500 ms) to fire without throwing
         await Task.Delay(700, TestContext.CancellationToken);
 
@@ -82,6 +84,9 @@ public sealed class FileWatcherServiceTests : IDisposable
         var path = Path.Combine(ApplicationPaths.TempFolder, $"test-{Guid.NewGuid()}.tmp");
 
         await File.WriteAllBytesAsync(path, [1, 2, 3], TestContext.CancellationToken);
+
+        Assert.IsTrue(File.Exists(path), "Test file should exist after creation");
+
         await Task.Delay(200, TestContext.CancellationToken);
 
         try { File.Delete(path); } catch { /* best-effort */ }
@@ -142,6 +147,8 @@ public sealed class FileWatcherServiceTests : IDisposable
 
         var path = Path.Combine(ApplicationPaths.TempFolder, $"test-{Guid.NewGuid()}.jpg");
         await File.WriteAllBytesAsync(path, [0xFF, 0xD8, 0xFF, 0xE0], TestContext.CancellationToken);
+
+        Assert.IsTrue(File.Exists(path), "Test file should exist after creation");
 
         // Wait for watcher debounce + background upload to complete
         await Task.Delay(1200, TestContext.CancellationToken);

--- a/windows/starsky.Tests/Services/FileWatcherServiceTests.cs
+++ b/windows/starsky.Tests/Services/FileWatcherServiceTests.cs
@@ -5,55 +5,61 @@ using starsky.Tests.Helpers;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public sealed class FileWatcherServiceTests : IDisposable
 {
     private readonly FileWatcherService _sut = new(NullLogger<FileWatcherService>.Instance);
 
-    [Fact]
+    [TestMethod]
     public void Start_DoesNotThrow()
     {
-        var ex = Record.Exception(() => _sut.Start());
-        Assert.Null(ex);
+        Exception? ex = null;
+        try { _sut.Start(); } catch (Exception e) { ex = e; }
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Stop_BeforeStart_DoesNotThrow()
     {
-        var ex = Record.Exception(() => _sut.Stop());
-        Assert.Null(ex);
+        Exception? ex = null;
+        try { _sut.Stop(); } catch (Exception e) { ex = e; }
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Stop_AfterStart_DoesNotThrow()
     {
         _sut.Start();
-        var ex = Record.Exception(() => _sut.Stop());
-        Assert.Null(ex);
+        Exception? ex = null;
+        try { _sut.Stop(); } catch (Exception e) { ex = e; }
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Dispose_BeforeStart_IsIdempotent()
     {
-        var ex = Record.Exception(() => _sut.Dispose());
-        Assert.Null(ex);
+        Exception? ex = null;
+        try { _sut.Dispose(); } catch (Exception e) { ex = e; }
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Dispose_AfterStart_DoesNotThrow()
     {
         _sut.Start();
-        var ex = Record.Exception(() => _sut.Dispose());
-        Assert.Null(ex);
+        Exception? ex = null;
+        try { _sut.Dispose(); } catch (Exception e) { ex = e; }
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Start_CreatesTempFolderIfMissing()
     {
         _sut.Start();
-        Assert.True(Directory.Exists(ApplicationPaths.TempFolder));
+        Assert.IsTrue(Directory.Exists(ApplicationPaths.TempFolder));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FileCreated_NonTmpFile_TriggersDebounce()
     {
         _sut.Start();
@@ -65,10 +71,10 @@ public sealed class FileWatcherServiceTests : IDisposable
         await Task.Delay(700);
 
         try { File.Delete(path); } catch { /* best-effort */ }
-        Assert.True(true); // reaching here without exception is the assertion
+        Assert.IsTrue(true); // reaching here without exception is the assertion
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FileCreated_TmpFile_IsIgnored()
     {
         _sut.Start();
@@ -78,10 +84,10 @@ public sealed class FileWatcherServiceTests : IDisposable
         await Task.Delay(200);
 
         try { File.Delete(path); } catch { /* best-effort */ }
-        Assert.True(true);
+        Assert.IsTrue(true);
     }
 
-    [Fact]
+    [TestMethod]
     public void LocalPathToStarskyPath_StripsWinTempFolderPrefix()
     {
         var tempFolder = ApplicationPaths.TempFolder;
@@ -89,42 +95,43 @@ public sealed class FileWatcherServiceTests : IDisposable
 
         var result = FileWatcherService.LocalPathToStarskyPath(localPath);
 
-        Assert.Equal("/photos/2024/image.jpg", result);
+        Assert.AreEqual("/photos/2024/image.jpg", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void LocalPathToStarskyPath_WhenOutsideTempFolder_NormalizesSlashes()
     {
         var result = FileWatcherService.LocalPathToStarskyPath(@"C:\some\other\file.jpg");
 
-        Assert.StartsWith("/", result);
-        Assert.DoesNotContain("\\", result);
+        Assert.IsTrue(result.StartsWith("/"));
+        Assert.IsFalse(result.Contains("\\"));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetUploadEndpoint_XmpLowercase_ReturnsSidecar()
-        => Assert.Equal("upload-sidecar", FileWatcherService.GetUploadEndpoint("photo.xmp"));
+        => Assert.AreEqual("upload-sidecar", FileWatcherService.GetUploadEndpoint("photo.xmp"));
 
-    [Fact]
+    [TestMethod]
     public void GetUploadEndpoint_XmpUppercase_ReturnsSidecar()
-        => Assert.Equal("upload-sidecar", FileWatcherService.GetUploadEndpoint("photo.XMP"));
+        => Assert.AreEqual("upload-sidecar", FileWatcherService.GetUploadEndpoint("photo.XMP"));
 
-    [Fact]
+    [TestMethod]
     public void GetUploadEndpoint_Jpg_ReturnsUpload()
-        => Assert.Equal("upload", FileWatcherService.GetUploadEndpoint("photo.jpg"));
+        => Assert.AreEqual("upload", FileWatcherService.GetUploadEndpoint("photo.jpg"));
 
-    [Fact]
+    [TestMethod]
     public void GetUploadEndpoint_NoExtension_ReturnsUpload()
-        => Assert.Equal("upload", FileWatcherService.GetUploadEndpoint("photo"));
+        => Assert.AreEqual("upload", FileWatcherService.GetUploadEndpoint("photo"));
 
-    [Fact]
+    [TestMethod]
     public void SetUploadContext_DoesNotThrow()
     {
-        var ex = Record.Exception(() => _sut.SetUploadContext("http://localhost:5000", "auth=abc"));
-        Assert.Null(ex);
+        Exception? ex = null;
+        try { _sut.SetUploadContext("http://localhost:5000", "auth=abc"); } catch (Exception e) { ex = e; }
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task UploadFileAsync_WhenServerReturns500_DoesNotThrow()
     {
         using var http = new HttpClient(
@@ -140,7 +147,7 @@ public sealed class FileWatcherServiceTests : IDisposable
         await Task.Delay(1200);
 
         try { File.Delete(path); } catch { /* best-effort */ }
-        Assert.True(true); // reaching here without unhandled exception is the assertion
+        Assert.IsTrue(true); // reaching here without unhandled exception is the assertion
     }
 
     public void Dispose()

--- a/windows/starsky.Tests/Services/NavigationServiceTests.cs
+++ b/windows/starsky.Tests/Services/NavigationServiceTests.cs
@@ -4,69 +4,70 @@ using Starsky.Desktop.Services;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public class NavigationServiceTests
 {
-    [Theory]
-    [InlineData("http://localhost:4000/starsky?f=/photos", "")]
-    [InlineData("http://localhost:9999", "")]
+    [TestMethod]
+    [DataRow("http://localhost:4000/starsky?f=/photos", "")]
+    [DataRow("http://localhost:9999", "")]
     public void IsAllowedOrigin_Localhost_ReturnsTrue(string url, string baseUrl)
     {
-        Assert.True(NavigationService.IsAllowedOrigin(new Uri(url), baseUrl));
+        Assert.IsTrue(NavigationService.IsAllowedOrigin(new Uri(url), baseUrl));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsAllowedOrigin_MatchingRemote_ReturnsTrue()
     {
-        Assert.True(NavigationService.IsAllowedOrigin(new Uri("https://example.com/starsky?f=/"), "https://example.com"));
+        Assert.IsTrue(NavigationService.IsAllowedOrigin(new Uri("https://example.com/starsky?f=/"), "https://example.com"));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsAllowedOrigin_DifferentHost_ReturnsFalse()
     {
-        Assert.False(NavigationService.IsAllowedOrigin(new Uri("https://evil.com"), "https://example.com"));
+        Assert.IsFalse(NavigationService.IsAllowedOrigin(new Uri("https://evil.com"), "https://example.com"));
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildStartUrl_WithRoute_AppendsRoute()
     {
         var url = NavigationService.BuildStartUrl("http://localhost:4000", "?f=/photos");
-        Assert.Equal("http://localhost:4000?f=/photos", url);
+        Assert.AreEqual("http://localhost:4000?f=/photos", url);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildStartUrl_NullRoute_UsesDefault()
     {
         var url = NavigationService.BuildStartUrl("http://localhost:4000", null);
-        Assert.Equal("http://localhost:4000?f=/", url);
+        Assert.AreEqual("http://localhost:4000?f=/", url);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildStartUrl_TrailingSlash_Trimmed()
     {
         var url = NavigationService.BuildStartUrl("http://localhost:4000/", "?f=/");
-        Assert.Equal("http://localhost:4000?f=/", url);
+        Assert.AreEqual("http://localhost:4000?f=/", url);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildStartUrl_RouteWithoutLeadingSlashOrQuery_PrependSlash()
     {
         var url = NavigationService.BuildStartUrl("http://localhost:4000", "starsky");
-        Assert.Equal("http://localhost:4000/starsky", url);
+        Assert.AreEqual("http://localhost:4000/starsky", url);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsAllowedOrigin_EmptyBaseUrl_OnlyAllowsLocalhost()
     {
-        Assert.False(NavigationService.IsAllowedOrigin(new Uri("https://example.com"), ""));
+        Assert.IsFalse(NavigationService.IsAllowedOrigin(new Uri("https://example.com"), ""));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsAllowedOrigin_InvalidBaseUrl_ReturnsFalse()
     {
-        Assert.False(NavigationService.IsAllowedOrigin(new Uri("https://example.com"), "not-a-url"));
+        Assert.IsFalse(NavigationService.IsAllowedOrigin(new Uri("https://example.com"), "not-a-url"));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetEffectiveBaseUrl_LocalMode_ReturnsLocalhostWithPort()
     {
         var settings = new SettingsService(NullLogger<SettingsService>.Instance);
@@ -75,10 +76,10 @@ public class NavigationServiceTests
 
         var url = nav.GetEffectiveBaseUrl(9876);
 
-        Assert.Equal("http://localhost:9876", url);
+        Assert.AreEqual("http://localhost:9876", url);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetEffectiveBaseUrl_RemoteMode_ReturnsRemoteUrl()
     {
         var settings = new SettingsService(NullLogger<SettingsService>.Instance);
@@ -88,10 +89,10 @@ public class NavigationServiceTests
 
         var url = nav.GetEffectiveBaseUrl(9876);
 
-        Assert.Equal("https://example.com", url);
+        Assert.AreEqual("https://example.com", url);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetEffectiveBaseUrl_LocalModeNoPort_ReturnsRemoteUrl()
     {
         var settings = new SettingsService(NullLogger<SettingsService>.Instance);
@@ -101,6 +102,6 @@ public class NavigationServiceTests
 
         var url = nav.GetEffectiveBaseUrl(null);
 
-        Assert.Equal("https://example.com", url);
+        Assert.AreEqual("https://example.com", url);
     }
 }

--- a/windows/starsky.Tests/Services/PortFinderTests.cs
+++ b/windows/starsky.Tests/Services/PortFinderTests.cs
@@ -9,7 +9,7 @@ public class PortFinderTests
     public void FindFreePort_ReturnsPositivePort()
     {
         var port = PortFinder.FindFreePort();
-        Assert.IsTrue(port > 0, $"Expected positive port, got {port}");
+        Assert.IsGreaterThan(0, port, $"Expected positive port, got {port}");
     }
 
     [TestMethod]
@@ -30,6 +30,6 @@ public class PortFinderTests
         // Ports can in theory be re-used, but two rapid calls rarely return the same value
         var ports = Enumerable.Range(0, 5).Select(_ => PortFinder.FindFreePort()).ToList();
         // At minimum all are valid
-        foreach (var p in ports) Assert.IsTrue(p > 0);
+        foreach (var p in ports) Assert.IsGreaterThan(0, p);
     }
 }

--- a/windows/starsky.Tests/Services/PortFinderTests.cs
+++ b/windows/starsky.Tests/Services/PortFinderTests.cs
@@ -2,16 +2,17 @@ using Starsky.Desktop.Services;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public class PortFinderTests
 {
-    [Fact]
+    [TestMethod]
     public void FindFreePort_ReturnsPositivePort()
     {
         var port = PortFinder.FindFreePort();
-        Assert.True(port > 0, $"Expected positive port, got {port}");
+        Assert.IsTrue(port > 0, $"Expected positive port, got {port}");
     }
 
-    [Fact]
+    [TestMethod]
     public void FindFreePort_PortIsNotInUse()
     {
         var port = PortFinder.FindFreePort();
@@ -20,15 +21,15 @@ public class PortFinderTests
         listener.Start();
         listener.Stop();
         var ep = (IPEndPoint)listener.LocalEndpoint;
-        Assert.Equal(port, ep.Port);
+        Assert.AreEqual(port, ep.Port);
     }
 
-    [Fact]
+    [TestMethod]
     public void FindFreePort_ReturnsDifferentPortsOnSuccessiveCalls()
     {
         // Ports can in theory be re-used, but two rapid calls rarely return the same value
         var ports = Enumerable.Range(0, 5).Select(_ => PortFinder.FindFreePort()).ToList();
         // At minimum all are valid
-        Assert.All(ports, p => Assert.True(p > 0));
+        foreach (var p in ports) Assert.IsTrue(p > 0);
     }
 }

--- a/windows/starsky.Tests/Services/RemoteUrlValidatorTests.cs
+++ b/windows/starsky.Tests/Services/RemoteUrlValidatorTests.cs
@@ -5,6 +5,7 @@ using starsky.Tests.Helpers;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public class RemoteUrlValidatorTests
 {
     private static RemoteUrlValidator Create(HttpStatusCode status, string content = "") =>
@@ -12,60 +13,60 @@ public class RemoteUrlValidatorTests
             NullLogger<RemoteUrlValidator>.Instance,
             new HttpClient(new FakeHttpMessageHandler(status, content)));
 
-    [Fact]
+    [TestMethod]
     public async Task ValidateAsync_EmptyString_ReturnsFalse()
     {
         var svc = Create(HttpStatusCode.OK);
 
         var result = await svc.ValidateAsync(string.Empty);
 
-        Assert.False(result.Success);
+        Assert.IsFalse(result.Success);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ValidateAsync_InvalidScheme_ReturnsFalse()
     {
         var svc = Create(HttpStatusCode.OK);
 
         var result = await svc.ValidateAsync("ftp://example.com");
 
-        Assert.False(result.Success);
-        Assert.Contains("http", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(result.Error!.Contains("http", StringComparison.OrdinalIgnoreCase));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ValidateAsync_WhenServerReturns200_ReturnsSuccess()
     {
         var svc = Create(HttpStatusCode.OK);
 
         var result = await svc.ValidateAsync("http://localhost:5000");
 
-        Assert.True(result.Success);
-        Assert.Null(result.Error);
+        Assert.IsTrue(result.Success);
+        Assert.IsNull(result.Error);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ValidateAsync_WhenServerReturns503_ReturnsSuccess()
     {
         var svc = Create(HttpStatusCode.ServiceUnavailable);
 
         var result = await svc.ValidateAsync("http://localhost:5000");
 
-        Assert.True(result.Success);
+        Assert.IsTrue(result.Success);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ValidateAsync_WhenServerReturnsOtherError_ReturnsFalse()
     {
         var svc = Create(HttpStatusCode.Forbidden);
 
         var result = await svc.ValidateAsync("http://localhost:5000");
 
-        Assert.False(result.Success);
-        Assert.Contains("403", result.Error);
+        Assert.IsFalse(result.Success);
+        Assert.IsTrue(result.Error!.Contains("403"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ValidateAsync_WhenRequestThrows_ReturnsFalse()
     {
         var handler = new ThrowingHttpMessageHandler();
@@ -75,10 +76,10 @@ public class RemoteUrlValidatorTests
 
         var result = await svc.ValidateAsync("http://localhost:5000");
 
-        Assert.False(result.Success);
+        Assert.IsFalse(result.Success);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ValidateAsync_TrailingSlash_DoesNotAffectResult()
     {
         var svc = Create(HttpStatusCode.OK);
@@ -86,17 +87,17 @@ public class RemoteUrlValidatorTests
         var withSlash = await svc.ValidateAsync("http://localhost:5000/");
         var withoutSlash = await svc.ValidateAsync("http://localhost:5000");
 
-        Assert.Equal(withSlash.Success, withoutSlash.Success);
+        Assert.AreEqual(withSlash.Success, withoutSlash.Success);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ValidateAsync_HttpsScheme_IsAccepted()
     {
         var svc = Create(HttpStatusCode.OK);
 
         var result = await svc.ValidateAsync("https://example.com");
 
-        Assert.True(result.Success);
+        Assert.IsTrue(result.Success);
     }
 
     private sealed class ThrowingHttpMessageHandler : HttpMessageHandler

--- a/windows/starsky.Tests/Services/RemoteUrlValidatorTests.cs
+++ b/windows/starsky.Tests/Services/RemoteUrlValidatorTests.cs
@@ -63,7 +63,7 @@ public class RemoteUrlValidatorTests
         var result = await svc.ValidateAsync("http://localhost:5000");
 
         Assert.IsFalse(result.Success);
-        Assert.IsTrue(result.Error!.Contains("403"));
+        Assert.Contains("403", result.Error!);
     }
 
     [TestMethod]

--- a/windows/starsky.Tests/Services/RoutePersistenceServiceTests.cs
+++ b/windows/starsky.Tests/Services/RoutePersistenceServiceTests.cs
@@ -22,7 +22,7 @@ public sealed class RoutePersistenceServiceTests : IDisposable
     [TestMethod]
     public void GetRoutes_WhenEmpty_ReturnsEmptyList()
     {
-        Assert.AreEqual(0, _sut.GetRoutes().Count);
+        Assert.IsEmpty(_sut.GetRoutes());
     }
 
     [TestMethod]
@@ -31,7 +31,7 @@ public sealed class RoutePersistenceServiceTests : IDisposable
         _sut.SaveRoute(0, "?f=/photos");
 
         var routes = _sut.GetRoutes();
-        Assert.AreEqual(1, routes.Count);
+        Assert.HasCount(1, routes);
         Assert.AreEqual("?f=/photos", routes[0].Route);
     }
 
@@ -56,7 +56,7 @@ public sealed class RoutePersistenceServiceTests : IDisposable
         _sut.SaveRoute(2, "?f=/deep");
 
         var routes = _sut.GetRoutes();
-        Assert.AreEqual(3, routes.Count);
+        Assert.HasCount(3, routes);
         Assert.AreEqual("?f=/", routes[0].Route);
         Assert.AreEqual("?f=/", routes[1].Route);
         Assert.AreEqual("?f=/deep", routes[2].Route);
@@ -71,7 +71,7 @@ public sealed class RoutePersistenceServiceTests : IDisposable
         _sut.RemoveRoute(0);
 
         var routes = _sut.GetRoutes();
-        Assert.AreEqual(1, routes.Count);
+        Assert.HasCount(1, routes);
         Assert.AreEqual("?f=/b", routes[0].Route);
     }
 
@@ -83,7 +83,7 @@ public sealed class RoutePersistenceServiceTests : IDisposable
 
         _sut.ClearAll();
 
-        Assert.AreEqual(0, _sut.GetRoutes().Count);
+        Assert.IsEmpty(_sut.GetRoutes());
     }
 
     public void Dispose()

--- a/windows/starsky.Tests/Services/RoutePersistenceServiceTests.cs
+++ b/windows/starsky.Tests/Services/RoutePersistenceServiceTests.cs
@@ -4,6 +4,7 @@ using Starsky.Desktop.Services;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public sealed class RoutePersistenceServiceTests : IDisposable
 {
     private readonly string _tempFile;
@@ -18,23 +19,23 @@ public sealed class RoutePersistenceServiceTests : IDisposable
         _sut = new RoutePersistenceService(_settings);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetRoutes_WhenEmpty_ReturnsEmptyList()
     {
-        Assert.Empty(_sut.GetRoutes());
+        Assert.AreEqual(0, _sut.GetRoutes().Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void SaveRoute_AddsEntry()
     {
         _sut.SaveRoute(0, "?f=/photos");
 
         var routes = _sut.GetRoutes();
-        Assert.Single(routes);
-        Assert.Equal("?f=/photos", routes[0].Route);
+        Assert.AreEqual(1, routes.Count);
+        Assert.AreEqual("?f=/photos", routes[0].Route);
     }
 
-    [Fact]
+    [TestMethod]
     public void SaveRoute_WithGeometry_PersistsGeometry()
     {
         var geo = new SavedWindowState { Left = 50, Top = 60, Width = 800, Height = 600, IsMaximized = true };
@@ -42,26 +43,26 @@ public sealed class RoutePersistenceServiceTests : IDisposable
         _sut.SaveRoute(0, "?f=/", geo);
 
         var state = _sut.GetRoutes()[0];
-        Assert.Equal(50, state.Left);
-        Assert.Equal(60, state.Top);
-        Assert.Equal(800, state.Width);
-        Assert.Equal(600, state.Height);
-        Assert.True(state.IsMaximized);
+        Assert.AreEqual(50, state.Left);
+        Assert.AreEqual(60, state.Top);
+        Assert.AreEqual(800, state.Width);
+        Assert.AreEqual(600, state.Height);
+        Assert.IsTrue(state.IsMaximized);
     }
 
-    [Fact]
+    [TestMethod]
     public void SaveRoute_ExpandsListWithBlanks()
     {
         _sut.SaveRoute(2, "?f=/deep");
 
         var routes = _sut.GetRoutes();
-        Assert.Equal(3, routes.Count);
-        Assert.Equal("?f=/", routes[0].Route);
-        Assert.Equal("?f=/", routes[1].Route);
-        Assert.Equal("?f=/deep", routes[2].Route);
+        Assert.AreEqual(3, routes.Count);
+        Assert.AreEqual("?f=/", routes[0].Route);
+        Assert.AreEqual("?f=/", routes[1].Route);
+        Assert.AreEqual("?f=/deep", routes[2].Route);
     }
 
-    [Fact]
+    [TestMethod]
     public void RemoveRoute_RemovesEntry()
     {
         _sut.SaveRoute(0, "?f=/a");
@@ -70,11 +71,11 @@ public sealed class RoutePersistenceServiceTests : IDisposable
         _sut.RemoveRoute(0);
 
         var routes = _sut.GetRoutes();
-        Assert.Single(routes);
-        Assert.Equal("?f=/b", routes[0].Route);
+        Assert.AreEqual(1, routes.Count);
+        Assert.AreEqual("?f=/b", routes[0].Route);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearAll_EmptiesList()
     {
         _sut.SaveRoute(0, "?f=/a");
@@ -82,7 +83,7 @@ public sealed class RoutePersistenceServiceTests : IDisposable
 
         _sut.ClearAll();
 
-        Assert.Empty(_sut.GetRoutes());
+        Assert.AreEqual(0, _sut.GetRoutes().Count);
     }
 
     public void Dispose()

--- a/windows/starsky.Tests/Services/SettingsServiceTests.cs
+++ b/windows/starsky.Tests/Services/SettingsServiceTests.cs
@@ -34,7 +34,7 @@ public sealed class SettingsServiceTests : IDisposable
         var s = svc.Load();
         Assert.AreEqual(RuntimeMode.Local, s.Mode);
         Assert.IsTrue(s.UpdateCheckEnabled);
-        Assert.AreEqual(0, s.Windows.Count);
+        Assert.IsEmpty(s.Windows);
     }
 
     [TestMethod]

--- a/windows/starsky.Tests/Services/SettingsServiceTests.cs
+++ b/windows/starsky.Tests/Services/SettingsServiceTests.cs
@@ -4,6 +4,7 @@ using Starsky.Desktop.Services;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public sealed class SettingsServiceTests : IDisposable
 {
     private readonly string _tempDir;
@@ -20,42 +21,42 @@ public sealed class SettingsServiceTests : IDisposable
     {
         if (settingsJson != null)
         {
-	        File.WriteAllText(_settingsFile, settingsJson);
+            File.WriteAllText(_settingsFile, settingsJson);
         }
 
         return new SettingsService(NullLogger<SettingsService>.Instance, _settingsFile);
     }
 
-    [Fact]
+    [TestMethod]
     public void Load_MissingFile_ReturnsDefaults()
     {
         var svc = CreateService();
         var s = svc.Load();
-        Assert.Equal(RuntimeMode.Local, s.Mode);
-        Assert.True(s.UpdateCheckEnabled);
-        Assert.Empty(s.Windows);
+        Assert.AreEqual(RuntimeMode.Local, s.Mode);
+        Assert.IsTrue(s.UpdateCheckEnabled);
+        Assert.AreEqual(0, s.Windows.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Load_ValidJson_RestoresSettings()
     {
         var json = """{"Mode":1,"RemoteBaseUrl":"https://example.com","UpdateCheckEnabled":false,"Windows":[]}""";
         var svc = CreateService(json);
         var s = svc.Load();
-        Assert.Equal(RuntimeMode.Remote, s.Mode);
-        Assert.Equal("https://example.com", s.RemoteBaseUrl);
-        Assert.False(s.UpdateCheckEnabled);
+        Assert.AreEqual(RuntimeMode.Remote, s.Mode);
+        Assert.AreEqual("https://example.com", s.RemoteBaseUrl);
+        Assert.IsFalse(s.UpdateCheckEnabled);
     }
 
-    [Fact]
+    [TestMethod]
     public void Load_CorruptJson_ReturnsDefaults()
     {
         var svc = CreateService("{not-valid-json}}}");
         var s = svc.Load();
-        Assert.Equal(RuntimeMode.Local, s.Mode);
+        Assert.AreEqual(RuntimeMode.Local, s.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Save_ThenLoad_RoundTrips()
     {
         var svc = CreateService();
@@ -68,11 +69,11 @@ public sealed class SettingsServiceTests : IDisposable
 
         var svc2 = new SettingsService(NullLogger<SettingsService>.Instance, _settingsFile);
         svc2.Load();
-        Assert.Equal(RuntimeMode.Remote, svc2.Current.Mode);
-        Assert.Equal("https://example.com", svc2.Current.RemoteBaseUrl);
+        Assert.AreEqual(RuntimeMode.Remote, svc2.Current.Mode);
+        Assert.AreEqual("https://example.com", svc2.Current.RemoteBaseUrl);
     }
 
-    [Fact]
+    [TestMethod]
     public void Save_NoArg_PersistsCurrentSettings()
     {
         var svc = CreateService();
@@ -82,28 +83,29 @@ public sealed class SettingsServiceTests : IDisposable
 
         var svc2 = new SettingsService(NullLogger<SettingsService>.Instance, _settingsFile);
         svc2.Load();
-        Assert.Equal("https://my-server.com", svc2.Current.RemoteBaseUrl);
+        Assert.AreEqual("https://my-server.com", svc2.Current.RemoteBaseUrl);
     }
 
-    [Fact]
+    [TestMethod]
     public void Save_ToInvalidPath_DoesNotThrow()
     {
         var badFile = Path.Combine(_tempDir, "sub", "deeper", "settings.json"); // parent doesn't exist
         var svc = new SettingsService(NullLogger<SettingsService>.Instance, badFile);
 
-        var ex = Record.Exception(() => svc.Save(new DesktopSettings()));
+        Exception? ex = null;
+        try { svc.Save(new DesktopSettings()); } catch (Exception e) { ex = e; }
 
-        Assert.Null(ex);
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Load_ReturnsCurrentAfterLoad()
     {
         var svc = CreateService();
 
         var settings = svc.Load();
 
-        Assert.Same(svc.Current, settings);
+        Assert.AreSame(svc.Current, settings);
     }
 
     public void Dispose()

--- a/windows/starsky.Tests/Services/UpdateServiceTests.cs
+++ b/windows/starsky.Tests/Services/UpdateServiceTests.cs
@@ -4,6 +4,7 @@ using Starsky.Desktop.Services;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public sealed class UpdateServiceTests : IDisposable
 {
     private readonly string _tempFile;
@@ -41,40 +42,40 @@ public sealed class UpdateServiceTests : IDisposable
 
     // --- CheckAsync routing ---
 
-    [Fact]
+    [TestMethod]
     public async Task CheckAsync_WhenUpdateCheckDisabled_ReturnsFalse()
     {
         _settings.Current.UpdateCheckEnabled = false;
 
-        Assert.False(await CreateService().CheckAsync());
+        Assert.IsFalse(await CreateService().CheckAsync());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CheckAsync_WhenWarningShownRecently_ReturnsFalse()
     {
         _settings.Current.UpdateCheckEnabled = true;
         _settings.Current.LastUpdateWarningShown = DateTime.UtcNow.AddMinutes(-1);
 
-        Assert.False(await CreateService().CheckAsync());
+        Assert.IsFalse(await CreateService().CheckAsync());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CheckAsync_WhenUpdateAvailable_ReturnsTrue()
     {
         _settings.Current.UpdateCheckEnabled = true;
 
-        Assert.True(await new FakeUpdateService(_settings, hasUpdate: true).CheckAsync());
+        Assert.IsTrue(await new FakeUpdateService(_settings, hasUpdate: true).CheckAsync());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CheckAsync_WhenNoUpdate_ReturnsFalse()
     {
         _settings.Current.UpdateCheckEnabled = true;
 
-        Assert.False(await new FakeUpdateService(_settings, hasUpdate: false).CheckAsync());
+        Assert.IsFalse(await new FakeUpdateService(_settings, hasUpdate: false).CheckAsync());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CheckAsync_WhenWarningShownLongAgo_ProceedsToCheck()
     {
         _settings.Current.UpdateCheckEnabled = true;
@@ -82,31 +83,34 @@ public sealed class UpdateServiceTests : IDisposable
 
         // Falls through to Velopack (unavailable in CI) then appcast stub — must not throw
         var svc = CreateService(httpGet: _ => Task.FromResult(AppcastXml("0.0.0")));
-        var ex = await Record.ExceptionAsync(() => svc.CheckAsync());
+        Exception? ex = null;
+        try { await svc.CheckAsync(); } catch (Exception e) { ex = e; }
 
-        Assert.Null(ex);
+        Assert.IsNull(ex);
     }
 
     // --- ApplyUpdateAsync ---
 
-    [Fact]
+    [TestMethod]
     public async Task ApplyUpdateAsync_WhenNoPendingUpdate_Throws()
     {
-        await Assert.ThrowsAsync<InvalidOperationException>(() => CreateService().ApplyUpdateAsync());
+        Exception? caught = null;
+        try { await CreateService().ApplyUpdateAsync(); } catch (InvalidOperationException e) { caught = e; }
+        Assert.IsInstanceOfType<InvalidOperationException>(caught);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ApplyUpdateAsync_WhenReadyToApply_DoesNotThrow()
     {
-        var ex = await Record.ExceptionAsync(() =>
-            new FakeUpdateService(_settings, canApply: true).ApplyUpdateAsync());
+        Exception? ex = null;
+        try { await new FakeUpdateService(_settings, canApply: true).ApplyUpdateAsync(); } catch (Exception e) { ex = e; }
 
-        Assert.Null(ex);
+        Assert.IsNull(ex);
     }
 
     // --- RecordWarningShown ---
 
-    [Fact]
+    [TestMethod]
     public void RecordWarningShown_SetsTimestamp()
     {
         var before = DateTime.UtcNow.AddSeconds(-1);
@@ -114,19 +118,19 @@ public sealed class UpdateServiceTests : IDisposable
 
         var loaded = new SettingsService(NullLogger<SettingsService>.Instance, _tempFile);
         loaded.Load();
-        Assert.NotNull(loaded.Current.LastUpdateWarningShown);
-        Assert.True(loaded.Current.LastUpdateWarningShown >= before);
+        Assert.IsNotNull(loaded.Current.LastUpdateWarningShown);
+        Assert.IsTrue(loaded.Current.LastUpdateWarningShown >= before);
     }
 
     // --- UpdatePreRelease setting ---
 
-    [Fact]
+    [TestMethod]
     public void UpdatePreRelease_DefaultsToFalse()
     {
-        Assert.False(_settings.Current.UpdatePreRelease);
+        Assert.IsFalse(_settings.Current.UpdatePreRelease);
     }
 
-    [Fact]
+    [TestMethod]
     public void UpdatePreRelease_IsPersisted()
     {
         _settings.Current.UpdatePreRelease = true;
@@ -135,44 +139,44 @@ public sealed class UpdateServiceTests : IDisposable
         var loaded = new SettingsService(NullLogger<SettingsService>.Instance, _tempFile);
         loaded.Load();
 
-        Assert.True(loaded.Current.UpdatePreRelease);
+        Assert.IsTrue(loaded.Current.UpdatePreRelease);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CheckAsync_WhenPreReleaseEnabled_ProceedsToCheck()
     {
         _settings.Current.UpdateCheckEnabled = true;
         _settings.Current.UpdatePreRelease = true;
 
-        Assert.True(await new FakeUpdateService(_settings, hasUpdate: true).CheckAsync());
+        Assert.IsTrue(await new FakeUpdateService(_settings, hasUpdate: true).CheckAsync());
     }
 
     // --- TryAppcastFallbackAsync (internal — tests CheckAppcastAsync + result wiring) ---
 
-    [Fact]
+    [TestMethod]
     public async Task TryAppcastFallbackAsync_WhenFeedReturnsNewerVersion_ReturnsTrueAndSetsUrl()
     {
         var svc = CreateService(httpGet: _ => Task.FromResult(AppcastXml("999.0.0")));
 
         var result = await svc.TryAppcastFallbackAsync();
 
-        Assert.True(result);
-        Assert.True(svc.IsGitHubFallbackUpdate);
-        Assert.Equal("https://github.com/qdraw/starsky/releases/tag/v999.0.0", svc.PendingGitHubReleaseUrl);
+        Assert.IsTrue(result);
+        Assert.IsTrue(svc.IsGitHubFallbackUpdate);
+        Assert.AreEqual("https://github.com/qdraw/starsky/releases/tag/v999.0.0", svc.PendingGitHubReleaseUrl);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TryAppcastFallbackAsync_WhenFeedReturnsOlderVersion_ReturnsFalse()
     {
         var svc = CreateService(httpGet: _ => Task.FromResult(AppcastXml("0.0.0")));
 
         var result = await svc.TryAppcastFallbackAsync();
 
-        Assert.False(result);
-        Assert.Null(svc.PendingGitHubReleaseUrl);
+        Assert.IsFalse(result);
+        Assert.IsNull(svc.PendingGitHubReleaseUrl);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TryAppcastFallbackAsync_WhenPreReleaseEnabled_PassesQueryParam()
     {
         _settings.Current.UpdatePreRelease = true;
@@ -185,11 +189,11 @@ public sealed class UpdateServiceTests : IDisposable
 
         await svc.TryAppcastFallbackAsync();
 
-        Assert.NotNull(capturedUrl);
-        Assert.Contains("?pre-release=1", capturedUrl);
+        Assert.IsNotNull(capturedUrl);
+        Assert.IsTrue(capturedUrl.Contains("?pre-release=1"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TryAppcastFallbackAsync_WhenPreReleaseDisabled_OmitsQueryParam()
     {
         _settings.Current.UpdatePreRelease = false;
@@ -202,16 +206,18 @@ public sealed class UpdateServiceTests : IDisposable
 
         await svc.TryAppcastFallbackAsync();
 
-        Assert.NotNull(capturedUrl);
-        Assert.DoesNotContain("?pre-release=1", capturedUrl);
+        Assert.IsNotNull(capturedUrl);
+        Assert.IsFalse(capturedUrl.Contains("?pre-release=1"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TryAppcastFallbackAsync_WhenHttpThrows_PropagatesException()
     {
         var svc = CreateService(httpGet: _ => Task.FromException<string>(new HttpRequestException("network error")));
 
-        await Assert.ThrowsAsync<HttpRequestException>(() => svc.TryAppcastFallbackAsync());
+        Exception? caught = null;
+        try { await svc.TryAppcastFallbackAsync(); } catch (HttpRequestException e) { caught = e; }
+        Assert.IsInstanceOfType<HttpRequestException>(caught);
     }
 
     public void Dispose()

--- a/windows/starsky.Tests/Services/UpdateServiceTests.cs
+++ b/windows/starsky.Tests/Services/UpdateServiceTests.cs
@@ -190,7 +190,7 @@ public sealed class UpdateServiceTests : IDisposable
         await svc.TryAppcastFallbackAsync();
 
         Assert.IsNotNull(capturedUrl);
-        Assert.IsTrue(capturedUrl.Contains("?pre-release=1"));
+        Assert.Contains("?pre-release=1", capturedUrl!);
     }
 
     [TestMethod]
@@ -207,7 +207,7 @@ public sealed class UpdateServiceTests : IDisposable
         await svc.TryAppcastFallbackAsync();
 
         Assert.IsNotNull(capturedUrl);
-        Assert.IsFalse(capturedUrl.Contains("?pre-release=1"));
+        Assert.DoesNotContain("?pre-release=1", capturedUrl!);
     }
 
     [TestMethod]

--- a/windows/starsky.Tests/Services/WindowManagerTests.cs
+++ b/windows/starsky.Tests/Services/WindowManagerTests.cs
@@ -4,6 +4,7 @@ using Starsky.Desktop.Services;
 
 namespace starsky.Tests.Services;
 
+[TestClass]
 public class WindowManagerTests
 {
     private static WindowManager CreateManager()
@@ -19,31 +20,34 @@ public class WindowManagerTests
             updateService, NullLogger<WindowManager>.Instance);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetLocalPort_DoesNotThrow()
     {
         var wm = CreateManager();
-        var ex = Record.Exception(() => wm.SetLocalPort(9999));
-        Assert.Null(ex);
+        Exception? ex = null;
+        try { wm.SetLocalPort(9999); } catch (Exception e) { ex = e; }
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void CloseAll_WithNoWindows_DoesNotThrow()
     {
         var wm = CreateManager();
-        var ex = Record.Exception(wm.CloseAll);
-        Assert.Null(ex);
+        Exception? ex = null;
+        try { wm.CloseAll(); } catch (Exception e) { ex = e; }
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void ReloadAll_WithNoWindows_DoesNotThrow()
     {
         var wm = CreateManager();
-        var ex = Record.Exception(wm.ReloadAll);
-        Assert.Null(ex);
+        Exception? ex = null;
+        try { wm.ReloadAll(); } catch (Exception e) { ex = e; }
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void MainWindowOptions_Properties_AreAccessible()
     {
         var settings = new SettingsService(NullLogger<SettingsService>.Instance);
@@ -73,111 +77,111 @@ public class WindowManagerTests
             WindowIndex = 3
         };
 
-        Assert.Same(settings, opts.Settings);
-        Assert.Same(routes, opts.Routes);
-        Assert.Same(webViewEnv, opts.WebViewEnv);
-        Assert.Same(fileDownload, opts.FileDownload);
-        Assert.Same(wm, opts.WindowManager);
-        Assert.Equal("http://localhost:5000", opts.BaseUrl);
-        Assert.Equal("?f=/photos", opts.InitialRoute);
-        Assert.Same(geometry, opts.Geometry);
-        Assert.Equal(3, opts.WindowIndex);
+        Assert.AreSame(settings, opts.Settings);
+        Assert.AreSame(routes, opts.Routes);
+        Assert.AreSame(webViewEnv, opts.WebViewEnv);
+        Assert.AreSame(fileDownload, opts.FileDownload);
+        Assert.AreSame(wm, opts.WindowManager);
+        Assert.AreEqual("http://localhost:5000", opts.BaseUrl);
+        Assert.AreEqual("?f=/photos", opts.InitialRoute);
+        Assert.AreSame(geometry, opts.Geometry);
+        Assert.AreEqual(3, opts.WindowIndex);
     }
 
     private static SavedWindowState OnScreen(double left = 200, double top = 200,
         double width = 1200, double height = 800, bool maximized = false) =>
         new() { Left = left, Top = top, Width = width, Height = height, IsMaximized = maximized };
 
-    [Fact]
+    [TestMethod]
     public void IsOnScreen_NormalWindowOnScreen_ReturnsTrue()
     {
-        Assert.True(WindowManager.IsOnScreen(OnScreen()));
+        Assert.IsTrue(WindowManager.IsOnScreen(OnScreen()));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsOnScreen_Maximized_AlwaysReturnsTrue()
     {
         // Maximized windows may have any stored position; WPF snaps to nearest screen.
         var offscreen = OnScreen(left: -99999, top: -99999, maximized: true);
-        Assert.True(WindowManager.IsOnScreen(offscreen));
+        Assert.IsTrue(WindowManager.IsOnScreen(offscreen));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsOnScreen_WindowFarOffLeftEdge_ReturnsFalse()
     {
         var state = OnScreen(left: -5000, top: 200);
-        Assert.False(WindowManager.IsOnScreen(state));
+        Assert.IsFalse(WindowManager.IsOnScreen(state));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsOnScreen_WindowFarOffRightEdge_ReturnsFalse()
     {
         var state = OnScreen(left: 999_999, top: 200);
-        Assert.False(WindowManager.IsOnScreen(state));
+        Assert.IsFalse(WindowManager.IsOnScreen(state));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsOnScreen_WindowFarAboveTopEdge_ReturnsFalse()
     {
         var state = OnScreen(left: 200, top: -5000);
-        Assert.False(WindowManager.IsOnScreen(state));
+        Assert.IsFalse(WindowManager.IsOnScreen(state));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsOnScreen_WindowFarBelowBottomEdge_ReturnsFalse()
     {
         var state = OnScreen(left: 200, top: 999_999);
-        Assert.False(WindowManager.IsOnScreen(state));
+        Assert.IsFalse(WindowManager.IsOnScreen(state));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsOnScreen_TooNarrow_ReturnsFalse()
     {
         var state = OnScreen(left: 200, top: 200, width: 50, height: 800);
-        Assert.False(WindowManager.IsOnScreen(state));
+        Assert.IsFalse(WindowManager.IsOnScreen(state));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsOnScreen_TooShort_ReturnsFalse()
     {
         var state = OnScreen(left: 200, top: 200, width: 1200, height: 50);
-        Assert.False(WindowManager.IsOnScreen(state));
+        Assert.IsFalse(WindowManager.IsOnScreen(state));
     }
 
     // ── ResolveGeometry ───────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void ResolveGeometry_NullGeometry_ReturnsDefaultState()
     {
         var result = WindowManager.ResolveGeometry(null, 0);
 
-        Assert.Equal(100, result.Left);
-        Assert.Equal(100, result.Top);
-        Assert.Equal(1200, result.Width);
-        Assert.Equal(800, result.Height);
-        Assert.Equal("?f=/", result.Route);
+        Assert.AreEqual(100, result.Left);
+        Assert.AreEqual(100, result.Top);
+        Assert.AreEqual(1200, result.Width);
+        Assert.AreEqual(800, result.Height);
+        Assert.AreEqual("?f=/", result.Route);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveGeometry_NullGeometry_WithOffset_AppliesOffset()
     {
         var result = WindowManager.ResolveGeometry(null, 48);
 
-        Assert.Equal(148, result.Left);
-        Assert.Equal(148, result.Top);
+        Assert.AreEqual(148, result.Left);
+        Assert.AreEqual(148, result.Top);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveGeometry_OnScreenGeometry_ReturnsOriginal()
     {
         var geometry = OnScreen(left: 200, top: 200, width: 1200, height: 800);
 
         var result = WindowManager.ResolveGeometry(geometry, 0);
 
-        Assert.Same(geometry, result);
+        Assert.AreSame(geometry, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveGeometry_OffScreenGeometry_ReturnsDefaultWithRoutePreserved()
     {
         var geometry = new SavedWindowState
@@ -191,15 +195,15 @@ public class WindowManagerTests
 
         var result = WindowManager.ResolveGeometry(geometry, 0);
 
-        Assert.Equal("?f=/photos", result.Route);
-        Assert.Equal(100, result.Left);
+        Assert.AreEqual("?f=/photos", result.Route);
+        Assert.AreEqual(100, result.Left);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResolveGeometry_NullGeometry_RouteIsDefault()
     {
         var result = WindowManager.ResolveGeometry(null, 0);
 
-        Assert.Equal("?f=/", result.Route);
+        Assert.AreEqual("?f=/", result.Route);
     }
 }

--- a/windows/starsky.Tests/starsky.Tests.csproj
+++ b/windows/starsky.Tests/starsky.Tests.csproj
@@ -8,11 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/windows/starsky.Tests/starsky.Tests.csproj
+++ b/windows/starsky.Tests/starsky.Tests.csproj
@@ -5,11 +5,14 @@
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
     <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request updates the test projects to use MSTest instead of xUnit, and refactors all test assertions and attributes accordingly. It also updates the global usings and makes minor improvements to assertion style and error handling in the tests.

Test framework migration and assertion updates:

* Migrated all test classes from xUnit (`[Fact]`, `Assert.Equal`, etc.) to MSTest (`[TestClass]`, `[TestMethod]`, `Assert.AreEqual`, etc.), including updating assertion methods and test attributes in files such as `DesktopSettingsTests.cs`, `AppcastCheckerTests.cs`, `ApplicationPathsTests.cs`, and `BackendServiceTests.cs`. [[1]](diffhunk://#diff-b1f19bf435a803c7783c8bbc3e9eaf32e3f34f5ee69df48ba075ea3c5e64b290R5-R19) [[2]](diffhunk://#diff-b1f19bf435a803c7783c8bbc3e9eaf32e3f34f5ee69df48ba075ea3c5e64b290L36-R44) [[3]](diffhunk://#diff-c82942fdbd99d160f4dbd08d2607da6511b7166818d384f57f51f6429ca514fbR5) [[4]](diffhunk://#diff-c82942fdbd99d160f4dbd08d2607da6511b7166818d384f57f51f6429ca514fbL27-R60) [[5]](diffhunk://#diff-c82942fdbd99d160f4dbd08d2607da6511b7166818d384f57f51f6429ca514fbL75-R91) [[6]](diffhunk://#diff-c82942fdbd99d160f4dbd08d2607da6511b7166818d384f57f51f6429ca514fbL100-R131) [[7]](diffhunk://#diff-c82942fdbd99d160f4dbd08d2607da6511b7166818d384f57f51f6429ca514fbL146-R159) [[8]](diffhunk://#diff-b5ffd7b0279634b023efb1a52c3f846a37caeaab9cfea7e3f800cc9c92caff6aR6-R88) [[9]](diffhunk://#diff-372b1b184ab5c91a7a27d9cfc1ba83458ff491ce5422983cb056fbf998bfec97R9-R51) [[10]](diffhunk://#diff-372b1b184ab5c91a7a27d9cfc1ba83458ff491ce5422983cb056fbf998bfec97L59-R69) [[11]](diffhunk://#diff-372b1b184ab5c91a7a27d9cfc1ba83458ff491ce5422983cb056fbf998bfec97L79-R89) [[12]](diffhunk://#diff-372b1b184ab5c91a7a27d9cfc1ba83458ff491ce5422983cb056fbf998bfec97L99-R133) [[13]](diffhunk://#diff-372b1b184ab5c91a7a27d9cfc1ba83458ff491ce5422983cb056fbf998bfec97L142-R182)

* Updated assertion style in various tests to use MSTest's assertion methods, such as `Assert.IsNull`, `Assert.IsTrue`, `Assert.IsInstanceOfType`, and `CollectionAssert.Contains`, and replaced xUnit-specific helpers like `Record.Exception` with try/catch blocks. [[1]](diffhunk://#diff-372b1b184ab5c91a7a27d9cfc1ba83458ff491ce5422983cb056fbf998bfec97R9-R51) [[2]](diffhunk://#diff-372b1b184ab5c91a7a27d9cfc1ba83458ff491ce5422983cb056fbf998bfec97L59-R69) [[3]](diffhunk://#diff-372b1b184ab5c91a7a27d9cfc1ba83458ff491ce5422983cb056fbf998bfec97L79-R89) [[4]](diffhunk://#diff-372b1b184ab5c91a7a27d9cfc1ba83458ff491ce5422983cb056fbf998bfec97L99-R133) [[5]](diffhunk://#diff-372b1b184ab5c91a7a27d9cfc1ba83458ff491ce5422983cb056fbf998bfec97L142-R182) [[6]](diffhunk://#diff-b5ffd7b0279634b023efb1a52c3f846a37caeaab9cfea7e3f800cc9c92caff6aR6-R88)

Test infrastructure and global usings:

* Replaced `global using Xunit;` with `global using Microsoft.VisualStudio.TestTools.UnitTesting;` and added `System.Text.RegularExpressions` to the global usings.

* Removed an unused `using System.Net;` statement from `BackendServiceTests.cs`.

These changes ensure consistency across the test suite and align the project with MSTest as the unit testing framework.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
