### PR TITLE
Add MountWatcher for Windows

### DIFF
--- a/documentation/docs/features/import/mountwatchercli.md
+++ b/documentation/docs/features/import/mountwatchercli.md
@@ -42,6 +42,21 @@ Additional flags:
 - Linux: systemd service install/uninstall flow (with user-level fallback).
 - Windows: Windows Service install/uninstall flow via `sc.exe`.
 
+## Windows Desktop App integration
+
+On the **Windows desktop app** (WPF), MountWatcher can be toggled without using the CLI directly:
+
+1. Open the app menu: **Settings → Mount Watcher**
+2. Click **Enable Mount Watcher (requires admin)**
+3. A Windows UAC consent prompt appears — approve it to install the service
+4. The submenu shows **Status: Running** once the service is active
+
+To stop and remove the service, open the same submenu and click **Disable Mount Watcher** (another UAC prompt appears).
+
+The preference is stored in `%AppData%\starsky\settings.json` (`MountWatcherEnabled`). When the app starts and the preference is enabled, it automatically reinstalls and starts the service. If installation fails (for example the binary is missing), the preference is cleared automatically so the app does not retry on every launch.
+
+> **Note:** The app itself does not run elevated. Only the `starskymountwatchercli.exe` sub-process is elevated for the duration of the `sc.exe create` or `sc.exe delete` call.
+
 ## Typical workflow
 
 1. Install and start the service.

--- a/documentation/docs/getting-started/desktop/desktop-windows.md
+++ b/documentation/docs/getting-started/desktop/desktop-windows.md
@@ -45,6 +45,26 @@ The Windows app supports two modes, switchable in Settings:
 
 The app checks for updates on startup and will prompt you when a new version is available. You can postpone the update; the check is suppressed for 4 days after dismissing a prompt. Update checking can be disabled in Settings.
 
+## Mount Watcher
+
+Mount Watcher is an optional background Windows Service that watches for connected camera storage (SD cards, USB cameras) and triggers an automatic import when one is detected.
+
+**To enable:**
+
+1. Open the **Settings** menu in the menu bar
+2. Hover over **Mount Watcher**
+3. Click **Enable Mount Watcher (requires admin)**
+4. Approve the Windows UAC consent dialog that appears
+5. The submenu updates to show **Status: Running**
+
+**To disable:** open the same submenu and click **Disable Mount Watcher** (another UAC dialog appears).
+
+The preference is saved to `%AppData%\starsky\settings.json`. When the app starts and Mount Watcher is enabled, it automatically reinstalls and starts the service — no UAC prompt on startup. If the service cannot be installed (for example the bundled binary is missing), the preference is cleared automatically.
+
+> The app itself does not run with elevated privileges. Only the `starskymountwatchercli.exe` sub-process is elevated for the duration of service registration.
+
+See [Mount Watcher CLI](../../features/import/mountwatchercli.md) for details on what the service does and how camera detection works.
+
 ## Advanced: custom installation directory
 
 By default the installer places the application in `%LocalAppData%\Starsky.Desktop`. To install to a different location, run the setup from the command line with the `--installto` flag:

--- a/history.md
+++ b/history.md
@@ -44,8 +44,9 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 _Note: Windows Desktop: Uninstall versions below 0.8.2 before updating._
 
