### PR TITLE
Root cause: beginTermination() dispatched NSApplication.shared.reply(…

### DIFF
--- a/history.md
+++ b/history.md
@@ -50,6 +50,8 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 _Note: Windows Desktop: Uninstall versions below 0.8.2 before updating_
 
+- [x] (Fixed) _App_ macOS: Show name of app in Splash screen (PR #3317)
+- [x] (Fixed) _App_ macOS: Manually closing a window no longer causes it to reopen on next launch (PR #3317)
 - [x] (Changed) _App_ macOS: Allow for Page Up, Page Down, Home and End keyboard shortcuts (PR #3315)
 - [x] (Changed) _App_ macOS: Only re-sign bundled backend when it exits unexpectedly on first launch (PR #3315)
 - [x] (Added) _App_ macOS: Dynamic Dock menu listing open windows with active-window highlight (PR #3315)

--- a/mac/starsky/App/AppCore.swift
+++ b/mac/starsky/App/AppCore.swift
@@ -223,7 +223,7 @@ class AppCore {
         DispatchQueue.main.async {
             reply()
         }
-        DispatchQueue.global(qos: .background).async {
+        DispatchQueue.global(qos: .utility).async {
             mws?.stopSync()
             fws.stop()
         }

--- a/mac/starsky/App/AppCore.swift
+++ b/mac/starsky/App/AppCore.swift
@@ -156,7 +156,6 @@ class AppCore {
 
         await MainActor.run {
             windowManager.restoreWindows()
-            NSApp.activate(ignoringOtherApps: true)
             onWindowsReady()
         }
 

--- a/mac/starsky/App/AppCore.swift
+++ b/mac/starsky/App/AppCore.swift
@@ -15,6 +15,7 @@ class AppCore {
 
     // Injected side-effectful operations — override in tests
     var terminate: () -> Void
+    var replyToTerminate: () -> Void
     var showError: @MainActor (String) -> Void
     var urlOpener: (URL) -> Void
     var healthCheckSession: URLSession
@@ -40,6 +41,7 @@ class AppCore {
         updateService: UpdateService,
         windowManager: any WindowManagerProtocol,
         terminate: @escaping () -> Void = { NSApplication.shared.terminate(nil) },
+        replyToTerminate: @escaping () -> Void = { NSApplication.shared.reply(toApplicationShouldTerminate: true) },
         showError: @escaping @MainActor (String) -> Void = { ErrorWindowController.show(message: $0) },
         urlOpener: @escaping (URL) -> Void = { NSWorkspace.shared.open($0) },
         healthCheckSession: URLSession = .shared,
@@ -62,6 +64,7 @@ class AppCore {
         self.updateService = updateService
         self.windowManager = windowManager
         self.terminate = terminate
+        self.replyToTerminate = replyToTerminate
         self.showError = showError
         self.urlOpener = urlOpener
         self.healthCheckSession = healthCheckSession
@@ -217,8 +220,9 @@ class AppCore {
         // Reply before any slow cleanup so the app disappears instantly for the user.
         // applicationWillTerminate sends SIGKILL as the final safety net.
         bs.beginShutdown()
+        let reply = replyToTerminate
         DispatchQueue.main.async {
-            NSApplication.shared.reply(toApplicationShouldTerminate: true)
+            reply()
         }
         DispatchQueue.global(qos: .background).async {
             mws?.stopSync()

--- a/mac/starsky/Presentation/MainWindowPresenter.swift
+++ b/mac/starsky/Presentation/MainWindowPresenter.swift
@@ -10,6 +10,7 @@ protocol MainWindowView: AnyObject {
     func allCookies() async -> [HTTPCookie]
 }
 
+@MainActor
 class MainWindowPresenter {
     weak var view: MainWindowView?
 
@@ -124,8 +125,12 @@ class MainWindowPresenter {
     }
 
     func windowWillClose() {
-        if let url = view?.currentURL() {
-            pageDidLoad(url: url, frame: view?.windowFrame, isZoomed: view?.windowIsZoomed ?? false)
+        if windowManager.isTerminating {
+            if let url = view?.currentURL() {
+                pageDidLoad(url: url, frame: view?.windowFrame, isZoomed: view?.windowIsZoomed ?? false)
+            }
+        } else {
+            routePersistenceService.removeRoute(index: index)
         }
     }
 }

--- a/mac/starsky/Presentation/WindowManagerProtocol.swift
+++ b/mac/starsky/Presentation/WindowManagerProtocol.swift
@@ -2,6 +2,7 @@ import Foundation
 
 @MainActor
 protocol WindowManagerProtocol: AnyObject {
+    var isTerminating: Bool { get }
     func openMainWindow(route: String?)
     func openMainWindow()
     func reopenAll()
@@ -14,6 +15,7 @@ protocol WindowManagerProtocol: AnyObject {
 
 // Default no-op implementations so existing conformers only need to add what they use.
 extension WindowManagerProtocol {
+    var isTerminating: Bool { false }
     func openMainWindow() {
         // Default behavior: forward to the route-based API with no route.
         openMainWindow(route: nil)

--- a/mac/starsky/Services/FileDownloadService.swift
+++ b/mac/starsky/Services/FileDownloadService.swift
@@ -214,7 +214,8 @@ class FileDownloadService: @unchecked Sendable {
 
         for (rawPath, flag) in zip(paths, flags) {
             guard flag & isFile != 0 else { continue }
-            guard flag & isRemoved == 0 else { continue }
+            // Skip pure deletions; allow atomic overwrites that set Removed alongside Renamed/Created.
+            guard flag & isRemoved == 0 || flag & isChange != 0 else { continue }
             guard flag & isChange != 0 else { continue }
             guard !rawPath.hasSuffix(".tmp") else { continue }
 

--- a/mac/starsky/WindowManager.swift
+++ b/mac/starsky/WindowManager.swift
@@ -4,6 +4,7 @@ class WindowManager {
     private var windows: [MainWindowController] = []
     private var localPort: Int = 0
     private var isReopening = false
+    private(set) var isTerminating = false
     private let settingsService: SettingsService
     private let routePersistenceService: RoutePersistenceService
     private let navigationService: NavigationService
@@ -113,6 +114,7 @@ class WindowManager {
 
     @MainActor
     func closeAll() {
+        isTerminating = true
         for controller in windows {
             controller.window?.close()
         }
@@ -146,7 +148,7 @@ class WindowManager {
     @MainActor
     func remove(controller: MainWindowController) {
         windows.removeAll { $0 === controller }
-        if windows.isEmpty && !isReopening {
+        if windows.isEmpty && !isReopening && !isTerminating {
             NSApplication.shared.terminate(nil)
         }
     }

--- a/mac/starsky/Windows/SplashWindowController.swift
+++ b/mac/starsky/Windows/SplashWindowController.swift
@@ -1,6 +1,7 @@
 import AppKit
 
 class SplashWindowController: NSWindowController {
+    private let titleLabel = NSTextField(labelWithString: "Starsky")
     private let statusLabel = NSTextField(labelWithString: NSLocalizedString("splash.status.starting", comment: ""))
     private let hintLabel = NSTextField(labelWithString: "")
     private var isDismissable = false
@@ -39,7 +40,13 @@ class SplashWindowController: NSWindowController {
             clickView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
         ])
 
-        statusLabel.textColor = .white
+        titleLabel.textColor = .white
+        titleLabel.font = NSFont.boldSystemFont(ofSize: 42)
+        titleLabel.alignment = .center
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        clickView.addSubview(titleLabel)
+
+        statusLabel.textColor = NSColor.white.withAlphaComponent(0.75)
         statusLabel.font = NSFont.systemFont(ofSize: 13)
         statusLabel.alignment = .center
         statusLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -52,12 +59,16 @@ class SplashWindowController: NSWindowController {
         clickView.addSubview(hintLabel)
 
         NSLayoutConstraint.activate([
+            titleLabel.centerXAnchor.constraint(equalTo: clickView.centerXAnchor),
+            titleLabel.centerYAnchor.constraint(equalTo: clickView.centerYAnchor, constant: -30),
+            titleLabel.widthAnchor.constraint(equalTo: clickView.widthAnchor, constant: -20),
+
             statusLabel.centerXAnchor.constraint(equalTo: clickView.centerXAnchor),
-            statusLabel.centerYAnchor.constraint(equalTo: clickView.centerYAnchor, constant: -10),
+            statusLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 12),
             statusLabel.widthAnchor.constraint(equalTo: clickView.widthAnchor, constant: -20),
 
             hintLabel.centerXAnchor.constraint(equalTo: clickView.centerXAnchor),
-            hintLabel.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 8),
+            hintLabel.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 6),
             hintLabel.widthAnchor.constraint(equalTo: clickView.widthAnchor, constant: -20)
         ])
     }

--- a/mac/starskyTests/App/AppCoreTests.swift
+++ b/mac/starskyTests/App/AppCoreTests.swift
@@ -111,6 +111,7 @@ private func makeCore(
         updateService: UpdateService(settingsService: settings),
         windowManager: windowManager,
         terminate: {},
+        replyToTerminate: {},
         showError: { _ in },
         urlOpener: { _ in },
         healthCheckSession: FakeURLProtocol.makeSession(),
@@ -350,7 +351,7 @@ final class AppCoreTests: XCTestCase {
         let watcher = MockFileWatcherService()
         let core = makeCore(fileWatcherService: watcher)
         core.beginTermination()
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        await waitUntil { watcher.stopCalled }
         XCTAssertTrue(watcher.stopCalled)
     }
 

--- a/mac/starskyTests/Presentation/MainWindowPresenterTests.swift
+++ b/mac/starskyTests/Presentation/MainWindowPresenterTests.swift
@@ -104,9 +104,10 @@ final class MainWindowPresenterTests: XCTestCase {
         XCTAssertTrue(routePersistenceService.getRoutes().first?.isMaximized ?? false)
     }
 
-    // MARK: - windowWillClose
+    // MARK: - windowWillClose (terminating)
 
-    func testWindowWillClosePreservesRouteForNextLaunch() {
+    func testWindowWillClosePreservesRouteWhenTerminating() {
+        mockWindowManager.isTerminating = true
         let presenter = makePresenter(index: 0)
         presenter.pageDidLoad(url: URL(string: "http://localhost:5000/photos")!, frame: nil, isZoomed: false)
         presenter.windowWillClose()
@@ -114,7 +115,8 @@ final class MainWindowPresenterTests: XCTestCase {
         XCTAssertEqual(routePersistenceService.getRoutes().first?.route, "/photos")
     }
 
-    func testWindowWillCloseSavesGeometryFromView() {
+    func testWindowWillCloseSavesGeometryFromViewWhenTerminating() {
+        mockWindowManager.isTerminating = true
         let presenter = makePresenter(index: 0)
         let mockView = MockMainWindowView()
         mockView.stubbedURL = URL(string: "http://localhost:5000/photos")
@@ -129,7 +131,8 @@ final class MainWindowPresenterTests: XCTestCase {
         XCTAssertEqual(saved?.height, 700)
     }
 
-    func testWindowWillClosePreservesAllRoutesForMultipleWindows() {
+    func testWindowWillClosePreservesAllRoutesForMultipleWindowsWhenTerminating() {
+        mockWindowManager.isTerminating = true
         let p0 = makePresenter(index: 0)
         let p1 = makePresenter(index: 1)
         p0.pageDidLoad(url: URL(string: "http://localhost:5000/a")!, frame: nil, isZoomed: false)
@@ -137,6 +140,41 @@ final class MainWindowPresenterTests: XCTestCase {
         p0.windowWillClose()
         // Both routes must remain so both windows restore on next launch
         XCTAssertEqual(routePersistenceService.getRoutes().count, 2)
+    }
+
+    // MARK: - windowWillClose (manual close, not terminating)
+
+    func testWindowWillCloseRemovesRouteWhenNotTerminating() {
+        let presenter = makePresenter(index: 0)
+        presenter.pageDidLoad(url: URL(string: "http://localhost:5000/photos")!, frame: nil, isZoomed: false)
+        XCTAssertEqual(routePersistenceService.getRoutes().count, 1)
+        presenter.windowWillClose()
+        // Route must be removed — a manually closed window should not reopen on next launch
+        XCTAssertEqual(routePersistenceService.getRoutes().count, 0)
+    }
+
+    func testWindowWillCloseRemovesOnlyClosedWindowRouteWhenNotTerminating() {
+        let p0 = makePresenter(index: 0)
+        let p1 = makePresenter(index: 1)
+        p0.pageDidLoad(url: URL(string: "http://localhost:5000/a")!, frame: nil, isZoomed: false)
+        p1.pageDidLoad(url: URL(string: "http://localhost:5000/b")!, frame: nil, isZoomed: false)
+        p1.windowWillClose()
+        // Only window 1 was closed; window 0 must still restore on next launch
+        let remaining = routePersistenceService.getRoutes()
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?.route, "/a")
+    }
+
+    func testWindowWillCloseDoesNotSaveGeometryWhenNotTerminating() {
+        let presenter = makePresenter(index: 0)
+        let mockView = MockMainWindowView()
+        mockView.stubbedURL = URL(string: "http://localhost:5000/photos")
+        mockView.stubbedFrame = NSRect(x: 10, y: 20, width: 900, height: 700)
+        presenter.view = mockView
+        presenter.pageDidLoad(url: URL(string: "http://localhost:5000/photos")!, frame: nil, isZoomed: false)
+        presenter.windowWillClose()
+        // Route was removed, not updated — no stale geometry entry
+        XCTAssertEqual(routePersistenceService.getRoutes().count, 0)
     }
 
     // MARK: - editFileInEditor
@@ -273,6 +311,7 @@ final class MainWindowPresenterTests: XCTestCase {
 
 @MainActor
 private class MockWindowManager: WindowManagerProtocol {
+    var isTerminating: Bool = false
     var openMainWindowCalled = false
     var openMainWindowRoute: String?
     var reopenAllCalled = false


### PR DESCRIPTION
…toApplicationShouldTerminate: true) to DispatchQueue.main.async — in the XCTest process this can trigger actual app termination, killing the process before the background GCD queue gets to run fws.stop() / mws.stopSync().


This pull request adds a new `replyToTerminate` dependency to the `AppCore` class to improve testability and flexibility around application termination behavior. The main changes involve injecting this new operation, updating the shutdown logic to use it, and adapting tests accordingly.

**Dependency injection and shutdown improvements:**

* Added a new `replyToTerminate` property to `AppCore`, allowing the reply to the termination request to be injected [[1]](diffhunk://#diff-0eb8b2a4f620e569a90c99ac6bf711a664938ccbbbc05aa7233268ff34553868R18) [[2]](diffhunk://#diff-0eb8b2a4f620e569a90c99ac6bf711a664938ccbbbc05aa7233268ff34553868R44) [[3]](diffhunk://#diff-0eb8b2a4f620e569a90c99ac6bf711a664938ccbbbc05aa7233268ff34553868R67).
* Updated the termination sequence in `AppCore.beginTermination()` to use the injected `replyToTerminate` closure instead of directly calling `NSApplication.shared.reply(toApplicationShouldTerminate:)`.

**Testing updates:**

* Updated test helpers and test cases to provide a `replyToTerminate` closure when constructing `AppCore` in tests.
* Improved the termination test to explicitly wait for the file watcher to stop using `await waitUntil` instead of a fixed sleep, making the test more robust.

# PR Details 
## Description / Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
