### PR TITLE
Windows: Manually closing a window no longer causes it to reopen on n…

### DIFF
--- a/history.md
+++ b/history.md
@@ -44,8 +44,7 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## version 0.9.3 - _(Unreleased)_ - 2026-?-? {#0.9.3}
 
-- [x] (Fixed) _App_ Windows: Manually closing a window no longer causes it to reopen on next launch (PR #3317)
-
+- [x] (Fixed) _App_ Windows: Manually closing a window no longer causes it to reopen on next launch (PR #3318)
 
 ## version 0.9.2 - 2026-09-08 {#0.9.2}
 

--- a/history.md
+++ b/history.md
@@ -44,7 +44,8 @@ Semantic Versioning 2.0.0 is from version 0.1.6+
 
 ## version 0.9.3 - _(Unreleased)_ - 2026-?-? {#0.9.3}
 
-- nothing yet
+- [x] (Fixed) _App_ Windows: Manually closing a window no longer causes it to reopen on next launch (PR #3317)
+
 
 ## version 0.9.2 - 2026-09-08 {#0.9.2}
 

--- a/mac/starsky/WindowManager.swift
+++ b/mac/starsky/WindowManager.swift
@@ -131,6 +131,7 @@ class WindowManager {
         isReopening = true
         routePersistenceService.clearAll()
         closeAll()
+        isTerminating = false
         openMainWindow()
         isReopening = false
     }

--- a/mac/starskyTests/WindowManagerTests.swift
+++ b/mac/starskyTests/WindowManagerTests.swift
@@ -43,6 +43,21 @@ final class WindowManagerTests: XCTestCase {
     }
 
     @MainActor
+    func testCloseAllSetsIsTerminating() {
+        sut.closeAll()
+        XCTAssertTrue(sut.isTerminating)
+    }
+
+    @MainActor
+    func testReopenAllResetsIsTerminating() {
+        sut.setLocalPort(1)
+        sut.closeAll()
+        XCTAssertTrue(sut.isTerminating)
+        sut.reopenAll()
+        XCTAssertFalse(sut.isTerminating)
+    }
+
+    @MainActor
     func testReloadAllWithNoWindows() {
         sut.reloadAll()
     }

--- a/windows/Models/MainWindowOptions.cs
+++ b/windows/Models/MainWindowOptions.cs
@@ -6,7 +6,6 @@ namespace Starsky.Desktop.Models;
 public sealed record MainWindowOptions
 {
     public required SettingsService Settings { get; init; }
-    public required RoutePersistenceService Routes { get; init; }
     public required WebViewEnvironmentService WebViewEnv { get; init; }
     public required FileDownloadService FileDownload { get; init; }
     public required FileWatcherService Watcher { get; init; }
@@ -15,7 +14,6 @@ public sealed record MainWindowOptions
     public required string BaseUrl { get; init; }
     public required string InitialRoute { get; init; }
     public required SavedWindowState Geometry { get; init; }
-    public required int WindowIndex { get; init; }
     public required UpdateService UpdateService { get; init; }
     public IMountWatcherService? MountWatcherService { get; init; }
 }

--- a/windows/Services/RoutePersistenceService.cs
+++ b/windows/Services/RoutePersistenceService.cs
@@ -39,6 +39,13 @@ public class RoutePersistenceService(SettingsService settings)
         settings.Save();
     }
 
+    public void SaveAll(IReadOnlyList<SavedWindowState> states)
+    {
+        settings.Current.Windows.Clear();
+        settings.Current.Windows.AddRange(states);
+        settings.Save();
+    }
+
     public void ClearAll()
     {
         settings.Current.Windows.Clear();

--- a/windows/Services/WindowManager.cs
+++ b/windows/Services/WindowManager.cs
@@ -59,7 +59,6 @@ public class WindowManager(
         var window = new MainWindow(new MainWindowOptions
         {
             Settings = settings,
-            Routes = routes,
             WebViewEnv = webViewEnv,
             FileDownload = fileDownload,
             Watcher = watcher,
@@ -68,7 +67,6 @@ public class WindowManager(
             BaseUrl = baseUrl,
             InitialRoute = route ?? "?f=/",
             Geometry = state,
-            WindowIndex = _mainWindows.Count,
             UpdateService = updateService,
             MountWatcherService = mountWatcherService
         });
@@ -101,9 +99,23 @@ public class WindowManager(
         }
     }
 
-    public void CloseAll()
+    private List<SavedWindowState> CollectStates(MainWindow? exclude = null) =>
+        _mainWindows
+            .Where(w => w != exclude)
+            .Select(w => w.GetCurrentState())
+            .ToList();
+
+    internal void PersistCurrentState(MainWindow? exclude = null) =>
+        routes.SaveAll(CollectStates(exclude));
+
+    public void CloseAll(bool saveState = true)
     {
         IsTerminating = true;
+        if (saveState)
+        {
+            routes.SaveAll(CollectStates());
+        }
+
         foreach (var w in _mainWindows.ToList())
         {
             try { w.Close(); } catch { /* best-effort */ }
@@ -113,8 +125,8 @@ public class WindowManager(
 
     public void ReopenAll()
     {
+        CloseAll(saveState: false);
         routes.ClearAll();
-        CloseAll();
         IsTerminating = false;
         OpenMainWindow(null, null);
     }

--- a/windows/Services/WindowManager.cs
+++ b/windows/Services/WindowManager.cs
@@ -23,6 +23,8 @@ public class WindowManager(
 	private readonly List<MainWindow> _mainWindows = [];
     private int? _localPort;
 
+    public bool IsTerminating { get; private set; }
+
     public void SetLocalPort(int port) => _localPort = port;
 
     internal static SavedWindowState ResolveGeometry(
@@ -75,7 +77,7 @@ public class WindowManager(
         window.Closed += (_, _) =>
         {
             _mainWindows.Remove(window);
-            if (_mainWindows.Count == 0 && Application.Current != null)
+            if (_mainWindows.Count == 0 && !IsTerminating && Application.Current != null)
             {
 	            Application.Current.Shutdown();
             }
@@ -101,6 +103,7 @@ public class WindowManager(
 
     public void CloseAll()
     {
+        IsTerminating = true;
         foreach (var w in _mainWindows.ToList())
         {
             try { w.Close(); } catch { /* best-effort */ }
@@ -112,6 +115,7 @@ public class WindowManager(
     {
         routes.ClearAll();
         CloseAll();
+        IsTerminating = false;
         OpenMainWindow(null, null);
     }
 

--- a/windows/Services/WindowManager.cs
+++ b/windows/Services/WindowManager.cs
@@ -25,6 +25,10 @@ public class WindowManager(
 
     public bool IsTerminating { get; private set; }
 
+    // True when this is the only window left; used by MainWindow_Closing to decide
+    // whether to save itself (last window = app is exiting, keep the state).
+    internal bool IsLastOpenWindow => _mainWindows.Count == 1;
+
     public void SetLocalPort(int port) => _localPort = port;
 
     internal static SavedWindowState ResolveGeometry(
@@ -111,7 +115,10 @@ public class WindowManager(
     public void CloseAll(bool saveState = true)
     {
         IsTerminating = true;
-        if (saveState)
+        // Skip when _mainWindows is already empty: the last window saved its own
+        // state in MainWindow_Closing before triggering Shutdown(), so overwriting
+        // with an empty list here would discard it.
+        if (saveState && _mainWindows.Count > 0)
         {
             routes.SaveAll(CollectStates());
         }

--- a/windows/Windows/MainWindow.xaml.cs
+++ b/windows/Windows/MainWindow.xaml.cs
@@ -137,9 +137,11 @@ public partial class MainWindow
     {
         if (!_windowManager.IsTerminating)
         {
-            // Snapshot all remaining windows (excluding this one) so the closed
-            // window is not restored on next launch, regardless of window count.
-            _windowManager.PersistCurrentState(exclude: this);
+            // When this is the last window, closing it exits the app — treat it like
+            // an app shutdown and keep its state so it's restored on next launch.
+            // When other windows remain, exclude this one so it's not restored.
+            var exclude = _windowManager.IsLastOpenWindow ? null : this;
+            _windowManager.PersistCurrentState(exclude: exclude);
         }
         // When terminating, CloseAll() already snapshotted all windows before Close() was called.
     }

--- a/windows/Windows/MainWindow.xaml.cs
+++ b/windows/Windows/MainWindow.xaml.cs
@@ -139,7 +139,14 @@ public partial class MainWindow
 
     private void MainWindow_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
-        _routes.SaveRoute(_windowIndex, _currentRoute, GetCurrentGeometry());
+        if (_windowManager.IsTerminating)
+        {
+            _routes.SaveRoute(_windowIndex, _currentRoute, GetCurrentGeometry());
+        }
+        else
+        {
+            _routes.RemoveRoute(_windowIndex);
+        }
     }
 
     private void MainWindow_KeyDown(object sender, KeyEventArgs e)

--- a/windows/Windows/MainWindow.xaml.cs
+++ b/windows/Windows/MainWindow.xaml.cs
@@ -18,7 +18,6 @@ public partial class MainWindow
     private const string ReleasesUrl = "https://github.com/qdraw/starsky/releases"; 
 
     private readonly SettingsService _settings;
-    private readonly RoutePersistenceService _routes;
     private readonly WebViewEnvironmentService _webViewEnv;
     private readonly FileDownloadService _fileDownload;
     private readonly FileWatcherService _watcher;
@@ -28,7 +27,6 @@ public partial class MainWindow
     private readonly ILogger _logger;
 
     private readonly string _baseUrl;
-    private readonly int _windowIndex;
     private string _currentRoute;
 
     public MainWindow(MainWindowOptions options)
@@ -36,7 +34,6 @@ public partial class MainWindow
         InitializeComponent();
 
         _settings = options.Settings;
-        _routes = options.Routes;
         _webViewEnv = options.WebViewEnv;
         _fileDownload = options.FileDownload;
         _watcher = options.Watcher;
@@ -45,7 +42,6 @@ public partial class MainWindow
         _mountWatcherService = options.MountWatcherService;
         _logger = options.Logger;
         _baseUrl = options.BaseUrl;
-        _windowIndex = options.WindowIndex;
         _currentRoute = options.InitialRoute;
 
         Left = options.Geometry.Left;
@@ -120,7 +116,7 @@ public partial class MainWindow
 
         // Persist relative part (path + query + fragment)
         _currentRoute = uri.PathAndQuery + uri.Fragment;
-        _routes.SaveRoute(_windowIndex, _currentRoute, GetCurrentGeometry());
+        _windowManager.PersistCurrentState();
     }
 
     private void CoreWebView2_NewWindowRequested(object? sender, CoreWebView2NewWindowRequestedEventArgs e)
@@ -139,14 +135,13 @@ public partial class MainWindow
 
     private void MainWindow_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
-        if (_windowManager.IsTerminating)
+        if (!_windowManager.IsTerminating)
         {
-            _routes.SaveRoute(_windowIndex, _currentRoute, GetCurrentGeometry());
+            // Snapshot all remaining windows (excluding this one) so the closed
+            // window is not restored on next launch, regardless of window count.
+            _windowManager.PersistCurrentState(exclude: this);
         }
-        else
-        {
-            _routes.RemoveRoute(_windowIndex);
-        }
+        // When terminating, CloseAll() already snapshotted all windows before Close() was called.
     }
 
     private void MainWindow_KeyDown(object sender, KeyEventArgs e)
@@ -173,7 +168,7 @@ public partial class MainWindow
         Dispatcher.Invoke(() => WebView.CoreWebView2?.Reload());
     }
 
-    private SavedWindowState GetCurrentGeometry() => new()
+    internal SavedWindowState GetCurrentState() => new()
     {
         Route = _currentRoute,
         Left = Left,

--- a/windows/starsky.Tests/Services/RoutePersistenceServiceTests.cs
+++ b/windows/starsky.Tests/Services/RoutePersistenceServiceTests.cs
@@ -76,6 +76,34 @@ public sealed class RoutePersistenceServiceTests : IDisposable
     }
 
     [TestMethod]
+    public void SaveAll_ReplacesEntireList()
+    {
+        _sut.SaveRoute(0, "?f=/old");
+
+        var states = new List<SavedWindowState>
+        {
+            new() { Route = "?f=/a", Left = 10, Top = 20, Width = 800, Height = 600 },
+            new() { Route = "?f=/b", Left = 50, Top = 60, Width = 1200, Height = 800 },
+        };
+        _sut.SaveAll(states);
+
+        var routes = _sut.GetRoutes();
+        Assert.HasCount(2, routes);
+        Assert.AreEqual("?f=/a", routes[0].Route);
+        Assert.AreEqual("?f=/b", routes[1].Route);
+    }
+
+    [TestMethod]
+    public void SaveAll_WithEmptyList_ClearsRoutes()
+    {
+        _sut.SaveRoute(0, "?f=/a");
+
+        _sut.SaveAll([]);
+
+        Assert.IsEmpty(_sut.GetRoutes());
+    }
+
+    [TestMethod]
     public void ClearAll_EmptiesList()
     {
         _sut.SaveRoute(0, "?f=/a");

--- a/windows/starsky.Tests/Services/WindowManagerTests.cs
+++ b/windows/starsky.Tests/Services/WindowManagerTests.cs
@@ -61,7 +61,9 @@ public class WindowManagerTests
         Assert.IsTrue(wm.IsTerminating);
         // ReopenAll calls CloseAll internally; flag must be cleared so the
         // reopened window can eventually shut down the app normally.
-        wm.ReopenAll();
+        // OpenMainWindow requires an STA thread (WPF), so swallow the resulting
+        // InvalidOperationException — IsTerminating is reset before that call.
+        try { wm.ReopenAll(); } catch (InvalidOperationException) { }
         Assert.IsFalse(wm.IsTerminating);
     }
 
@@ -91,7 +93,6 @@ public class WindowManagerTests
         var opts = new MainWindowOptions
         {
             Settings = settings,
-            Routes = routes,
             WebViewEnv = webViewEnv,
             FileDownload = fileDownload,
             Watcher = watcher,
@@ -101,18 +102,15 @@ public class WindowManagerTests
             BaseUrl = "http://localhost:5000",
             InitialRoute = "?f=/photos",
             Geometry = geometry,
-            WindowIndex = 3
         };
 
         Assert.AreSame(settings, opts.Settings);
-        Assert.AreSame(routes, opts.Routes);
         Assert.AreSame(webViewEnv, opts.WebViewEnv);
         Assert.AreSame(fileDownload, opts.FileDownload);
         Assert.AreSame(wm, opts.WindowManager);
         Assert.AreEqual("http://localhost:5000", opts.BaseUrl);
         Assert.AreEqual("?f=/photos", opts.InitialRoute);
         Assert.AreSame(geometry, opts.Geometry);
-        Assert.AreEqual(3, opts.WindowIndex);
     }
 
     private static SavedWindowState OnScreen(double left = 200, double top = 200,

--- a/windows/starsky.Tests/Services/WindowManagerTests.cs
+++ b/windows/starsky.Tests/Services/WindowManagerTests.cs
@@ -30,12 +30,39 @@ public class WindowManagerTests
     }
 
     [TestMethod]
+    public void IsTerminating_DefaultValue_IsFalse()
+    {
+        var wm = CreateManager();
+        Assert.IsFalse(wm.IsTerminating);
+    }
+
+    [TestMethod]
     public void CloseAll_WithNoWindows_DoesNotThrow()
     {
         var wm = CreateManager();
         Exception? ex = null;
         try { wm.CloseAll(); } catch (Exception e) { ex = e; }
         Assert.IsNull(ex);
+    }
+
+    [TestMethod]
+    public void CloseAll_SetsIsTerminating()
+    {
+        var wm = CreateManager();
+        wm.CloseAll();
+        Assert.IsTrue(wm.IsTerminating);
+    }
+
+    [TestMethod]
+    public void ReopenAll_ResetsIsTerminating()
+    {
+        var wm = CreateManager();
+        wm.CloseAll();
+        Assert.IsTrue(wm.IsTerminating);
+        // ReopenAll calls CloseAll internally; flag must be cleared so the
+        // reopened window can eventually shut down the app normally.
+        wm.ReopenAll();
+        Assert.IsFalse(wm.IsTerminating);
     }
 
     [TestMethod]


### PR DESCRIPTION
…ext launch

when closing a window this is not saved in settings, when closing the app and start it the old windows are still there. So for example you have 2 windows open, close 1 and keep 1 and then close the app. it should only keep the last. but if you have two windows open and close the app the next time it should show two windows. If you close all windows it should pick the default window

# PR Details 
## Description / Motivation and Context

This pull request improves the handling of window closing and reopening logic for both Windows and Mac platforms, ensuring that manually closed windows do not reopen unintentionally and that application state is managed more robustly during termination and reopening scenarios. It introduces an explicit `IsTerminating` flag to track when the application is shutting down, updates window state persistence accordingly, and adds comprehensive tests for this new behavior.

**Window closing and reopening logic improvements:**

* Added an `IsTerminating` flag to `WindowManager` on both Windows and Mac to track when the application is in the process of shutting down. This flag is now set to `true` during `CloseAll()` and reset to `false` in `ReopenAll()`, ensuring correct state management. [[1]](diffhunk://#diff-69ec912f0e05911307eb4a8e2e0249cd490d70de477575ebf59ad9e46002f753R26-R27) [[2]](diffhunk://#diff-69ec912f0e05911307eb4a8e2e0249cd490d70de477575ebf59ad9e46002f753R106) [[3]](diffhunk://#diff-69ec912f0e05911307eb4a8e2e0249cd490d70de477575ebf59ad9e46002f753R118) [[4]](diffhunk://#diff-fcd4bd4c4f6b44b336b36a1e408250b02503183af61b11a94dc7e44baa946e28R134)
* Updated the logic in `OpenMainWindow` (Windows) so that the application only shuts down automatically when all windows are closed and the app is not terminating, preventing unintended shutdowns during termination.

**Window state persistence:**

* Modified `MainWindow_Closing` (Windows) to save or remove window state based on the `IsTerminating` flag, ensuring that manually closed windows do not reopen on next launch, while windows closed during termination still persist their state.

**Testing enhancements:**

* Added unit tests on both Windows and Mac to verify that `IsTerminating` is set and reset appropriately in `CloseAll()` and `ReopenAll()`, and that its default value is `false`. [[1]](diffhunk://#diff-a412b0170f622c8d7975ad1f853bb7417719f7971f865cd581dc6e807c57ce62R45-R59) [[2]](diffhunk://#diff-0c0531fe4ad1c2ce55b79d8dd41f3c69462b86328e6e172f48413cee3c95a535R32-R38) [[3]](diffhunk://#diff-0c0531fe4ad1c2ce55b79d8dd41f3c69462b86328e6e172f48413cee3c95a535R48-R67)

**Documentation:**

* Updated `history.md` to document the fix for manually closed windows reopening on the next launch.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] C# Unit tests 
- [ ] Typescript Unit tests 
- [ ] Other Unit tests
- [ ] Manual tests
- [ ] Automatic End2end tests (starsky-tools/end2end)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added _for new features_
- [ ] Breaking change _fix or feature that would cause existing functionality to change_
- [ ] Changed _for non-breaking changes in existing functionality for example docs change / refactoring / dependency upgrades_
- [ ] Deprecated _for soon-to-be removed features_
- [ ] Removed _for now removed features_
- [ ] Fixed _for any bug fixes_
- [ ] Security _in case of vulnerabilities_


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (update when needed)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the **./history.md** document