+- [x] (Added) _App_ Windows: Add menu option to install MountWatcher (PR #3309)
 - [x] (Changed) _App_ macOS & Windows: Ctrl + W & Command + W Close window (PR #3308)
-- [x] (Changed) _App_ macOS: Add menu options to install MountWatcher (PR #3308)
+- [x] (Added) _App_ macOS: Add menu option to install MountWatcher (PR #3308)
 - [x] (Fixed) _Back-end_ Retry logic in the QueryGetAllRecursiveAsync (PR #3305)
 - [x] (Changed) _App_ Windows: Use Microsoft Testing Platform instead of vstest (PR #3300)
 - [x] (Changed) _Back-end_ Use Microsoft Testing Platform instead of vstest (PR #3297)

--- a/windows/App.xaml.cs
+++ b/windows/App.xaml.cs
@@ -41,7 +41,7 @@ public partial class App : Application
         // 4. Initialize services
         _backend = new BackendService(logFactory.CreateLogger<BackendService>());
         _watcher = new FileWatcherService(logFactory.CreateLogger<FileWatcherService>());
-        var mountWatcherService = new MountWatcherService();
+        var mountWatcherService = new MountWatcherService(logFactory.CreateLogger<MountWatcherService>());
         _mountWatcherLifecycle = new MountWatcherLifecycle(
             mountWatcherService, settingsService, logFactory.CreateLogger<MountWatcherLifecycle>());
         var webViewEnv = new WebViewEnvironmentService();

--- a/windows/App.xaml.cs
+++ b/windows/App.xaml.cs
@@ -14,6 +14,7 @@ public partial class App : Application
     private BackendService? _backend;
     private FileWatcherService? _watcher;
     private WindowManager? _windowManager;
+    private MountWatcherLifecycle? _mountWatcherLifecycle;
     private int _localPort;
 
     protected override async void OnStartup(StartupEventArgs e)
@@ -40,15 +41,19 @@ public partial class App : Application
         // 4. Initialize services
         _backend = new BackendService(logFactory.CreateLogger<BackendService>());
         _watcher = new FileWatcherService(logFactory.CreateLogger<FileWatcherService>());
+        var mountWatcherService = new MountWatcherService();
+        _mountWatcherLifecycle = new MountWatcherLifecycle(
+            mountWatcherService, settingsService, logFactory.CreateLogger<MountWatcherLifecycle>());
         var webViewEnv = new WebViewEnvironmentService();
         var navigation = new NavigationService(settingsService);
         var routes = new RoutePersistenceService(settingsService);
         var fileDownload = new FileDownloadService(logFactory.CreateLogger<FileDownloadService>());
-        var updateService = new UpdateService(settingsService, logFactory.CreateLogger<UpdateService>());
+        var updateService = new UpdateService(settingsService, logFactory.CreateLogger<UpdateService>(),
+            mountWatcherService: mountWatcherService);
 
         _windowManager = new WindowManager(
             settingsService, routes, navigation, webViewEnv, fileDownload, _watcher,
-            updateService, logFactory.CreateLogger<WindowManager>());
+            updateService, logFactory.CreateLogger<WindowManager>(), mountWatcherService);
 
         // 5. Show splash
         var splash = new SplashWindow();
@@ -95,6 +100,9 @@ public partial class App : Application
             // 7. Start file watcher
             _watcher.Start();
 
+            // 7a. Enable MountWatcher if configured
+            await _mountWatcherLifecycle.OnStartupAsync();
+
             // 8. Restore windows
             splash.UpdateStatus("Opening Starsky…");
             _windowManager.RestoreWindows();
@@ -137,6 +145,7 @@ public partial class App : Application
     protected override async void OnExit(ExitEventArgs e)
     {
         _logger?.LogInformation("Starsky Desktop shutting down");
+        _mountWatcherLifecycle?.OnShutdown();
         _watcher?.Stop();
         _windowManager?.CloseAll();
         if (_backend != null)

--- a/windows/Models/DesktopSettings.cs
+++ b/windows/Models/DesktopSettings.cs
@@ -8,4 +8,5 @@ public class DesktopSettings
     public bool UpdatePreRelease { get; set; } = false;
     public DateTime? LastUpdateWarningShown { get; set; }
     public List<SavedWindowState> Windows { get; set; } = [];
+    public bool MountWatcherEnabled { get; set; } = false;
 }

--- a/windows/Models/MainWindowOptions.cs
+++ b/windows/Models/MainWindowOptions.cs
@@ -17,4 +17,5 @@ public sealed record MainWindowOptions
     public required SavedWindowState Geometry { get; init; }
     public required int WindowIndex { get; init; }
     public required UpdateService UpdateService { get; init; }
+    public IMountWatcherService? MountWatcherService { get; init; }
 }

--- a/windows/SPEC.md
+++ b/windows/SPEC.md
@@ -90,6 +90,9 @@ Program.Main()
        │    [Remote]  Validate RemoteBaseUrl is set (else ErrorWindow + Shutdown)
        │
        ├─ 7. FileWatcherService.Start()
+       ├─ 7a. MountWatcherLifecycle.OnStartupAsync()
+       │       → if MountWatcherEnabled: starskymountwatchercli.exe --install (elevated)
+       │       → on failure: clear MountWatcherEnabled + save settings
        ├─ 8. WindowManager.RestoreWindows()
        ├─ 9. SplashWindow.Close()
        │
@@ -99,9 +102,10 @@ Program.Main()
 
 ### Shutdown Sequence (`App.OnExit`)
 
-1. `FileWatcherService.Stop()`
-2. `WindowManager.CloseAll()`
-3. `BackendService.StopAsync()` — kills the backend process, waits up to 5 seconds
+1. `MountWatcherLifecycle.OnShutdown()` — if `MountWatcherEnabled`: runs `starskymountwatchercli.exe --uninstall` synchronously (elevated) so the binary is not locked when Velopack replaces files
+2. `FileWatcherService.Stop()`
+3. `WindowManager.CloseAll()`
+4. `BackendService.StopAsync()` — kills the backend process, waits up to 5 seconds
 
 ---
 
@@ -138,6 +142,7 @@ Default size: **1200×800**. Position: saved and restored per window index.
 | File | Edit File in Editor | Ctrl+E | Local: forward keystroke to web app; Remote: download file + open locally |
 | Settings | Connection Settings… | — | Open SettingsWindow |
 | Settings | Application Settings | Ctrl+Shift+K | Inject `Ctrl+Shift+K` keyboard event into web app |
+| Settings → Mount Watcher | Enable / Disable Mount Watcher | — | Toggle MountWatcher Windows Service (UAC elevation required); shows current status when submenu is open |
 | View | Developer Tools | F12 | Open WebView2 DevTools window |
 | View | Open in Browser | — | Open current URL in default system browser |
 | Help | Documentation | — | Open `https://qdraw.nl/special/starsky/docs/` in system browser |
@@ -185,6 +190,8 @@ Fixed 380×480, not resizable, centered on owner. Contains:
 | **Server URL** text box | Editable only in Remote mode |
 | **Save URL** button | Calls `RemoteUrlValidator.ValidateAsync(url)` → if valid, saves URL and calls `ReopenAll()`; shows green "Setting is saved" or red error message |
 | **Check for updates** checkbox | Toggles `UpdateCheckEnabled` in settings; saved immediately |
+
+MountWatcher enable/disable is accessed from **Settings → Mount Watcher** in the main menu bar (not from SettingsWindow).
 
 ### 5.4 ErrorWindow
 
@@ -337,7 +344,31 @@ Manages the collection of open `MainWindow` instances.
 
 When the last window closes, `Application.Current.Shutdown()` is called.
 
-### 6.12 DailyFileLoggerProvider / DailyFileLogger
+### 6.13 MountWatcherService
+
+Optional integration with the `starskymountwatchercli.exe` binary bundled in `runtime-starsky-win-x64\`.
+
+| Method | Behaviour |
+|---|---|
+| `EnableAsync()` | Returns `false` immediately if the binary is missing; otherwise calls `RunElevatedAsync("--install")` via `IProcessRunner.RunElevated` — triggers a UAC elevation prompt; returns `true` on exit code 0 |
+| `DisableAsync()` | Same flow with `--uninstall`; if binary is missing, succeeds only when `GetStatus()` returns `NotInstalled` |
+| `GetStatus()` | Runs `sc.exe query starsky-mountwatcher` via `IProcessRunner.Run`; exit code ≠ 0 → `NotInstalled`; output contains "RUNNING" → `Running`; otherwise → `Stopped`; exception → `Unknown` |
+| `StopSync()` | Synchronous uninstall call; used on app shutdown and before Velopack update so the binary is not file-locked during replacement; no-op when binary is missing |
+
+`IProcessRunner` is the seam for unit testing — `WindowsProcessRunner` wraps real `Process.Start` calls; `FakeProcessRunner` is used in tests.
+
+The service name is always `starsky-mountwatcher` regardless of build configuration, because the CLI binary in the runtime directory is always a Release build.
+
+### 6.14 MountWatcherLifecycle
+
+Encapsulates startup/shutdown logic for MountWatcher so it can be tested independently of the WPF `Application` class.
+
+| Method | Behaviour |
+|---|---|
+| `OnStartupAsync()` | No-op when `MountWatcherEnabled = false`; calls `EnableAsync()`; on failure: clears `MountWatcherEnabled` and saves settings so the app does not retry on every start with a broken or missing binary |
+| `OnShutdown()` | No-op when `MountWatcherEnabled = false`; calls `StopSync()` synchronously |
+
+### 6.15 DailyFileLoggerProvider / DailyFileLogger
 
 Custom `ILoggerProvider` that writes log lines to date-stamped files:  
 `%AppData%\starsky\logs\starsky-{yyyy-MM-dd}.log`
@@ -362,6 +393,7 @@ Persisted to `%AppData%\starsky\settings.json` as indented JSON.
 | `UpdateCheckEnabled` | `bool` | `true` | Whether to check for updates on startup |
 | `LastUpdateWarningShown` | `DateTime?` | `null` | UTC timestamp of last update prompt (suppression window) |
 | `Windows` | `List<SavedWindowState>` | `[]` | Per-window route + geometry state |
+| `MountWatcherEnabled` | `bool` | `false` | Whether MountWatcher Windows Service should be started on app launch |
 
 ### 7.2 SavedWindowState
 
@@ -416,6 +448,7 @@ starsky-win-x64-desktop.exe --installto "D:\Apps\Starsky"
 | `%AppData%\starsky\thumbnailTempFolder\` | Thumbnail cache |
 | `%LocalAppData%\starsky\tempFolder\` | Downloaded files (file-download feature) |
 | `<exe dir>\runtime-starsky-win-x64\starsky.exe` | Bundled ASP.NET Core backend |
+| `<exe dir>\runtime-starsky-win-x64\starskymountwatchercli.exe` | MountWatcher CLI (install/uninstall Windows Service) |
 
 ---
 
@@ -455,8 +488,8 @@ dotnet publish windows/Starsky.Desktop.csproj -c Release -r win-x64 --self-conta
 ## 10. Test Suite
 
 **Project:** `windows/starsky.Tests/starsky.Tests.csproj`  
-**Framework:** xUnit 2.9.2, `net10.0-windows`, `UseWPF=true`  
-**Total:** 52 tests, all passing
+**Framework:** MSTest 4.4.0, `net10.0-windows`, `UseWPF=true`  
+**Total:** 179 tests, all passing
 
 ### Test Infrastructure
 
@@ -477,6 +510,7 @@ dotnet publish windows/Starsky.Desktop.csproj -c Release -r win-x64 --self-conta
 | `RoutePersistenceServiceTests` | 6 | Empty list; save entry; save with geometry; list expansion with blanks; remove entry; clear all |
 | `SettingsServiceTests` | 4 | Missing file (defaults); valid JSON; corrupt JSON (defaults); save-then-load round-trip |
 | `UpdateServiceTests` | 4 | `UpdateCheckEnabled = false`; recent warning suppresses; `RecordWarningShown` persists timestamp; `ApplyUpdateAsync` throws without pending update |
+| `MountWatcherServiceTests` | 33 | `DesktopSettings.MountWatcherEnabled` default and JSON round-trip; `MountWatcherService` enable/disable/status/stop branches via `FakeProcessRunner`; `MountWatcherLifecycle` startup (skip, call, keep, clear, persist) and shutdown; `UpdateService.ApplyUpdateAsync` calls `StopSync` before applying |
 
 ### Running Tests
 
@@ -538,6 +572,7 @@ Triggered on version tag pushes. Builds and publishes the desktop release binari
 | External navigation | `NavigationStarting` cancels non-allowlisted navigations and redirects to system browser |
 | External new-window | `NewWindowRequested` intercepts `target="_blank"`; only allowed origins open in-app |
 | Local backend auth bypass | `app__NoAccountLocalhost=true` — only safe because the backend binds to `127.0.0.1`; no remote access |
+| MountWatcher elevation | Enable/disable triggers a UAC consent prompt via `ProcessStartInfo.Verb = "runas"`; the WPF app itself does **not** run elevated; only the CLI sub-process is elevated for the duration of `sc.exe create/delete` |
 | Remote URL validation | Scheme must be `http`/`https`; server must respond to `/api/health` |
 | Credential storage | No credentials stored; Remote mode relies on the web app's own cookie-based session |
 | Update integrity | Velopack validates packages via signatures from GitHub Releases |

--- a/windows/Services/IMountWatcherService.cs
+++ b/windows/Services/IMountWatcherService.cs
@@ -1,0 +1,11 @@
+namespace Starsky.Desktop.Services;
+
+public enum MountWatcherStatus { Running, Stopped, NotInstalled, Unknown }
+
+public interface IMountWatcherService
+{
+    Task<bool> EnableAsync();
+    Task<bool> DisableAsync();
+    MountWatcherStatus GetStatus();
+    void StopSync();
+}

--- a/windows/Services/IProcessRunner.cs
+++ b/windows/Services/IProcessRunner.cs
@@ -1,0 +1,9 @@
+namespace Starsky.Desktop.Services;
+
+internal record ProcessResult(int ExitCode, string Output);
+
+internal interface IProcessRunner
+{
+    ProcessResult Run(string fileName, string args);
+    ProcessResult RunElevated(string fileName, string args);
+}

--- a/windows/Services/MountWatcherLifecycle.cs
+++ b/windows/Services/MountWatcherLifecycle.cs
@@ -30,7 +30,16 @@ internal class MountWatcherLifecycle(
             return;
         }
 
-        logger.LogWarning("MountWatcher enable failed on startup; clearing preference");
+        // --install exits non-zero when the service is already registered (sc.exe 1073).
+        // Only clear the preference when the service is genuinely absent.
+        var status = mountWatcherService.GetStatus();
+        if (status is MountWatcherStatus.Running or MountWatcherStatus.Stopped)
+        {
+            logger.LogInformation("MountWatcher enable failed but service is {Status}; keeping preference", status);
+            return;
+        }
+
+        logger.LogWarning("MountWatcher enable failed and service is absent; clearing preference");
         settingsService.Current.MountWatcherEnabled = false;
         settingsService.Save();
     }

--- a/windows/Services/MountWatcherLifecycle.cs
+++ b/windows/Services/MountWatcherLifecycle.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging;
+
+namespace Starsky.Desktop.Services;
+
+/// <summary>
+/// Encapsulates the startup/shutdown lifecycle of MountWatcher so it can be unit-tested
+/// independently of the WPF Application class.
+/// </summary>
+internal class MountWatcherLifecycle(
+    IMountWatcherService mountWatcherService,
+    SettingsService settingsService,
+    ILogger<MountWatcherLifecycle> logger)
+{
+    /// <summary>
+    /// Called during app startup. Enables the service when the preference is set,
+    /// and clears the preference when enable fails so the app does not retry on
+    /// every start with a broken binary.
+    /// </summary>
+    internal async Task OnStartupAsync()
+    {
+        if (!settingsService.Current.MountWatcherEnabled)
+            return;
+
+        var ok = await mountWatcherService.EnableAsync();
+        if (ok)
+        {
+            logger.LogInformation("MountWatcher enabled on startup");
+            return;
+        }
+
+        logger.LogWarning("MountWatcher enable failed on startup; clearing preference");
+        settingsService.Current.MountWatcherEnabled = false;
+        settingsService.Save();
+    }
+
+    /// <summary>
+    /// Called during app shutdown (or before a Velopack update restarts the app).
+    /// Stops the service synchronously so the binary is not locked when files are replaced.
+    /// </summary>
+    internal void OnShutdown()
+    {
+        if (!settingsService.Current.MountWatcherEnabled)
+            return;
+
+        logger.LogInformation("Stopping MountWatcher on shutdown");
+        mountWatcherService.StopSync();
+    }
+}

--- a/windows/Services/MountWatcherLifecycle.cs
+++ b/windows/Services/MountWatcherLifecycle.cs
@@ -19,7 +19,9 @@ internal class MountWatcherLifecycle(
     internal async Task OnStartupAsync()
     {
         if (!settingsService.Current.MountWatcherEnabled)
-            return;
+        {
+	        return;
+        }
 
         var ok = await mountWatcherService.EnableAsync();
         if (ok)
@@ -40,7 +42,9 @@ internal class MountWatcherLifecycle(
     internal void OnShutdown()
     {
         if (!settingsService.Current.MountWatcherEnabled)
-            return;
+        {
+	        return;
+        }
 
         logger.LogInformation("Stopping MountWatcher on shutdown");
         mountWatcherService.StopSync();

--- a/windows/Services/MountWatcherService.cs
+++ b/windows/Services/MountWatcherService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -5,14 +6,15 @@ namespace Starsky.Desktop.Services;
 
 public class MountWatcherService : IMountWatcherService
 {
-    // The CLI binary in the runtime directory is always a Release build,
-    // so it always registers the service under the production name.
-    internal const string ServiceName = "starsky-mountwatcher";
+    // Windows services use the reverse-DNS name from WatchServiceName.GetReverseDnsName().
+    // The Linux systemd name ("starsky-mountwatcher") is different — do not use it here.
+    internal static readonly string ServiceName = "nl.qdraw.mountwatcher";
 
     private readonly string _cliBinaryPath;
     private readonly ILogger<MountWatcherService> _logger;
     private readonly IProcessRunner _runner;
 
+    [ExcludeFromCodeCoverage]
     public MountWatcherService(ILogger<MountWatcherService> logger)
         : this(Path.Combine(ApplicationPaths.RuntimeDir, "starskymountwatchercli.exe"),
                logger,

--- a/windows/Services/MountWatcherService.cs
+++ b/windows/Services/MountWatcherService.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -12,14 +11,21 @@ public class MountWatcherService : IMountWatcherService
 
     private readonly string _cliBinaryPath;
     private readonly ILogger<MountWatcherService> _logger;
+    private readonly IProcessRunner _runner;
 
     public MountWatcherService(ILogger<MountWatcherService> logger)
-        : this(Path.Combine(ApplicationPaths.RuntimeDir, "starskymountwatchercli.exe"), logger) { }
+        : this(Path.Combine(ApplicationPaths.RuntimeDir, "starskymountwatchercli.exe"),
+               logger,
+               new WindowsProcessRunner()) { }
 
-    internal MountWatcherService(string cliBinaryPath, ILogger<MountWatcherService>? logger = null)
+    internal MountWatcherService(
+        string cliBinaryPath,
+        ILogger<MountWatcherService>? logger = null,
+        IProcessRunner? runner = null)
     {
         _cliBinaryPath = cliBinaryPath;
         _logger = logger ?? NullLoggerFactory.Instance.CreateLogger<MountWatcherService>();
+        _runner = runner ?? new WindowsProcessRunner();
     }
 
     public async Task<bool> EnableAsync()
@@ -71,29 +77,17 @@ public class MountWatcherService : IMountWatcherService
     {
         try
         {
-            var psi = new ProcessStartInfo(Path.Combine(Environment.SystemDirectory, "sc.exe"), $"query {ServiceName}")
-            {
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-            using var process = Process.Start(psi);
-            if (process == null)
-            {
-                _logger.LogWarning("[MountWatcher] GetStatus: failed to start sc.exe");
-                return MountWatcherStatus.Unknown;
-            }
+            var result = _runner.Run(
+                Path.Combine(Environment.SystemDirectory, "sc.exe"),
+                $"query {ServiceName}");
 
-            var output = process.StandardOutput.ReadToEnd();
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
+            if (result.ExitCode != 0)
             {
-                _logger.LogDebug("[MountWatcher] GetStatus: service not installed (sc.exe exit {ExitCode})", process.ExitCode);
+                _logger.LogDebug("[MountWatcher] GetStatus: service not installed (sc.exe exit {ExitCode})", result.ExitCode);
                 return MountWatcherStatus.NotInstalled;
             }
 
-            var status = output.Contains("RUNNING", StringComparison.OrdinalIgnoreCase)
+            var status = result.Output.Contains("RUNNING", StringComparison.OrdinalIgnoreCase)
                 ? MountWatcherStatus.Running
                 : MountWatcherStatus.Stopped;
 
@@ -119,15 +113,8 @@ public class MountWatcherService : IMountWatcherService
 
         try
         {
-            var psi = new ProcessStartInfo(_cliBinaryPath, "--uninstall")
-            {
-                Verb = "runas",
-                UseShellExecute = true,
-                CreateNoWindow = true
-            };
-            using var process = Process.Start(psi);
-            process?.WaitForExit();
-            _logger.LogInformation("[MountWatcher] StopSync: completed (exit {ExitCode})", process?.ExitCode);
+            var result = _runner.RunElevated(_cliBinaryPath, "--uninstall");
+            _logger.LogInformation("[MountWatcher] StopSync: completed (exit {ExitCode})", result.ExitCode);
         }
         catch (Exception ex)
         {
@@ -141,22 +128,9 @@ public class MountWatcherService : IMountWatcherService
         {
             try
             {
-                var psi = new ProcessStartInfo(_cliBinaryPath, args)
-                {
-                    Verb = "runas",
-                    UseShellExecute = true,
-                    CreateNoWindow = true
-                };
-                using var process = Process.Start(psi);
-                if (process == null)
-                {
-                    _logger.LogWarning("[MountWatcher] RunElevatedAsync: Process.Start returned null for args={Args}", args);
-                    return -1;
-                }
-
-                process.WaitForExit();
-                _logger.LogDebug("[MountWatcher] RunElevatedAsync: args={Args} exit={ExitCode}", args, process.ExitCode);
-                return process.ExitCode;
+                var result = _runner.RunElevated(_cliBinaryPath, args);
+                _logger.LogDebug("[MountWatcher] RunElevatedAsync: args={Args} exit={ExitCode}", args, result.ExitCode);
+                return result.ExitCode;
             }
             catch (Exception ex)
             {

--- a/windows/Services/MountWatcherService.cs
+++ b/windows/Services/MountWatcherService.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics;
+
+namespace Starsky.Desktop.Services;
+
+public class MountWatcherService : IMountWatcherService
+{
+#if DEBUG
+    internal const string ServiceName = "starsky-mountwatcher-debug";
+#else
+    internal const string ServiceName = "starsky-mountwatcher";
+#endif
+
+    private readonly string _cliBinaryPath;
+
+    public MountWatcherService()
+        : this(Path.Combine(ApplicationPaths.RuntimeDir, "starskymountwatchercli.exe")) { }
+
+    internal MountWatcherService(string cliBinaryPath)
+    {
+        _cliBinaryPath = cliBinaryPath;
+    }
+
+    public async Task<bool> EnableAsync()
+    {
+        if (!File.Exists(_cliBinaryPath))
+            return false;
+
+        var exitCode = await RunElevatedAsync("--install");
+        return exitCode == 0;
+    }
+
+    public async Task<bool> DisableAsync()
+    {
+        if (!File.Exists(_cliBinaryPath))
+            return GetStatus() == MountWatcherStatus.NotInstalled;
+
+        var exitCode = await RunElevatedAsync("--uninstall");
+        return exitCode == 0;
+    }
+
+    public MountWatcherStatus GetStatus()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("sc.exe", $"query {ServiceName}")
+            {
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var process = Process.Start(psi);
+            if (process == null) return MountWatcherStatus.Unknown;
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0) return MountWatcherStatus.NotInstalled;
+
+            return output.Contains("RUNNING", StringComparison.OrdinalIgnoreCase)
+                ? MountWatcherStatus.Running
+                : MountWatcherStatus.Stopped;
+        }
+        catch
+        {
+            return MountWatcherStatus.Unknown;
+        }
+    }
+
+    public void StopSync()
+    {
+        if (!File.Exists(_cliBinaryPath))
+            return;
+
+        try
+        {
+            var psi = new ProcessStartInfo(_cliBinaryPath, "--uninstall")
+            {
+                Verb = "runas",
+                UseShellExecute = true,
+                CreateNoWindow = true
+            };
+            using var process = Process.Start(psi);
+            process?.WaitForExit();
+        }
+        catch
+        {
+            // fire-and-forget; app is shutting down
+        }
+    }
+
+    private Task<int> RunElevatedAsync(string args)
+    {
+        return Task.Run(() =>
+        {
+            try
+            {
+                var psi = new ProcessStartInfo(_cliBinaryPath, args)
+                {
+                    Verb = "runas",
+                    UseShellExecute = true,
+                    CreateNoWindow = true
+                };
+                using var process = Process.Start(psi);
+                if (process == null) return -1;
+                process.WaitForExit();
+                return process.ExitCode;
+            }
+            catch
+            {
+                return -1;
+            }
+        });
+    }
+}

--- a/windows/Services/MountWatcherService.cs
+++ b/windows/Services/MountWatcherService.cs
@@ -71,7 +71,7 @@ public class MountWatcherService : IMountWatcherService
     {
         try
         {
-            var psi = new ProcessStartInfo("sc.exe", $"query {ServiceName}")
+            var psi = new ProcessStartInfo(Path.Combine(Environment.SystemDirectory, "sc.exe"), $"query {ServiceName}")
             {
                 RedirectStandardOutput = true,
                 UseShellExecute = false,

--- a/windows/Services/MountWatcherService.cs
+++ b/windows/Services/MountWatcherService.cs
@@ -1,40 +1,69 @@
 using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Starsky.Desktop.Services;
 
 public class MountWatcherService : IMountWatcherService
 {
-#if DEBUG
-    internal const string ServiceName = "starsky-mountwatcher-debug";
-#else
+    // The CLI binary in the runtime directory is always a Release build,
+    // so it always registers the service under the production name.
     internal const string ServiceName = "starsky-mountwatcher";
-#endif
 
     private readonly string _cliBinaryPath;
+    private readonly ILogger<MountWatcherService> _logger;
 
-    public MountWatcherService()
-        : this(Path.Combine(ApplicationPaths.RuntimeDir, "starskymountwatchercli.exe")) { }
+    public MountWatcherService(ILogger<MountWatcherService> logger)
+        : this(Path.Combine(ApplicationPaths.RuntimeDir, "starskymountwatchercli.exe"), logger) { }
 
-    internal MountWatcherService(string cliBinaryPath)
+    internal MountWatcherService(string cliBinaryPath, ILogger<MountWatcherService>? logger = null)
     {
         _cliBinaryPath = cliBinaryPath;
+        _logger = logger ?? NullLoggerFactory.Instance.CreateLogger<MountWatcherService>();
     }
 
     public async Task<bool> EnableAsync()
     {
+        _logger.LogInformation("[MountWatcher] EnableAsync: binary={Path}", _cliBinaryPath);
+
         if (!File.Exists(_cliBinaryPath))
+        {
+            _logger.LogWarning("[MountWatcher] EnableAsync: binary not found at {Path}", _cliBinaryPath);
             return false;
+        }
 
         var exitCode = await RunElevatedAsync("--install");
+        if (exitCode == 0)
+        {
+            _logger.LogInformation("[MountWatcher] EnableAsync: install succeeded");
+        }
+        else
+        {
+            _logger.LogWarning("[MountWatcher] EnableAsync: install failed with exit code {ExitCode}", exitCode);
+        }
         return exitCode == 0;
     }
 
     public async Task<bool> DisableAsync()
     {
+        _logger.LogInformation("[MountWatcher] DisableAsync: binary={Path}", _cliBinaryPath);
+
         if (!File.Exists(_cliBinaryPath))
-            return GetStatus() == MountWatcherStatus.NotInstalled;
+        {
+            var status = GetStatus();
+            _logger.LogWarning("[MountWatcher] DisableAsync: binary not found; current status={Status}", status);
+            return status == MountWatcherStatus.NotInstalled;
+        }
 
         var exitCode = await RunElevatedAsync("--uninstall");
+        if (exitCode == 0)
+        {
+            _logger.LogInformation("[MountWatcher] DisableAsync: uninstall succeeded");
+        }
+        else
+        {
+            _logger.LogWarning("[MountWatcher] DisableAsync: uninstall failed with exit code {ExitCode}", exitCode);
+        }
         return exitCode == 0;
     }
 
@@ -49,26 +78,44 @@ public class MountWatcherService : IMountWatcherService
                 CreateNoWindow = true
             };
             using var process = Process.Start(psi);
-            if (process == null) return MountWatcherStatus.Unknown;
+            if (process == null)
+            {
+                _logger.LogWarning("[MountWatcher] GetStatus: failed to start sc.exe");
+                return MountWatcherStatus.Unknown;
+            }
+
             var output = process.StandardOutput.ReadToEnd();
             process.WaitForExit();
 
-            if (process.ExitCode != 0) return MountWatcherStatus.NotInstalled;
+            if (process.ExitCode != 0)
+            {
+                _logger.LogDebug("[MountWatcher] GetStatus: service not installed (sc.exe exit {ExitCode})", process.ExitCode);
+                return MountWatcherStatus.NotInstalled;
+            }
 
-            return output.Contains("RUNNING", StringComparison.OrdinalIgnoreCase)
+            var status = output.Contains("RUNNING", StringComparison.OrdinalIgnoreCase)
                 ? MountWatcherStatus.Running
                 : MountWatcherStatus.Stopped;
+
+            _logger.LogDebug("[MountWatcher] GetStatus: {Status}", status);
+            return status;
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "[MountWatcher] GetStatus: unexpected error");
             return MountWatcherStatus.Unknown;
         }
     }
 
     public void StopSync()
     {
+        _logger.LogInformation("[MountWatcher] StopSync: stopping service synchronously");
+
         if (!File.Exists(_cliBinaryPath))
+        {
+            _logger.LogWarning("[MountWatcher] StopSync: binary not found at {Path}; skipping", _cliBinaryPath);
             return;
+        }
 
         try
         {
@@ -80,10 +127,11 @@ public class MountWatcherService : IMountWatcherService
             };
             using var process = Process.Start(psi);
             process?.WaitForExit();
+            _logger.LogInformation("[MountWatcher] StopSync: completed (exit {ExitCode})", process?.ExitCode);
         }
-        catch
+        catch (Exception ex)
         {
-            // fire-and-forget; app is shutting down
+            _logger.LogWarning(ex, "[MountWatcher] StopSync: failed (app is shutting down)");
         }
     }
 
@@ -100,12 +148,19 @@ public class MountWatcherService : IMountWatcherService
                     CreateNoWindow = true
                 };
                 using var process = Process.Start(psi);
-                if (process == null) return -1;
+                if (process == null)
+                {
+                    _logger.LogWarning("[MountWatcher] RunElevatedAsync: Process.Start returned null for args={Args}", args);
+                    return -1;
+                }
+
                 process.WaitForExit();
+                _logger.LogDebug("[MountWatcher] RunElevatedAsync: args={Args} exit={ExitCode}", args, process.ExitCode);
                 return process.ExitCode;
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogWarning(ex, "[MountWatcher] RunElevatedAsync: failed for args={Args}", args);
                 return -1;
             }
         });

--- a/windows/Services/UpdateService.cs
+++ b/windows/Services/UpdateService.cs
@@ -86,7 +86,11 @@ public class UpdateService
 
     public Task ApplyUpdateAsync()
     {
-        if (!HasPendingUpdate) throw new InvalidOperationException("No pending update available.");
+        if (!HasPendingUpdate)
+        {
+	        throw new InvalidOperationException("No pending update available.");
+        }
+
         _mountWatcherService?.StopSync();
         return DoApplyUpdateAsync();
     }

--- a/windows/Services/UpdateService.cs
+++ b/windows/Services/UpdateService.cs
@@ -17,15 +17,18 @@ public class UpdateService
     private readonly SettingsService _settings;
     private readonly ILogger<UpdateService> _logger;
     private readonly Func<string, Task<string>> _httpGet;
+    private readonly IMountWatcherService? _mountWatcherService;
     private UpdateManager? _updateManager;
     private UpdateInfo? _pendingUpdate;
 
     public UpdateService(SettingsService settings, ILogger<UpdateService> logger,
-        Func<string, Task<string>>? httpGet = null)
+        Func<string, Task<string>>? httpGet = null,
+        IMountWatcherService? mountWatcherService = null)
     {
         _settings = settings;
         _logger = logger;
         _httpGet = httpGet ?? DefaultHttpGetAsync;
+        _mountWatcherService = mountWatcherService;
         IsVelopackAvailable = ProbeInstalled();
     }
 
@@ -83,7 +86,9 @@ public class UpdateService
 
     public Task ApplyUpdateAsync()
     {
-        return !HasPendingUpdate ? throw new InvalidOperationException("No pending update available.") : DoApplyUpdateAsync();
+        if (!HasPendingUpdate) throw new InvalidOperationException("No pending update available.");
+        _mountWatcherService?.StopSync();
+        return DoApplyUpdateAsync();
     }
 
     public void RecordWarningShown()

--- a/windows/Services/WindowManager.cs
+++ b/windows/Services/WindowManager.cs
@@ -17,7 +17,8 @@ public class WindowManager(
 	FileDownloadService fileDownload,
 	FileWatcherService watcher,
 	UpdateService updateService,
-	ILogger<WindowManager> logger)
+	ILogger<WindowManager> logger,
+	IMountWatcherService? mountWatcherService = null)
 {
 	private readonly List<MainWindow> _mainWindows = [];
     private int? _localPort;
@@ -66,7 +67,8 @@ public class WindowManager(
             InitialRoute = route ?? "?f=/",
             Geometry = state,
             WindowIndex = _mainWindows.Count,
-            UpdateService = updateService
+            UpdateService = updateService,
+            MountWatcherService = mountWatcherService
         });
 
         _mainWindows.Add(window);

--- a/windows/Services/WindowsProcessRunner.cs
+++ b/windows/Services/WindowsProcessRunner.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+
+namespace Starsky.Desktop.Services;
+
+internal sealed class WindowsProcessRunner : IProcessRunner
+{
+    public ProcessResult Run(string fileName, string args)
+    {
+        var psi = new ProcessStartInfo(fileName, args)
+        {
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using var process = Process.Start(psi);
+        if (process == null) return new ProcessResult(-1, string.Empty);
+        var output = process.StandardOutput.ReadToEnd();
+        process.WaitForExit();
+        return new ProcessResult(process.ExitCode, output);
+    }
+
+    public ProcessResult RunElevated(string fileName, string args)
+    {
+        var psi = new ProcessStartInfo(fileName, args)
+        {
+            Verb = "runas",
+            UseShellExecute = true,
+            CreateNoWindow = true
+        };
+        using var process = Process.Start(psi);
+        if (process == null) return new ProcessResult(-1, string.Empty);
+        process.WaitForExit();
+        return new ProcessResult(process.ExitCode, string.Empty);
+    }
+}

--- a/windows/Services/WindowsProcessRunner.cs
+++ b/windows/Services/WindowsProcessRunner.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Starsky.Desktop.Services;
 
+[ExcludeFromCodeCoverage]
 internal sealed class WindowsProcessRunner : IProcessRunner
 {
     public ProcessResult Run(string fileName, string args)

--- a/windows/Windows/MainWindow.xaml
+++ b/windows/Windows/MainWindow.xaml
@@ -31,6 +31,11 @@
             <MenuItem Header="_Settings">
                 <MenuItem Header="_Connection Settings…" Click="ConnectionSettings_Click"/>
                 <MenuItem Header="_Application Settings" InputGestureText="Ctrl+Shift+K" Click="AppSettings_Click"/>
+                <Separator/>
+                <MenuItem Header="_Mount Watcher" SubmenuOpened="MountWatcherMenu_SubmenuOpened">
+                    <MenuItem x:Name="MountWatcherStatusItem" IsEnabled="False" Visibility="Collapsed"/>
+                    <MenuItem x:Name="MountWatcherToggleItem" Click="MountWatcherToggle_Click"/>
+                </MenuItem>
             </MenuItem>
             <MenuItem Header="_View">
                 <MenuItem Header="Actual _Size" InputGestureText="Ctrl+0" Click="ActualSize_Click"/>

--- a/windows/Windows/MainWindow.xaml.cs
+++ b/windows/Windows/MainWindow.xaml.cs
@@ -351,7 +351,10 @@ public partial class MainWindow
 
     private void MountWatcherMenu_SubmenuOpened(object sender, RoutedEventArgs e)
     {
-        if (_mountWatcherService == null) return;
+        if (_mountWatcherService == null)
+        {
+	        return;
+        }
 
         var enabled = _settings.Current.MountWatcherEnabled;
         if (enabled)
@@ -370,7 +373,10 @@ public partial class MainWindow
 
     private async void MountWatcherToggle_Click(object sender, RoutedEventArgs e)
     {
-        if (_mountWatcherService == null) return;
+        if (_mountWatcherService == null)
+        {
+	        return;
+        }
 
         if (_settings.Current.MountWatcherEnabled)
         {

--- a/windows/Windows/MainWindow.xaml.cs
+++ b/windows/Windows/MainWindow.xaml.cs
@@ -24,6 +24,7 @@ public partial class MainWindow
     private readonly FileWatcherService _watcher;
     private readonly WindowManager _windowManager;
     private readonly UpdateService _updateService;
+    private readonly IMountWatcherService? _mountWatcherService;
     private readonly ILogger _logger;
 
     private readonly string _baseUrl;
@@ -41,6 +42,7 @@ public partial class MainWindow
         _watcher = options.Watcher;
         _windowManager = options.WindowManager;
         _updateService = options.UpdateService;
+        _mountWatcherService = options.MountWatcherService;
         _logger = options.Logger;
         _baseUrl = options.BaseUrl;
         _windowIndex = options.WindowIndex;
@@ -342,6 +344,62 @@ public partial class MainWindow
         finally
         {
             CheckForUpdatesMenuItem.IsEnabled = true;
+        }
+    }
+
+    // ── MountWatcher menu ─────────────────────────────────────────────────────
+
+    private void MountWatcherMenu_SubmenuOpened(object sender, RoutedEventArgs e)
+    {
+        if (_mountWatcherService == null) return;
+
+        var enabled = _settings.Current.MountWatcherEnabled;
+        if (enabled)
+        {
+            var status = _mountWatcherService.GetStatus();
+            MountWatcherStatusItem.Header = $"Status: {status}";
+            MountWatcherStatusItem.Visibility = Visibility.Visible;
+            MountWatcherToggleItem.Header = "Disable _Mount Watcher";
+        }
+        else
+        {
+            MountWatcherStatusItem.Visibility = Visibility.Collapsed;
+            MountWatcherToggleItem.Header = "Enable _Mount Watcher (requires admin)";
+        }
+    }
+
+    private async void MountWatcherToggle_Click(object sender, RoutedEventArgs e)
+    {
+        if (_mountWatcherService == null) return;
+
+        if (_settings.Current.MountWatcherEnabled)
+        {
+            var ok = await _mountWatcherService.DisableAsync();
+            if (ok)
+            {
+                _settings.Current.MountWatcherEnabled = false;
+                _settings.Save();
+            }
+            else
+            {
+                MessageBox.Show("Failed to disable Mount Watcher.", "Mount Watcher",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+        else
+        {
+            var ok = await _mountWatcherService.EnableAsync();
+            if (ok)
+            {
+                _settings.Current.MountWatcherEnabled = true;
+                _settings.Save();
+            }
+            else
+            {
+                MessageBox.Show(
+                    "Failed to enable Mount Watcher.\n\nEnsure the starskymountwatchercli.exe binary is present and that you approved the administrator prompt.",
+                    "Mount Watcher", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
         }
     }
 }

--- a/windows/Windows/MainWindow.xaml.cs
+++ b/windows/Windows/MainWindow.xaml.cs
@@ -361,10 +361,9 @@ public partial class MainWindow
 	        return;
         }
 
-        var enabled = _settings.Current.MountWatcherEnabled;
-        if (enabled)
+        var status = _mountWatcherService.GetStatus();
+        if (status is MountWatcherStatus.Running or MountWatcherStatus.Stopped)
         {
-            var status = _mountWatcherService.GetStatus();
             MountWatcherStatusItem.Header = $"Status: {status}";
             MountWatcherStatusItem.Visibility = Visibility.Visible;
             MountWatcherToggleItem.Header = "Disable _Mount Watcher";
@@ -383,7 +382,8 @@ public partial class MainWindow
 	        return;
         }
 
-        if (_settings.Current.MountWatcherEnabled)
+        var status = _mountWatcherService.GetStatus();
+        if (status is MountWatcherStatus.Running or MountWatcherStatus.Stopped)
         {
             var ok = await _mountWatcherService.DisableAsync();
             if (ok)

--- a/windows/build-velopack.ps1
+++ b/windows/build-velopack.ps1
@@ -10,6 +10,7 @@
       3. Install the Velopack CLI (vpk) if not already present.
       4. vpk pack to produce the installer and update feed.
       5. Rename the setup exe to starsky-win-x64-desktop.exe.
+      6. Extract Starsky.Desktop-win-Portable.zip (skipped if the zip is absent).
 
 .PARAMETER Version
     Version string to embed (e.g. "0.8.2"). Defaults to the <Version> in the csproj.
@@ -169,6 +170,23 @@ if (-not $SetupExe) {
     $FinalName = Join-Path $OutputDir 'starsky-win-x64-desktop.exe'
     Move-Item $SetupExe.FullName $FinalName -Force
     Write-Host "  Installer: $FinalName" -ForegroundColor Green
+}
+
+# ---------------------------------------------------------------------------
+# Step 6 — Extract portable zip
+# ---------------------------------------------------------------------------
+Write-Host "`n[Step 6] Extracting portable zip..." -ForegroundColor Cyan
+
+$PortableZip = Join-Path $OutputDir 'Starsky.Desktop-win-Portable.zip'
+if (-not (Test-Path $PortableZip)) {
+    Write-Host "  Portable zip not found, skipping extraction." -ForegroundColor Yellow
+} else {
+    $PortableExtractDir = Join-Path $OutputDir 'Starsky.Desktop-win-Portable'
+    if (Test-Path $PortableExtractDir) {
+        Remove-Item $PortableExtractDir -Recurse -Force
+    }
+    Expand-Archive -Path $PortableZip -DestinationPath $PortableExtractDir
+    Write-Host "  Extracted to: $PortableExtractDir" -ForegroundColor Green
 }
 
 # ---------------------------------------------------------------------------

--- a/windows/starsky.Tests/FakeCreateAn/FakeMountWatcherService.cs
+++ b/windows/starsky.Tests/FakeCreateAn/FakeMountWatcherService.cs
@@ -1,0 +1,18 @@
+using Starsky.Desktop.Services;
+
+namespace starsky.Tests.FakeCreateAn;
+
+internal sealed class FakeMountWatcherService : IMountWatcherService
+{
+    public bool EnableCalled;
+    public bool DisableCalled;
+    public bool StopSyncCalled;
+    public bool EnableResult = true;
+    public bool DisableResult = true;
+    public MountWatcherStatus StatusResult = MountWatcherStatus.NotInstalled;
+
+    public Task<bool> EnableAsync() { EnableCalled = true; return Task.FromResult(EnableResult); }
+    public Task<bool> DisableAsync() { DisableCalled = true; return Task.FromResult(DisableResult); }
+    public MountWatcherStatus GetStatus() => StatusResult;
+    public void StopSync() { StopSyncCalled = true; }
+}

--- a/windows/starsky.Tests/FakeCreateAn/FakeProcessRunner.cs
+++ b/windows/starsky.Tests/FakeCreateAn/FakeProcessRunner.cs
@@ -6,6 +6,8 @@ internal sealed class FakeProcessRunner : IProcessRunner
 {
     private readonly Queue<ProcessResult> _results = new();
     private readonly Queue<ProcessResult> _elevatedResults = new();
+    private bool _throwOnRun;
+    private bool _throwOnElevated;
 
     public List<(string FileName, string Args)> RunCalls { get; } = [];
     public List<(string FileName, string Args)> RunElevatedCalls { get; } = [];
@@ -22,15 +24,29 @@ internal sealed class FakeProcessRunner : IProcessRunner
         return this;
     }
 
+    public FakeProcessRunner ThrowOnRun()
+    {
+        _throwOnRun = true;
+        return this;
+    }
+
+    public FakeProcessRunner ThrowOnElevated()
+    {
+        _throwOnElevated = true;
+        return this;
+    }
+
     public ProcessResult Run(string fileName, string args)
     {
         RunCalls.Add((fileName, args));
+        if (_throwOnRun) throw new InvalidOperationException("fake run failure");
         return _results.TryDequeue(out var r) ? r : new ProcessResult(0, string.Empty);
     }
 
     public ProcessResult RunElevated(string fileName, string args)
     {
         RunElevatedCalls.Add((fileName, args));
+        if (_throwOnElevated) throw new InvalidOperationException("fake elevated failure");
         return _elevatedResults.TryDequeue(out var r) ? r : new ProcessResult(0, string.Empty);
     }
 }

--- a/windows/starsky.Tests/FakeCreateAn/FakeProcessRunner.cs
+++ b/windows/starsky.Tests/FakeCreateAn/FakeProcessRunner.cs
@@ -1,0 +1,36 @@
+using Starsky.Desktop.Services;
+
+namespace starsky.Tests.FakeCreateAn;
+
+internal sealed class FakeProcessRunner : IProcessRunner
+{
+    private readonly Queue<ProcessResult> _results = new();
+    private readonly Queue<ProcessResult> _elevatedResults = new();
+
+    public List<(string FileName, string Args)> RunCalls { get; } = [];
+    public List<(string FileName, string Args)> RunElevatedCalls { get; } = [];
+
+    public FakeProcessRunner EnqueueRun(int exitCode, string output = "")
+    {
+        _results.Enqueue(new ProcessResult(exitCode, output));
+        return this;
+    }
+
+    public FakeProcessRunner EnqueueElevated(int exitCode)
+    {
+        _elevatedResults.Enqueue(new ProcessResult(exitCode, string.Empty));
+        return this;
+    }
+
+    public ProcessResult Run(string fileName, string args)
+    {
+        RunCalls.Add((fileName, args));
+        return _results.TryDequeue(out var r) ? r : new ProcessResult(0, string.Empty);
+    }
+
+    public ProcessResult RunElevated(string fileName, string args)
+    {
+        RunElevatedCalls.Add((fileName, args));
+        return _elevatedResults.TryDequeue(out var r) ? r : new ProcessResult(0, string.Empty);
+    }
+}

--- a/windows/starsky.Tests/Models/DesktopSettingsTests.cs
+++ b/windows/starsky.Tests/Models/DesktopSettingsTests.cs
@@ -14,6 +14,7 @@ public class DesktopSettingsTests
         Assert.IsTrue(s.UpdateCheckEnabled);
         Assert.IsNull(s.LastUpdateWarningShown);
         Assert.IsEmpty(s.Windows);
+        Assert.IsFalse(s.MountWatcherEnabled);
     }
 
     [TestMethod]

--- a/windows/starsky.Tests/Services/MountWatcherServiceTests.cs
+++ b/windows/starsky.Tests/Services/MountWatcherServiceTests.cs
@@ -2,194 +2,37 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Starsky.Desktop.Models;
 using Starsky.Desktop.Services;
 using starsky.Tests.FakeCreateAn;
-using System.Threading.Tasks;
 
 namespace starsky.Tests.Services;
 
 [TestClass]
 public class MountWatcherServiceTests
 {
-    // ── DesktopSettings ───────────────────────────────────────────────────────
+    // ── Helpers ───────────────────────────────────────────────────────────────
 
-    [TestMethod]
-    public void DesktopSettings_MountWatcherEnabled_DefaultsToFalse()
+    private static string TempSettings() =>
+        Path.Combine(Path.GetTempPath(), $"starsky-mw-{Guid.NewGuid()}.json");
+
+    private static string NonExistentBinary() =>
+        Path.Combine(Path.GetTempPath(), "nonexistent_cli.exe");
+
+    /// <summary>
+    /// Creates a real (empty) file to stand in for the CLI binary so File.Exists passes.
+    /// </summary>
+    private static string CreateTempBinary()
     {
-        var s = new DesktopSettings();
-        Assert.IsFalse(s.MountWatcherEnabled);
+        var path = Path.Combine(Path.GetTempPath(), $"fake_cli_{Guid.NewGuid()}.exe");
+        File.WriteAllBytes(path, []);
+        return path;
     }
 
-    [TestMethod]
-    public void DesktopSettings_MountWatcherEnabled_RoundTripsJson()
-    {
-        var original = new DesktopSettings { MountWatcherEnabled = true };
-        var json = JsonSerializer.Serialize(original);
-        var restored = JsonSerializer.Deserialize<DesktopSettings>(json)!;
-
-        Assert.IsTrue(restored.MountWatcherEnabled);
-    }
-
-    [TestMethod]
-    public void DesktopSettings_MountWatcherEnabled_FalseRoundTripsJson()
-    {
-        var original = new DesktopSettings { MountWatcherEnabled = false };
-        var json = JsonSerializer.Serialize(original);
-        var restored = JsonSerializer.Deserialize<DesktopSettings>(json)!;
-
-        Assert.IsFalse(restored.MountWatcherEnabled);
-    }
-
-    // ── FakeMountWatcherService ───────────────────────────────────────────────
-
-    [TestMethod]
-    public async Task FakeMountWatcherService_Enable_SetsCalledFlag()
-    {
-        var fake = new FakeMountWatcherService();
-        var result = await fake.EnableAsync();
-
-        Assert.IsTrue(fake.EnableCalled);
-        Assert.IsTrue(result);
-    }
-
-    [TestMethod]
-    public async Task FakeMountWatcherService_Enable_ReturnsConfiguredResult()
-    {
-        var fake = new FakeMountWatcherService { EnableResult = false };
-        var result = await fake.EnableAsync();
-
-        Assert.IsFalse(result);
-    }
-
-    [TestMethod]
-    public async Task FakeMountWatcherService_Disable_SetsCalledFlag()
-    {
-        var fake = new FakeMountWatcherService();
-        var result = await fake.DisableAsync();
-
-        Assert.IsTrue(fake.DisableCalled);
-        Assert.IsTrue(result);
-    }
-
-    [TestMethod]
-    public void FakeMountWatcherService_StopSync_SetsCalledFlag()
-    {
-        var fake = new FakeMountWatcherService();
-        fake.StopSync();
-
-        Assert.IsTrue(fake.StopSyncCalled);
-    }
-
-    [TestMethod]
-    public void FakeMountWatcherService_GetStatus_ReturnsConfiguredStatus()
-    {
-        var fake = new FakeMountWatcherService { StatusResult = MountWatcherStatus.Running };
-        Assert.AreEqual(MountWatcherStatus.Running, fake.GetStatus());
-    }
-
-    // ── MountWatcherService — binary-missing fast-paths ───────────────────────
-
-    [TestMethod]
-    public async Task MountWatcherService_Enable_ReturnsFalse_WhenBinaryMissing()
-    {
-        var svc = new MountWatcherService(Path.Combine(Path.GetTempPath(), "nonexistent_cli.exe"));
-        var result = await svc.EnableAsync();
-
-        Assert.IsFalse(result);
-    }
-
-    [TestMethod]
-    public async Task MountWatcherService_Disable_ReturnsFalse_WhenBinaryMissingAndServiceInstalled()
-    {
-        var svc = new MountWatcherService(Path.Combine(Path.GetTempPath(), "nonexistent_cli.exe"));
-        // GetStatus() → NotInstalled (no service registered in CI)
-        // DisableAsync with missing binary returns true only if service is also not installed
-        var result = await svc.DisableAsync();
-        // In CI/dev with no service installed, NotInstalled → true
-        // We only verify it doesn't throw
-        Assert.IsTrue(result == true || result == false);
-    }
-
-    [TestMethod]
-    public void MountWatcherService_StopSync_DoesNotThrow_WhenBinaryMissing()
-    {
-        var svc = new MountWatcherService(Path.Combine(Path.GetTempPath(), "nonexistent_cli.exe"));
-
-        Exception? ex = null;
-        try { svc.StopSync(); } catch (Exception e) { ex = e; }
-
-        Assert.IsNull(ex);
-    }
-
-    [TestMethod]
-    public void MountWatcherService_GetStatus_ReturnsNotInstalledOrUnknown_WhenServiceAbsent()
-    {
-        var svc = new MountWatcherService(Path.Combine(Path.GetTempPath(), "nonexistent_cli.exe"));
-        var status = svc.GetStatus();
-
-        Assert.IsTrue(status is MountWatcherStatus.NotInstalled or MountWatcherStatus.Unknown);
-    }
-
-    // ── UpdateService — StopSync called before apply ──────────────────────────
-
-    [TestMethod]
-    public async Task UpdateService_ApplyUpdateAsync_CallsStopSync_BeforeApply()
-    {
-        var tempFile = Path.Combine(Path.GetTempPath(), $"starsky-mw-upd-{Guid.NewGuid()}.json");
-        try
-        {
-            var settings = new SettingsService(NullLogger<SettingsService>.Instance, tempFile);
-            settings.Load();
-
-            var fake = new FakeMountWatcherService();
-            var svc = new FakeUpdateServiceWithMountWatcher(settings, fake);
-
-            await svc.ApplyUpdateAsync();
-
-            Assert.IsTrue(fake.StopSyncCalled);
-        }
-        finally
-        {
-            try { File.Delete(tempFile); } catch { /* best-effort */ }
-        }
-    }
-
-    [TestMethod]
-    public async Task UpdateService_ApplyUpdateAsync_DoesNotThrow_WhenNoMountWatcherService()
-    {
-        var tempFile = Path.Combine(Path.GetTempPath(), $"starsky-mw-upd2-{Guid.NewGuid()}.json");
-        try
-        {
-            var settings = new SettingsService(NullLogger<SettingsService>.Instance, tempFile);
-            settings.Load();
-
-            var svc = new FakeUpdateServiceWithMountWatcher(settings, null);
-
-            Exception? ex = null;
-            try { await svc.ApplyUpdateAsync(); } catch (Exception e) { ex = e; }
-
-            Assert.IsNull(ex);
-        }
-        finally
-        {
-            try { File.Delete(tempFile); } catch { /* best-effort */ }
-        }
-    }
-
-    private sealed class FakeUpdateServiceWithMountWatcher(
-        SettingsService settings,
-        IMountWatcherService? mountWatcherService)
-        : UpdateService(settings, NullLogger<UpdateService>.Instance,
-            mountWatcherService: mountWatcherService)
-    {
-        protected override bool HasPendingUpdate => true;
-        protected override Task DoApplyUpdateAsync() => Task.CompletedTask;
-    }
-
-    // ── MountWatcherLifecycle ─────────────────────────────────────────────────
+    private static MountWatcherService WithRunner(string binaryPath, FakeProcessRunner runner) =>
+        new(binaryPath, NullLogger<MountWatcherService>.Instance, runner);
 
     private static (MountWatcherLifecycle lifecycle, SettingsService settings, FakeMountWatcherService fake)
         CreateLifecycle(string? tempFile = null)
     {
-        var file = tempFile ?? Path.Combine(Path.GetTempPath(), $"starsky-mwl-{Guid.NewGuid()}.json");
+        var file = tempFile ?? TempSettings();
         var settings = new SettingsService(NullLogger<SettingsService>.Instance, file);
         settings.Load();
         var fake = new FakeMountWatcherService();
@@ -198,118 +41,374 @@ public class MountWatcherServiceTests
         return (lifecycle, settings, fake);
     }
 
+    // ── DesktopSettings ───────────────────────────────────────────────────────
+
     [TestMethod]
-    public async Task Lifecycle_OnStartupAsync_DoesNotCallEnable_WhenPreferenceIsFalse()
+    public void DesktopSettings_MountWatcherEnabled_DefaultsToFalse()
     {
-        var (lifecycle, settings, fake) = CreateLifecycle();
-        settings.Current.MountWatcherEnabled = false;
-
-        await lifecycle.OnStartupAsync();
-
-        Assert.IsFalse(fake.EnableCalled);
+        Assert.IsFalse(new DesktopSettings().MountWatcherEnabled);
     }
 
     [TestMethod]
-    public async Task Lifecycle_OnStartupAsync_CallsEnable_WhenPreferenceIsTrue()
+    public void DesktopSettings_MountWatcherEnabled_True_RoundTripsJson()
     {
-        var (lifecycle, settings, fake) = CreateLifecycle();
-        settings.Current.MountWatcherEnabled = true;
+        var original = new DesktopSettings { MountWatcherEnabled = true };
+        var restored = JsonSerializer.Deserialize<DesktopSettings>(JsonSerializer.Serialize(original))!;
+        Assert.IsTrue(restored.MountWatcherEnabled);
+    }
 
-        await lifecycle.OnStartupAsync();
+    [TestMethod]
+    public void DesktopSettings_MountWatcherEnabled_False_RoundTripsJson()
+    {
+        var original = new DesktopSettings { MountWatcherEnabled = false };
+        var restored = JsonSerializer.Deserialize<DesktopSettings>(JsonSerializer.Serialize(original))!;
+        Assert.IsFalse(restored.MountWatcherEnabled);
+    }
 
+    // ── MountWatcherService — EnableAsync ─────────────────────────────────────
+
+    [TestMethod]
+    public async Task Enable_ReturnsFalse_WhenBinaryMissing()
+    {
+        var svc = WithRunner(NonExistentBinary(), new FakeProcessRunner());
+        Assert.IsFalse(await svc.EnableAsync());
+    }
+
+    [TestMethod]
+    public async Task Enable_ReturnsTrue_WhenInstallSucceeds()
+    {
+        var bin = CreateTempBinary();
+        try
+        {
+            var runner = new FakeProcessRunner().EnqueueElevated(0);
+            var svc = WithRunner(bin, runner);
+
+            Assert.IsTrue(await svc.EnableAsync());
+            Assert.HasCount(1, runner.RunElevatedCalls);
+            Assert.AreEqual("--install", runner.RunElevatedCalls[0].Args);
+        }
+        finally { TryDelete(bin); }
+    }
+
+    [TestMethod]
+    public async Task Enable_ReturnsFalse_WhenInstallFails()
+    {
+        var bin = CreateTempBinary();
+        try
+        {
+            var runner = new FakeProcessRunner().EnqueueElevated(1);
+            Assert.IsFalse(await WithRunner(bin, runner).EnableAsync());
+        }
+        finally { TryDelete(bin); }
+    }
+
+    // ── MountWatcherService — DisableAsync ────────────────────────────────────
+
+    [TestMethod]
+    public async Task Disable_ReturnsTrue_WhenBinaryMissingAndServiceNotInstalled()
+    {
+        // Binary missing, sc.exe says not installed → success
+        var runner = new FakeProcessRunner().EnqueueRun(1060, ""); // sc.exe: not found
+        var svc = WithRunner(NonExistentBinary(), runner);
+        Assert.IsTrue(await svc.DisableAsync());
+    }
+
+    [TestMethod]
+    public async Task Disable_ReturnsFalse_WhenBinaryMissingButServiceStillInstalled()
+    {
+        // Binary missing, sc.exe says service exists → failure
+        var runner = new FakeProcessRunner().EnqueueRun(0, "STATE: 1 STOPPED");
+        var svc = WithRunner(NonExistentBinary(), runner);
+        Assert.IsFalse(await svc.DisableAsync());
+    }
+
+    [TestMethod]
+    public async Task Disable_ReturnsTrue_WhenUninstallSucceeds()
+    {
+        var bin = CreateTempBinary();
+        try
+        {
+            var runner = new FakeProcessRunner().EnqueueElevated(0);
+            Assert.IsTrue(await WithRunner(bin, runner).DisableAsync());
+            Assert.AreEqual("--uninstall", runner.RunElevatedCalls[0].Args);
+        }
+        finally { TryDelete(bin); }
+    }
+
+    [TestMethod]
+    public async Task Disable_ReturnsFalse_WhenUninstallFails()
+    {
+        var bin = CreateTempBinary();
+        try
+        {
+            var runner = new FakeProcessRunner().EnqueueElevated(1);
+            Assert.IsFalse(await WithRunner(bin, runner).DisableAsync());
+        }
+        finally { TryDelete(bin); }
+    }
+
+    // ── MountWatcherService — GetStatus ───────────────────────────────────────
+
+    [TestMethod]
+    public void GetStatus_ReturnsRunning_WhenScExeOutputContainsRunning()
+    {
+        var runner = new FakeProcessRunner().EnqueueRun(0, "STATE              : 4  RUNNING");
+        Assert.AreEqual(MountWatcherStatus.Running, WithRunner(NonExistentBinary(), runner).GetStatus());
+    }
+
+    [TestMethod]
+    public void GetStatus_ReturnsStopped_WhenScExeSucceedsWithoutRunning()
+    {
+        var runner = new FakeProcessRunner().EnqueueRun(0, "STATE              : 1  STOPPED");
+        Assert.AreEqual(MountWatcherStatus.Stopped, WithRunner(NonExistentBinary(), runner).GetStatus());
+    }
+
+    [TestMethod]
+    public void GetStatus_ReturnsNotInstalled_WhenScExeExitsNonZero()
+    {
+        var runner = new FakeProcessRunner().EnqueueRun(1060, "");
+        Assert.AreEqual(MountWatcherStatus.NotInstalled, WithRunner(NonExistentBinary(), runner).GetStatus());
+    }
+
+    [TestMethod]
+    public void GetStatus_ReturnsRunning_CaseInsensitive()
+    {
+        var runner = new FakeProcessRunner().EnqueueRun(0, "state: running");
+        Assert.AreEqual(MountWatcherStatus.Running, WithRunner(NonExistentBinary(), runner).GetStatus());
+    }
+
+    // ── MountWatcherService — StopSync ────────────────────────────────────────
+
+    [TestMethod]
+    public void StopSync_DoesNothing_WhenBinaryMissing()
+    {
+        var runner = new FakeProcessRunner();
+        WithRunner(NonExistentBinary(), runner).StopSync();
+        Assert.IsEmpty(runner.RunElevatedCalls);
+    }
+
+    [TestMethod]
+    public void StopSync_CallsUninstall_WhenBinaryExists()
+    {
+        var bin = CreateTempBinary();
+        try
+        {
+            var runner = new FakeProcessRunner().EnqueueElevated(0);
+            WithRunner(bin, runner).StopSync();
+            Assert.HasCount(1, runner.RunElevatedCalls);
+            Assert.AreEqual("--uninstall", runner.RunElevatedCalls[0].Args);
+        }
+        finally { TryDelete(bin); }
+    }
+
+    [TestMethod]
+    public void StopSync_DoesNotThrow_WhenUninstallFails()
+    {
+        var bin = CreateTempBinary();
+        try
+        {
+            var runner = new FakeProcessRunner().EnqueueElevated(1);
+            Exception? ex = null;
+            try { WithRunner(bin, runner).StopSync(); } catch (Exception e) { ex = e; }
+            Assert.IsNull(ex);
+        }
+        finally { TryDelete(bin); }
+    }
+
+    // ── MountWatcherService — ServiceName constant ────────────────────────────
+
+    [TestMethod]
+    public void ServiceName_IsProductionName()
+    {
+        // Protects against accidental debug-mode suffix being left in
+        Assert.IsFalse(MountWatcherService.ServiceName.EndsWith("-debug", StringComparison.Ordinal));
+        Assert.IsTrue(MountWatcherService.ServiceName.StartsWith("starsky-", StringComparison.Ordinal));
+    }
+
+    // ── FakeMountWatcherService ───────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task Fake_Enable_SetsCalledFlag()
+    {
+        var fake = new FakeMountWatcherService();
+        await fake.EnableAsync();
         Assert.IsTrue(fake.EnableCalled);
     }
 
     [TestMethod]
-    public async Task Lifecycle_OnStartupAsync_KeepsPreference_WhenEnableSucceeds()
+    public async Task Fake_Enable_ReturnsConfiguredResult()
     {
-        var (lifecycle, settings, fake) = CreateLifecycle();
-        settings.Current.MountWatcherEnabled = true;
-        fake.EnableResult = true;
-
-        await lifecycle.OnStartupAsync();
-
-        Assert.IsTrue(settings.Current.MountWatcherEnabled);
+        var fake = new FakeMountWatcherService { EnableResult = false };
+        Assert.IsFalse(await fake.EnableAsync());
     }
 
     [TestMethod]
-    public async Task Lifecycle_OnStartupAsync_ClearsPreference_WhenEnableFails()
+    public async Task Fake_Disable_SetsCalledFlag()
     {
-        var tempFile = Path.Combine(Path.GetTempPath(), $"starsky-mwl-fail-{Guid.NewGuid()}.json");
-        try
-        {
-            var (lifecycle, settings, fake) = CreateLifecycle(tempFile);
-            settings.Current.MountWatcherEnabled = true;
-            fake.EnableResult = false;
-
-            await lifecycle.OnStartupAsync();
-
-            Assert.IsFalse(settings.Current.MountWatcherEnabled);
-        }
-        finally
-        {
-            try { File.Delete(tempFile); } catch { /* best-effort */ }
-        }
+        var fake = new FakeMountWatcherService();
+        await fake.DisableAsync();
+        Assert.IsTrue(fake.DisableCalled);
     }
 
     [TestMethod]
-    public async Task Lifecycle_OnStartupAsync_PersistsCleared_Preference_WhenEnableFails()
+    public void Fake_StopSync_SetsCalledFlag()
     {
-        var tempFile = Path.Combine(Path.GetTempPath(), $"starsky-mwl-persist-{Guid.NewGuid()}.json");
-        try
-        {
-            var (lifecycle, settings, fake) = CreateLifecycle(tempFile);
-            settings.Current.MountWatcherEnabled = true;
-            fake.EnableResult = false;
-
-            await lifecycle.OnStartupAsync();
-
-            // Reload from disk and verify the preference was persisted as false
-            var reloaded = new SettingsService(NullLogger<SettingsService>.Instance, tempFile);
-            reloaded.Load();
-            Assert.IsFalse(reloaded.Current.MountWatcherEnabled);
-        }
-        finally
-        {
-            try { File.Delete(tempFile); } catch { /* best-effort */ }
-        }
-    }
-
-    [TestMethod]
-    public void Lifecycle_OnShutdown_CallsStopSync_WhenPreferenceIsTrue()
-    {
-        var (lifecycle, settings, fake) = CreateLifecycle();
-        settings.Current.MountWatcherEnabled = true;
-
-        lifecycle.OnShutdown();
-
+        var fake = new FakeMountWatcherService();
+        fake.StopSync();
         Assert.IsTrue(fake.StopSyncCalled);
     }
 
     [TestMethod]
-    public void Lifecycle_OnShutdown_DoesNotCallStopSync_WhenPreferenceIsFalse()
+    public void Fake_GetStatus_ReturnsConfiguredStatus()
+    {
+        var fake = new FakeMountWatcherService { StatusResult = MountWatcherStatus.Running };
+        Assert.AreEqual(MountWatcherStatus.Running, fake.GetStatus());
+    }
+
+    // ── MountWatcherLifecycle — OnStartupAsync ────────────────────────────────
+
+    [TestMethod]
+    public async Task Lifecycle_OnStartup_SkipsEnable_WhenPreferenceIsFalse()
     {
         var (lifecycle, settings, fake) = CreateLifecycle();
         settings.Current.MountWatcherEnabled = false;
+        await lifecycle.OnStartupAsync();
+        Assert.IsFalse(fake.EnableCalled);
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnStartup_CallsEnable_WhenPreferenceIsTrue()
+    {
+        var (lifecycle, settings, fake) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = true;
+        await lifecycle.OnStartupAsync();
+        Assert.IsTrue(fake.EnableCalled);
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnStartup_KeepsPreference_WhenEnableSucceeds()
+    {
+        var (lifecycle, settings, _) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = true;
+        await lifecycle.OnStartupAsync();
+        Assert.IsTrue(settings.Current.MountWatcherEnabled);
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnStartup_ClearsPreference_WhenEnableFails()
+    {
+        var tempFile = TempSettings();
+        try
+        {
+            var (lifecycle, settings, fake) = CreateLifecycle(tempFile);
+            settings.Current.MountWatcherEnabled = true;
+            fake.EnableResult = false;
+            await lifecycle.OnStartupAsync();
+            Assert.IsFalse(settings.Current.MountWatcherEnabled);
+        }
+        finally { TryDelete(tempFile); }
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnStartup_PersistsClearedPreference_WhenEnableFails()
+    {
+        var tempFile = TempSettings();
+        try
+        {
+            var (lifecycle, settings, fake) = CreateLifecycle(tempFile);
+            settings.Current.MountWatcherEnabled = true;
+            fake.EnableResult = false;
+            await lifecycle.OnStartupAsync();
+
+            var reloaded = new SettingsService(NullLogger<SettingsService>.Instance, tempFile);
+            reloaded.Load();
+            Assert.IsFalse(reloaded.Current.MountWatcherEnabled);
+        }
+        finally { TryDelete(tempFile); }
+    }
+
+    // ── MountWatcherLifecycle — OnShutdown ────────────────────────────────────
+
+    [TestMethod]
+    public void Lifecycle_OnShutdown_CallsStopSync_WhenEnabled()
+    {
+        var (lifecycle, settings, fake) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = true;
+        lifecycle.OnShutdown();
+        Assert.IsTrue(fake.StopSyncCalled);
+    }
+
+    [TestMethod]
+    public void Lifecycle_OnShutdown_SkipsStopSync_WhenDisabled()
+    {
+        var (lifecycle, settings, fake) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = false;
+        lifecycle.OnShutdown();
+        Assert.IsFalse(fake.StopSyncCalled);
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnShutdown_SkipsStopSync_AfterEnableFailed()
+    {
+        var (lifecycle, settings, fake) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = true;
+        fake.EnableResult = false;
+        await lifecycle.OnStartupAsync();
+        fake.StopSyncCalled = false;
 
         lifecycle.OnShutdown();
 
         Assert.IsFalse(fake.StopSyncCalled);
     }
 
+    // ── UpdateService — StopSync before apply ─────────────────────────────────
+
     [TestMethod]
-    public async Task Lifecycle_OnShutdown_DoesNotCallStopSync_AfterEnableFails()
+    public async Task UpdateService_ApplyUpdate_CallsStopSync_BeforeApply()
     {
-        // If enable failed on startup and preference was cleared, shutdown should not stop
-        var (lifecycle, settings, fake) = CreateLifecycle();
-        settings.Current.MountWatcherEnabled = true;
-        fake.EnableResult = false;
+        var tempFile = TempSettings();
+        try
+        {
+            var settings = new SettingsService(NullLogger<SettingsService>.Instance, tempFile);
+            settings.Load();
+            var fake = new FakeMountWatcherService();
+            var svc = new FakeUpdateService(settings, fake);
 
-        await lifecycle.OnStartupAsync(); // clears MountWatcherEnabled
-        fake.StopSyncCalled = false;     // reset flag
+            await svc.ApplyUpdateAsync();
 
-        lifecycle.OnShutdown();
+            Assert.IsTrue(fake.StopSyncCalled);
+        }
+        finally { TryDelete(tempFile); }
+    }
 
-        Assert.IsFalse(fake.StopSyncCalled);
+    [TestMethod]
+    public async Task UpdateService_ApplyUpdate_DoesNotThrow_WithoutMountWatcher()
+    {
+        var tempFile = TempSettings();
+        try
+        {
+            var settings = new SettingsService(NullLogger<SettingsService>.Instance, tempFile);
+            settings.Load();
+            var svc = new FakeUpdateService(settings, null);
+
+            Exception? ex = null;
+            try { await svc.ApplyUpdateAsync(); } catch (Exception e) { ex = e; }
+            Assert.IsNull(ex);
+        }
+        finally { TryDelete(tempFile); }
+    }
+
+    private sealed class FakeUpdateService(SettingsService settings, IMountWatcherService? mws)
+        : UpdateService(settings, NullLogger<UpdateService>.Instance, mountWatcherService: mws)
+    {
+        protected override bool HasPendingUpdate => true;
+        protected override Task DoApplyUpdateAsync() => Task.CompletedTask;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best-effort */ }
     }
 }

--- a/windows/starsky.Tests/Services/MountWatcherServiceTests.cs
+++ b/windows/starsky.Tests/Services/MountWatcherServiceTests.cs
@@ -177,6 +177,13 @@ public class MountWatcherServiceTests
         Assert.AreEqual(MountWatcherStatus.Running, WithRunner(NonExistentBinary(), runner).GetStatus());
     }
 
+    [TestMethod]
+    public void GetStatus_ReturnsUnknown_WhenRunnerThrows()
+    {
+        var runner = new FakeProcessRunner().ThrowOnRun();
+        Assert.AreEqual(MountWatcherStatus.Unknown, WithRunner(NonExistentBinary(), runner).GetStatus());
+    }
+
     // ── MountWatcherService — StopSync ────────────────────────────────────────
 
     [TestMethod]
@@ -215,14 +222,28 @@ public class MountWatcherServiceTests
         finally { TryDelete(bin); }
     }
 
+    [TestMethod]
+    public void StopSync_DoesNotThrow_WhenRunnerThrows()
+    {
+        var bin = CreateTempBinary();
+        try
+        {
+            var runner = new FakeProcessRunner().ThrowOnElevated();
+            Exception? ex = null;
+            try { WithRunner(bin, runner).StopSync(); } catch (Exception e) { ex = e; }
+            Assert.IsNull(ex);
+        }
+        finally { TryDelete(bin); }
+    }
+
     // ── MountWatcherService — ServiceName constant ────────────────────────────
 
     [TestMethod]
-    public void ServiceName_IsProductionName()
+    public void ServiceName_IsProductionReverseDnsName()
     {
-        // Protects against accidental debug-mode suffix being left in
-        Assert.IsFalse(MountWatcherService.ServiceName.EndsWith("-debug", StringComparison.Ordinal));
-        Assert.IsTrue(MountWatcherService.ServiceName.StartsWith("starsky-", StringComparison.Ordinal));
+        // Must match WatchServiceName.GetReverseDnsName() in the CLI — Windows uses the
+        // reverse-DNS form, NOT the Linux systemd name ("starsky-mountwatcher").
+        Assert.AreEqual("nl.qdraw.mountwatcher", MountWatcherService.ServiceName);
     }
 
     // ── FakeMountWatcherService ───────────────────────────────────────────────
@@ -307,6 +328,28 @@ public class MountWatcherServiceTests
             Assert.IsFalse(settings.Current.MountWatcherEnabled);
         }
         finally { TryDelete(tempFile); }
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnStartup_KeepsPreference_WhenEnableFailsButServiceIsRunning()
+    {
+        var (lifecycle, settings, fake) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = true;
+        fake.EnableResult = false;
+        fake.StatusResult = MountWatcherStatus.Running;
+        await lifecycle.OnStartupAsync();
+        Assert.IsTrue(settings.Current.MountWatcherEnabled);
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnStartup_KeepsPreference_WhenEnableFailsButServiceIsStopped()
+    {
+        var (lifecycle, settings, fake) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = true;
+        fake.EnableResult = false;
+        fake.StatusResult = MountWatcherStatus.Stopped;
+        await lifecycle.OnStartupAsync();
+        Assert.IsTrue(settings.Current.MountWatcherEnabled);
     }
 
     [TestMethod]

--- a/windows/starsky.Tests/Services/MountWatcherServiceTests.cs
+++ b/windows/starsky.Tests/Services/MountWatcherServiceTests.cs
@@ -1,0 +1,315 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Starsky.Desktop.Models;
+using Starsky.Desktop.Services;
+using starsky.Tests.FakeCreateAn;
+using System.Threading.Tasks;
+
+namespace starsky.Tests.Services;
+
+[TestClass]
+public class MountWatcherServiceTests
+{
+    // ── DesktopSettings ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void DesktopSettings_MountWatcherEnabled_DefaultsToFalse()
+    {
+        var s = new DesktopSettings();
+        Assert.IsFalse(s.MountWatcherEnabled);
+    }
+
+    [TestMethod]
+    public void DesktopSettings_MountWatcherEnabled_RoundTripsJson()
+    {
+        var original = new DesktopSettings { MountWatcherEnabled = true };
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<DesktopSettings>(json)!;
+
+        Assert.IsTrue(restored.MountWatcherEnabled);
+    }
+
+    [TestMethod]
+    public void DesktopSettings_MountWatcherEnabled_FalseRoundTripsJson()
+    {
+        var original = new DesktopSettings { MountWatcherEnabled = false };
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<DesktopSettings>(json)!;
+
+        Assert.IsFalse(restored.MountWatcherEnabled);
+    }
+
+    // ── FakeMountWatcherService ───────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task FakeMountWatcherService_Enable_SetsCalledFlag()
+    {
+        var fake = new FakeMountWatcherService();
+        var result = await fake.EnableAsync();
+
+        Assert.IsTrue(fake.EnableCalled);
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public async Task FakeMountWatcherService_Enable_ReturnsConfiguredResult()
+    {
+        var fake = new FakeMountWatcherService { EnableResult = false };
+        var result = await fake.EnableAsync();
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public async Task FakeMountWatcherService_Disable_SetsCalledFlag()
+    {
+        var fake = new FakeMountWatcherService();
+        var result = await fake.DisableAsync();
+
+        Assert.IsTrue(fake.DisableCalled);
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void FakeMountWatcherService_StopSync_SetsCalledFlag()
+    {
+        var fake = new FakeMountWatcherService();
+        fake.StopSync();
+
+        Assert.IsTrue(fake.StopSyncCalled);
+    }
+
+    [TestMethod]
+    public void FakeMountWatcherService_GetStatus_ReturnsConfiguredStatus()
+    {
+        var fake = new FakeMountWatcherService { StatusResult = MountWatcherStatus.Running };
+        Assert.AreEqual(MountWatcherStatus.Running, fake.GetStatus());
+    }
+
+    // ── MountWatcherService — binary-missing fast-paths ───────────────────────
+
+    [TestMethod]
+    public async Task MountWatcherService_Enable_ReturnsFalse_WhenBinaryMissing()
+    {
+        var svc = new MountWatcherService(Path.Combine(Path.GetTempPath(), "nonexistent_cli.exe"));
+        var result = await svc.EnableAsync();
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public async Task MountWatcherService_Disable_ReturnsFalse_WhenBinaryMissingAndServiceInstalled()
+    {
+        var svc = new MountWatcherService(Path.Combine(Path.GetTempPath(), "nonexistent_cli.exe"));
+        // GetStatus() → NotInstalled (no service registered in CI)
+        // DisableAsync with missing binary returns true only if service is also not installed
+        var result = await svc.DisableAsync();
+        // In CI/dev with no service installed, NotInstalled → true
+        // We only verify it doesn't throw
+        Assert.IsTrue(result == true || result == false);
+    }
+
+    [TestMethod]
+    public void MountWatcherService_StopSync_DoesNotThrow_WhenBinaryMissing()
+    {
+        var svc = new MountWatcherService(Path.Combine(Path.GetTempPath(), "nonexistent_cli.exe"));
+
+        Exception? ex = null;
+        try { svc.StopSync(); } catch (Exception e) { ex = e; }
+
+        Assert.IsNull(ex);
+    }
+
+    [TestMethod]
+    public void MountWatcherService_GetStatus_ReturnsNotInstalledOrUnknown_WhenServiceAbsent()
+    {
+        var svc = new MountWatcherService(Path.Combine(Path.GetTempPath(), "nonexistent_cli.exe"));
+        var status = svc.GetStatus();
+
+        Assert.IsTrue(status is MountWatcherStatus.NotInstalled or MountWatcherStatus.Unknown);
+    }
+
+    // ── UpdateService — StopSync called before apply ──────────────────────────
+
+    [TestMethod]
+    public async Task UpdateService_ApplyUpdateAsync_CallsStopSync_BeforeApply()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"starsky-mw-upd-{Guid.NewGuid()}.json");
+        try
+        {
+            var settings = new SettingsService(NullLogger<SettingsService>.Instance, tempFile);
+            settings.Load();
+
+            var fake = new FakeMountWatcherService();
+            var svc = new FakeUpdateServiceWithMountWatcher(settings, fake);
+
+            await svc.ApplyUpdateAsync();
+
+            Assert.IsTrue(fake.StopSyncCalled);
+        }
+        finally
+        {
+            try { File.Delete(tempFile); } catch { /* best-effort */ }
+        }
+    }
+
+    [TestMethod]
+    public async Task UpdateService_ApplyUpdateAsync_DoesNotThrow_WhenNoMountWatcherService()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"starsky-mw-upd2-{Guid.NewGuid()}.json");
+        try
+        {
+            var settings = new SettingsService(NullLogger<SettingsService>.Instance, tempFile);
+            settings.Load();
+
+            var svc = new FakeUpdateServiceWithMountWatcher(settings, null);
+
+            Exception? ex = null;
+            try { await svc.ApplyUpdateAsync(); } catch (Exception e) { ex = e; }
+
+            Assert.IsNull(ex);
+        }
+        finally
+        {
+            try { File.Delete(tempFile); } catch { /* best-effort */ }
+        }
+    }
+
+    private sealed class FakeUpdateServiceWithMountWatcher(
+        SettingsService settings,
+        IMountWatcherService? mountWatcherService)
+        : UpdateService(settings, NullLogger<UpdateService>.Instance,
+            mountWatcherService: mountWatcherService)
+    {
+        protected override bool HasPendingUpdate => true;
+        protected override Task DoApplyUpdateAsync() => Task.CompletedTask;
+    }
+
+    // ── MountWatcherLifecycle ─────────────────────────────────────────────────
+
+    private static (MountWatcherLifecycle lifecycle, SettingsService settings, FakeMountWatcherService fake)
+        CreateLifecycle(string? tempFile = null)
+    {
+        var file = tempFile ?? Path.Combine(Path.GetTempPath(), $"starsky-mwl-{Guid.NewGuid()}.json");
+        var settings = new SettingsService(NullLogger<SettingsService>.Instance, file);
+        settings.Load();
+        var fake = new FakeMountWatcherService();
+        var lifecycle = new MountWatcherLifecycle(
+            fake, settings, NullLogger<MountWatcherLifecycle>.Instance);
+        return (lifecycle, settings, fake);
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnStartupAsync_DoesNotCallEnable_WhenPreferenceIsFalse()
+    {
+        var (lifecycle, settings, fake) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = false;
+
+        await lifecycle.OnStartupAsync();
+
+        Assert.IsFalse(fake.EnableCalled);
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnStartupAsync_CallsEnable_WhenPreferenceIsTrue()
+    {
+        var (lifecycle, settings, fake) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = true;
+
+        await lifecycle.OnStartupAsync();
+
+        Assert.IsTrue(fake.EnableCalled);
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnStartupAsync_KeepsPreference_WhenEnableSucceeds()
+    {
+        var (lifecycle, settings, fake) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = true;
+        fake.EnableResult = true;
+
+        await lifecycle.OnStartupAsync();
+
+        Assert.IsTrue(settings.Current.MountWatcherEnabled);
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnStartupAsync_ClearsPreference_WhenEnableFails()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"starsky-mwl-fail-{Guid.NewGuid()}.json");
+        try
+        {
+            var (lifecycle, settings, fake) = CreateLifecycle(tempFile);
+            settings.Current.MountWatcherEnabled = true;
+            fake.EnableResult = false;
+
+            await lifecycle.OnStartupAsync();
+
+            Assert.IsFalse(settings.Current.MountWatcherEnabled);
+        }
+        finally
+        {
+            try { File.Delete(tempFile); } catch { /* best-effort */ }
+        }
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnStartupAsync_PersistsCleared_Preference_WhenEnableFails()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"starsky-mwl-persist-{Guid.NewGuid()}.json");
+        try
+        {
+            var (lifecycle, settings, fake) = CreateLifecycle(tempFile);
+            settings.Current.MountWatcherEnabled = true;
+            fake.EnableResult = false;
+
+            await lifecycle.OnStartupAsync();
+
+            // Reload from disk and verify the preference was persisted as false
+            var reloaded = new SettingsService(NullLogger<SettingsService>.Instance, tempFile);
+            reloaded.Load();
+            Assert.IsFalse(reloaded.Current.MountWatcherEnabled);
+        }
+        finally
+        {
+            try { File.Delete(tempFile); } catch { /* best-effort */ }
+        }
+    }
+
+    [TestMethod]
+    public void Lifecycle_OnShutdown_CallsStopSync_WhenPreferenceIsTrue()
+    {
+        var (lifecycle, settings, fake) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = true;
+
+        lifecycle.OnShutdown();
+
+        Assert.IsTrue(fake.StopSyncCalled);
+    }
+
+    [TestMethod]
+    public void Lifecycle_OnShutdown_DoesNotCallStopSync_WhenPreferenceIsFalse()
+    {
+        var (lifecycle, settings, fake) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = false;
+
+        lifecycle.OnShutdown();
+
+        Assert.IsFalse(fake.StopSyncCalled);
+    }
+
+    [TestMethod]
+    public async Task Lifecycle_OnShutdown_DoesNotCallStopSync_AfterEnableFails()
+    {
+        // If enable failed on startup and preference was cleared, shutdown should not stop
+        var (lifecycle, settings, fake) = CreateLifecycle();
+        settings.Current.MountWatcherEnabled = true;
+        fake.EnableResult = false;
+
+        await lifecycle.OnStartupAsync(); // clears MountWatcherEnabled
+        fake.StopSyncCalled = false;     // reset flag
+
+        lifecycle.OnShutdown();
+
+        Assert.IsFalse(fake.StopSyncCalled);
+    }
+}


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request introduces the new "Mount Watcher" feature to the Starsky Desktop application, allowing users to enable or disable a background service for monitoring mount points (drives/folders). The implementation includes service lifecycle management, integration with the update process, and a user interface for toggling the feature. The changes also ensure robust handling during application startup, shutdown, and updates.

**Mount Watcher Service Integration:**

- Added `MountWatcherService` and `IMountWatcherService` to encapsulate logic for installing, uninstalling, and checking the status of the mount watcher service, including running the CLI tool with elevation and handling service state. (`windows/Services/MountWatcherService.cs` [[1]](diffhunk://#diff-3cf5e02e7ab876837311493d2962608b973c423a27496f4f90f58eeb9e6f4c0dR1-R113) `windows/Services/IMountWatcherService.cs` [[2]](diffhunk://#diff-d27af87f0c3a73a34275684f82b8359533e970647386b218e65ec66b65a0620bR1-R11)
- Introduced `MountWatcherLifecycle` to manage startup and shutdown of the mount watcher, ensuring preferences are respected and the service is cleanly stopped before updates or shutdown. (`windows/Services/MountWatcherLifecycle.cs` [[1]](diffhunk://#diff-1f52a82100dcb8b098a1b0b5667a7d7b73ccc7e45b33be545c65133e5c247221R1-R48) `windows/App.xaml.cs` [[2]](diffhunk://#diff-59392b2c1c50f5382fd87fa9869b1dcb848afdb8bd3cd93658e805c810a717f0R17) [[3]](diffhunk://#diff-59392b2c1c50f5382fd87fa9869b1dcb848afdb8bd3cd93658e805c810a717f0R44-R56) [[4]](diffhunk://#diff-59392b2c1c50f5382fd87fa9869b1dcb848afdb8bd3cd93658e805c810a717f0R103-R105) [[5]](diffhunk://#diff-59392b2c1c50f5382fd87fa9869b1dcb848afdb8bd3cd93658e805c810a717f0R148)

**Application and Update Integration:**

- Integrated the mount watcher service into the main application startup and shutdown flow, and ensured it is stopped before applying updates to prevent file lock issues. (`windows/App.xaml.cs` [[1]](diffhunk://#diff-59392b2c1c50f5382fd87fa9869b1dcb848afdb8bd3cd93658e805c810a717f0R44-R56) [[2]](diffhunk://#diff-59392b2c1c50f5382fd87fa9869b1dcb848afdb8bd3cd93658e805c810a717f0R103-R105) [[3]](diffhunk://#diff-59392b2c1c50f5382fd87fa9869b1dcb848afdb8bd3cd93658e805c810a717f0R148); `windows/Services/UpdateService.cs` [[4]](diffhunk://#diff-d2dc4fee790186d83faa9cd90cade2a630e45b1e599d1b15b3f847ea6123ca96R20-R31) [[5]](diffhunk://#diff-d2dc4fee790186d83faa9cd90cade2a630e45b1e599d1b15b3f847ea6123ca96L86-R91)
- Extended the `UpdateService`, `WindowManager`, and `MainWindowOptions` to accept and pass through the mount watcher service dependency. (`windows/Services/UpdateService.cs` [[1]](diffhunk://#diff-d2dc4fee790186d83faa9cd90cade2a630e45b1e599d1b15b3f847ea6123ca96R20-R31) `windows/Services/WindowManager.cs` [[2]](diffhunk://#diff-69ec912f0e05911307eb4a8e2e0249cd490d70de477575ebf59ad9e46002f753L20-R21) [[3]](diffhunk://#diff-69ec912f0e05911307eb4a8e2e0249cd490d70de477575ebf59ad9e46002f753L69-R71) `windows/Models/MainWindowOptions.cs` [[4]](diffhunk://#diff-75b56540256479759e98af3f02a29ec1e52f1ad5b5440831abc5001c13003e49R20)

**User Interface Enhancements:**

- Added a new "Mount Watcher" menu to the application, allowing users to view the current status and enable/disable the service with appropriate feedback and error handling. (`windows/Windows/MainWindow.xaml` [[1]](diffhunk://#diff-d169f74df3d489a79bbf677c93dcbf353e9c54c0395049705cb1febb6b0a54c1R34-R38) `windows/Windows/MainWindow.xaml.cs` [[2]](diffhunk://#diff-b6204eacc158f3353af9e55e8fb7c99581fbf4e05ddc19a643f1bb77873c859cR27) [[3]](diffhunk://#diff-b6204eacc158f3353af9e55e8fb7c99581fbf4e05ddc19a643f1bb77873c859cR45) [[4]](diffhunk://#diff-b6204eacc158f3353af9e55e8fb7c99581fbf4e05ddc19a643f1bb77873c859cR349-R404)

**Settings and Testing:**

- Added a `MountWatcherEnabled` property to `DesktopSettings` to persist user preference, and updated related tests to verify default values. (`windows/Models/DesktopSettings.cs` [[1]](diffhunk://#diff-76c22fc63d88a2b69ab851c8b8302c446116caaa6ebe22a979cf43e3b1dcbc71R11) `windows/starsky.Tests/Models/DesktopSettingsTests.cs` [[2]](diffhunk://#diff-b1f19bf435a803c7783c8bbc3e9eaf32e3f34f5ee69df48ba075ea3c5e64b290R17)
- Added a `FakeMountWatcherService` for unit testing. (`windows/starsky.Tests/FakeCreateAn/FakeMountWatcherService.cs` [windows/starsky.Tests/FakeCreateAn/FakeMountWatcherService.csR1-R18](diffhunk://#diff-3b1180455a804071c13e4164dfd24c440275978ce00ef68af408842bad4bba9eR1-R18))

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
