### PR TITLE
Skip new lines in Preferences > ReadonlyFolders & mac os tests

### DIFF
--- a/history.md
+++ b/history.md
@@ -44,9 +44,10 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 _Note: Windows Desktop: Uninstall versions below 0.8.2 before updating._
 
-- [x] (Fixed) _Front-end_ Wait for backend when rename  (PR #3312)
+- [x] (Fixed) _Front-end_ Skip new lines in Preferences > ReadonlyFolders (PR #3313)
+- [x] (Fixed) _Front-end_ Wait for backend when rename (PR #3312)
 - [x] (Fixed) _Back-end_ Handle concurrency in `ThumbnailQuery.UpdateAsync` (PR #3312)
-- [x] (Fixed) _App_ macOS: Backend process not terminated on app quit  (PR #3312)
+- [x] (Fixed) _App_ macOS: Backend process not terminated on app quit (PR #3312)
 - [x] (Fixed) _App_ macOS: Avoid backend restart when shutdown initiated (PR #3312)
 
 ## version 0.9.1 - 2026-09-07 {#0.9.1}

--- a/mac/starskyTests/App/AppCoreTests.swift
+++ b/mac/starskyTests/App/AppCoreTests.swift
@@ -584,7 +584,7 @@ final class AppCoreTests: XCTestCase {
         s.mountWatcherEnabled = true
         core.settingsService.save(s)
         core.beginTermination()
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        await waitUntil { mws.stopSyncCalled }
         XCTAssertTrue(mws.stopSyncCalled)
     }
 
@@ -593,7 +593,16 @@ final class AppCoreTests: XCTestCase {
         let core = makeCore(mountWatcherService: mws)
         // mountWatcherEnabled defaults to false
         core.beginTermination()
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        // no positive signal to wait on here, so give the background queue a generous head start
+        try? await Task.sleep(nanoseconds: 300_000_000)
         XCTAssertFalse(mws.stopSyncCalled)
+    }
+
+    /// Polls a condition on a background queue's async work, avoiding flaky fixed sleeps under CI load.
+    private func waitUntil(timeout: TimeInterval = 2, _ condition: @escaping () -> Bool) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
     }
 }

--- a/starsky/starsky/clientapp/src/components/organisms/preferences-app-settings-readonly-folders/preferences-app-settings-readonly-folders.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/preferences-app-settings-readonly-folders/preferences-app-settings-readonly-folders.spec.tsx
@@ -270,6 +270,45 @@ describe("PreferencesAppSettingsReadonlyFolders", () => {
         component.unmount();
       });
     });
+
+    it("trims newlines from contentEditable innerText before saving", async () => {
+      const permissions = {
+        statusCode: 200,
+        data: ["AppSettingsWrite"]
+      } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: ["/2024"] }
+      } as IConnectionDefault;
+
+      jest.spyOn(useFetch, "default").mockImplementation((url) => {
+        if (url === new UrlQuery().UrlAccountPermissions()) return permissions;
+        return appSettings;
+      });
+
+      const mockResult: Promise<IConnectionDefault> = Promise.resolve({
+        statusCode: 200,
+        data: null
+      });
+      const fetchPostSpy = jest
+        .spyOn(FetchPost, "default")
+        .mockImplementationOnce(() => mockResult);
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      const formControl = screen.getByTestId("form-control");
+      formControl.innerText = "/renamed\n";
+      await act(async () => {
+        fireEvent.focusOut(formControl);
+        await mockResult;
+      });
+
+      expect(fetchPostSpy).toHaveBeenCalledWith(expect.anything(), "ReadOnlyFolders%5B0%5D=%2Frenamed");
+
+      act(() => {
+        component.unmount();
+      });
+    });
   });
 
   describe("error handling", () => {

--- a/starsky/starsky/clientapp/src/components/organisms/preferences-app-settings-readonly-folders/preferences-app-settings-readonly-folders.spec.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/preferences-app-settings-readonly-folders/preferences-app-settings-readonly-folders.spec.tsx
@@ -309,6 +309,48 @@ describe("PreferencesAppSettingsReadonlyFolders", () => {
         component.unmount();
       });
     });
+
+    it("keeps other rows unchanged when blurring a single row", async () => {
+      const permissions = {
+        statusCode: 200,
+        data: ["AppSettingsWrite"]
+      } as IConnectionDefault;
+      const appSettings = {
+        statusCode: 200,
+        data: { readOnlyFolders: ["/2024", "/2023"] }
+      } as IConnectionDefault;
+
+      jest.spyOn(useFetch, "default").mockImplementation((url) => {
+        if (url === new UrlQuery().UrlAccountPermissions()) return permissions;
+        return appSettings;
+      });
+
+      const mockResult: Promise<IConnectionDefault> = Promise.resolve({
+        statusCode: 200,
+        data: null
+      });
+      const fetchPostSpy = jest
+        .spyOn(FetchPost, "default")
+        .mockImplementationOnce(() => mockResult);
+
+      const component = render(<PreferencesAppSettingsReadonlyFolders />);
+
+      const formControls = screen.getAllByTestId("form-control");
+      formControls[0].innerText = "/renamed";
+      await act(async () => {
+        fireEvent.focusOut(formControls[0]);
+        await mockResult;
+      });
+
+      expect(fetchPostSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        "ReadOnlyFolders%5B0%5D=%2Frenamed&ReadOnlyFolders%5B1%5D=%2F2023"
+      );
+
+      act(() => {
+        component.unmount();
+      });
+    });
   });
 
   describe("error handling", () => {

--- a/starsky/starsky/clientapp/src/components/organisms/preferences-app-settings-readonly-folders/preferences-app-settings-readonly-folders.tsx
+++ b/starsky/starsky/clientapp/src/components/organisms/preferences-app-settings-readonly-folders/preferences-app-settings-readonly-folders.tsx
@@ -84,7 +84,9 @@ const PreferencesAppSettingsReadonlyFolders: React.FunctionComponent = () => {
   }
 
   function handleBlur(id: number, value: string) {
-    const updated = rows.map((r) => (r.id === id ? { ...r, folder: value } : r));
+    // contentEditable divs can leave a trailing newline in innerText
+    const trimmed = value.replace(/[\r\n]+/g, "").trim();
+    const updated = rows.map((r) => (r.id === id ? { ...r, folder: trimmed } : r));
     setRows(updated);
     saveAll(updated);
   }


### PR DESCRIPTION
# PR Details 
## Description / Motivation and Context

This pull request introduces improvements to both the backend test reliability and frontend user input handling. The backend test now uses a polling mechanism to avoid flaky sleeps, while the frontend ensures that newlines are trimmed from contentEditable input before saving, with a corresponding test added.

**Backend Test Reliability Improvements:**

* Replaced a fixed sleep in `AppCoreTests` with a new `waitUntil` polling helper to avoid flaky tests under CI load. [[1]](diffhunk://#diff-cad4b745295304049c8a31113e957eaebdca1db3cabce0c582cb4a758444a1ddL587-R587) [[2]](diffhunk://#diff-cad4b745295304049c8a31113e957eaebdca1db3cabce0c582cb4a758444a1ddL596-R607)

**Frontend Input Handling and Testing:**

* Updated `handleBlur` in `PreferencesAppSettingsReadonlyFolders` to trim newlines from the contentEditable `innerText` before saving, preventing unintended characters from being persisted.
* Added a test to ensure newlines are trimmed from contentEditable input before saving in `preferences-app-settings-readonly-folders.spec.tsx`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
